### PR TITLE
feat(handoff): add launchd-based restart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ TelePi is a Telegram bridge for the [Pi coding agent](https://github.com/badlogi
    npm run dev
    ```
 
+4. Optional: build TelePi for `launchd`:
+   ```bash
+   npm run build
+   ```
+
 ## Telegram Commands
 
 | Command | Description |
@@ -60,7 +65,7 @@ TelePi supports seamless bi-directional session hand-off between Pi CLI and Tele
 You're working in Pi CLI on your laptop and want to continue from your phone:
 
 1. **In Pi CLI**, type `/handoff`
-2. The extension kills any running TelePi instance, launches TelePi with your current session, and shuts down Pi CLI
+2. The extension opens your current session in TelePi and shuts down Pi CLI
 3. **Open Telegram** — TelePi is already running with your full conversation context. Just keep typing.
 
 **Extension installation** — symlink into Pi's global extensions directory:
@@ -72,11 +77,41 @@ ln -s "$(pwd)/extensions/telepi-handoff.ts" ~/.pi/agent/extensions/telepi-handof
 
 Pi auto-discovers it after symlinking (or run `/reload` in Pi).
 
+The extension supports two hand-off modes, controlled via shell environment variables:
+
+- `TELEPI_HANDOFF_MODE=direct` *(default)* — old behavior: kill the current TelePi dev process and start a new one with `npx tsx src/index.ts`
+- `TELEPI_HANDOFF_MODE=launchd` — set `PI_SESSION_PATH` in the `launchd` user environment and restart a LaunchAgent
+- `TELEPI_LAUNCHD_LABEL` *(optional, default: `com.telepi`)* — LaunchAgent label to restart in `launchd` mode
+
+#### Direct mode
+
 Set `TELEPI_DIR` in your shell profile to point to your TelePi installation:
 
 ```bash
+export TELEPI_HANDOFF_MODE=direct
 export TELEPI_DIR="/path/to/TelePi"
 ```
+
+#### launchd mode (recommended on macOS)
+
+1. Build TelePi:
+   ```bash
+   npm run build
+   ```
+2. Copy `launchd/com.telepi.plist` to `~/Library/LaunchAgents/com.telepi.plist`
+3. Replace the placeholder paths with your real TelePi path, Node path, and log file locations
+4. Load it:
+   ```bash
+   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.telepi.plist
+   launchctl kickstart -k gui/$UID/com.telepi
+   ```
+5. Export the hand-off settings in your shell profile:
+   ```bash
+   export TELEPI_HANDOFF_MODE=launchd
+   export TELEPI_LAUNCHD_LABEL=com.telepi
+   ```
+
+In `launchd` mode, `/handoff` only does two things: set `PI_SESSION_PATH` in `launchd`, then restart the configured LaunchAgent. That keeps TelePi to a single bot process and avoids Telegram token conflicts.
 
 ### Telegram → CLI (`/handback`)
 
@@ -132,6 +167,8 @@ Sessions are stored under `~/.pi/agent/sessions/--<encoded-workspace-path>--/`.
 TelePi/
 ├── extensions/
 │   └── telepi-handoff.ts        ← Pi CLI extension (git-tracked)
+├── launchd/
+│   └── com.telepi.plist
 ├── src/
 │   ├── index.ts                 ← entry point
 │   ├── bot.ts                   ← Telegram bot (Grammy)
@@ -170,7 +207,7 @@ The compose file:
 
 - Only Telegram user IDs in `TELEGRAM_ALLOWED_USER_IDS` can interact with the bot
 - Pi tools are scoped to the workspace via `createCodingTools(workspace)` and re-scoped on session switch
-- The `/handoff` extension only shuts down Pi CLI if TelePi launches successfully
+- The `/handoff` extension only shuts down Pi CLI if TelePi launches or restarts successfully
 - URL sanitization blocks `javascript:` and other unsafe protocols in formatted output
 - Shell commands in `/handback` use `spawnSync` (no shell interpretation) for clipboard copy
 

--- a/extensions/telepi-handoff.ts
+++ b/extensions/telepi-handoff.ts
@@ -1,5 +1,24 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+type HandoffMode = "direct" | "launchd";
+
+const DEFAULT_LAUNCHD_LABEL = "com.telepi";
+
+function shellQuote(value: string): string {
+  return value.replace(/'/g, "'\\''");
+}
+
+function resolveHandoffMode(): HandoffMode | undefined {
+  const raw = process.env.TELEPI_HANDOFF_MODE?.trim().toLowerCase();
+  if (!raw || raw === "direct") {
+    return "direct";
+  }
+  if (raw === "launchd") {
+    return "launchd";
+  }
+  return undefined;
+}
+
 export default function (pi: ExtensionAPI) {
   pi.registerCommand("handoff", {
     description: "Hand off this session to TelePi (Telegram)",
@@ -11,50 +30,96 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      const telePiDir = process.env.TELEPI_DIR;
-      if (!telePiDir) {
+      const handoffMode = resolveHandoffMode();
+      if (!handoffMode) {
         ctx.ui.notify(
-          "TELEPI_DIR is not set. Add it to your shell profile:\n" +
-          "  export TELEPI_DIR=/path/to/TelePi",
+          "Invalid TELEPI_HANDOFF_MODE. Expected one of: direct, launchd",
           "error",
         );
         return;
       }
 
-      ctx.ui.notify(
-        `Handing off to TelePi...\nSession: ${sessionFile}`,
-        "info",
-      );
-
-      // Kill any existing TelePi instance first (same bot token = conflict)
-      await pi.exec("bash", ["-c", `pkill -f "tsx.*TelePi" 2>/dev/null || true`], { timeout: 3000 }).catch(() => {});
-
-      // Use a safe quoting approach for the session path
-      const safeSessionFile = sessionFile.replace(/'/g, "'\\''");
-
+      const safeSessionFile = shellQuote(sessionFile);
       let launched = false;
-      try {
-        const result = await pi.exec(
-          "bash",
-          ["-c", `cd '${telePiDir.replace(/'/g, "'\\''")}' && PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > /tmp/telepi.log 2>&1 & echo $!`],
-          { timeout: 5000 },
-        );
-        const pid = result.stdout.trim();
-        if (pid && result.code === 0) {
-          ctx.ui.notify(`TelePi started (PID: ${pid}). Check Telegram!`, "success");
-          launched = true;
-        } else {
-          ctx.ui.notify(`TelePi may have failed to start. Check /tmp/telepi.log`, "warning");
-        }
-      } catch {
+
+      if (handoffMode === "launchd") {
+        const launchdLabel = process.env.TELEPI_LAUNCHD_LABEL?.trim() || DEFAULT_LAUNCHD_LABEL;
+        const safeLaunchdLabel = shellQuote(launchdLabel);
+
         ctx.ui.notify(
-          `Could not auto-launch TelePi. Start it manually:\n` +
-          `cd "${telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
-          "warning",
+          `Handing off to TelePi via launchd...\nSession: ${sessionFile}\nJob: ${launchdLabel}`,
+          "info",
         );
+
+        try {
+          await pi.exec(
+            "bash",
+            [
+              "-lc",
+              `session_file='${safeSessionFile}'
+label='${safeLaunchdLabel}'
+launchctl setenv PI_SESSION_PATH "$session_file"
+launchctl kickstart -k "gui/$UID/$label"`,
+            ],
+            { timeout: 5000 },
+          );
+
+          ctx.ui.notify(`TelePi restarted via launchd job ${launchdLabel}. Check Telegram!`, "success");
+          launched = true;
+        } catch {
+          ctx.ui.notify(
+            "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
+            `launchctl setenv PI_SESSION_PATH "${sessionFile}"\n` +
+            `launchctl kickstart -k gui/$UID/${launchdLabel}`,
+            "warning",
+          );
+        }
+      } else {
+        const telePiDir = process.env.TELEPI_DIR;
+        if (!telePiDir) {
+          ctx.ui.notify(
+            "TELEPI_DIR is not set. Add it to your shell profile:\n" +
+            "  export TELEPI_DIR=/path/to/TelePi\n\n" +
+            "Or switch to launchd mode with:\n" +
+            "  export TELEPI_HANDOFF_MODE=launchd",
+            "error",
+          );
+          return;
+        }
+
+        ctx.ui.notify(
+          `Handing off to TelePi...\nSession: ${sessionFile}`,
+          "info",
+        );
+
+        await pi.exec("bash", ["-lc", 'pkill -f "tsx.*TelePi" 2>/dev/null || true'], { timeout: 3000 }).catch(() => {});
+
+        try {
+          const result = await pi.exec(
+            "bash",
+            [
+              "-lc",
+              `cd '${shellQuote(telePiDir)}'
+PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > /tmp/telepi.log 2>&1 & echo $!`,
+            ],
+            { timeout: 5000 },
+          );
+          const pid = result.stdout.trim();
+          if (pid && result.code === 0) {
+            ctx.ui.notify(`TelePi started (PID: ${pid}). Check Telegram!`, "success");
+            launched = true;
+          } else {
+            ctx.ui.notify(`TelePi may have failed to start. Check /tmp/telepi.log`, "warning");
+          }
+        } catch {
+          ctx.ui.notify(
+            `Could not auto-launch TelePi. Start it manually:\n` +
+            `cd "${telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
+            "warning",
+          );
+        }
       }
 
-      // Only shut down Pi CLI if TelePi launched successfully
       if (launched) {
         ctx.shutdown();
       }

--- a/launchd/com.telepi.plist
+++ b/launchd/com.telepi.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.telepi</string>
+
+  <key>WorkingDirectory</key>
+  <string>/ABSOLUTE/PATH/TO/TelePi</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/ABSOLUTE/PATH/TO/node</string>
+    <string>/ABSOLUTE/PATH/TO/TelePi/dist/index.js</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/ABSOLUTE/PATH/TO/telepi.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/ABSOLUTE/PATH/TO/telepi.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
Great project, works really great for me so far. This PR adds support for launchd, so I won't forget to start TelePi on login. Caveat: this is mostly agent work, so please feel free to close the PR, if you don't want to take those changes. Handoff is working great for me through it so far. 

## Summary
- add a launchd plist template for restart-based handoff on macOS
- extend the handoff flow to support env-controlled handoff modes and a configurable launch agent label
- document the launchd setup and restart-based handoff workflow

## Why
Using launchd makes the handoff/restart flow more robust on macOS because the service manager can bring the process back up consistently after exit. The handoff mode and label are configurable so the same implementation can work in different local setups without code changes.