### PR TITLE
Respect scoped model selection in the Telegram model picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ TelePi is a Telegram bridge for the [Pi coding agent](https://github.com/badlogi
 | `/session` | Show current session details (ID, file, workspace, model) |
 | `/sessions` | List all sessions across all workspaces with tap-to-switch buttons |
 | `/sessions <path>` | Switch directly to a specific session file |
-| `/model` | Pick a different AI model from an inline keyboard |
+| `/model` | Pick an AI model from the current Pi model scope, with an option to show all available models |
 | `/tree` | View the session entry tree; navigate with inline buttons |
 | `/branch <id>` | Navigate to a specific entry ID (with confirmation) |
 | `/label [args]` | Add or clear labels on entries for easy reference |

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -8,7 +8,7 @@ import { autoRetry } from "@grammyjs/auto-retry";
 
 import type { TelePiConfig, ToolVerbosity } from "./config.js";
 import { escapeHTML, formatTelegramHTML } from "./format.js";
-import { type PiSessionInfo, type PiSessionService } from "./pi-session.js";
+import { type PiSessionInfo, type PiSessionModelOption, type PiSessionService } from "./pi-session.js";
 import {
   renderBranchConfirmation,
   renderLabels,
@@ -113,7 +113,7 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
   const pendingSessionButtons = new Map<number, KeyboardItem[]>();
   const pendingWorkspacePicks = new Map<number, string[]>();
   const pendingWorkspaceButtons = new Map<number, KeyboardItem[]>();
-  const pendingModelPicks = new Map<number, Array<{ provider: string; id: string }>>();
+  const pendingModelPicks = new Map<number, PiSessionModelOption[]>();
   const pendingModelButtons = new Map<number, KeyboardItem[]>();
   const pendingModelExtraButtons = new Map<number, KeyboardItem[]>();
   const pendingTreeNavs = new Map<number, string>();
@@ -910,17 +910,15 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
       return;
     }
 
-    pendingModelPicks.set(
-      chatId,
-      models.map((model) => ({ provider: model.provider, id: model.id })),
-    );
+    pendingModelPicks.set(chatId, models);
 
     const modelButtons = models.map((model, index) => {
       const prefix = model.current ? "✅ " : "";
       const modelRef = `${model.provider}/${model.id}`;
       const nameSuffix = model.name && model.name !== model.id ? ` · ${model.name}` : "";
+      const thinkingSuffix = model.thinkingLevel ? ` : ${model.thinkingLevel}` : "";
       return {
-        label: `${prefix}${modelRef}${nameSuffix}`,
+        label: `${prefix}${modelRef}${nameSuffix}${thinkingSuffix}`,
         callbackData: `model_${index}`,
       };
     });
@@ -1348,7 +1346,11 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
 
     isSwitching = true;
     try {
-      const modelName = await piSession.setModel(models[index].provider, models[index].id);
+      const modelName = await piSession.setModel(
+        models[index].provider,
+        models[index].id,
+        models[index].thinkingLevel,
+      );
       const html = `<b>Model switched to:</b> <code>${escapeHTML(modelName)}</code>`;
       const plainText = `Model switched to: ${modelName}`;
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1310,6 +1310,12 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
       return;
     }
 
+    const models = pendingModelPicks.get(chatId);
+    if (!models || models.length === 0) {
+      await ctx.answerCallbackQuery({ text: "Expired, run /model again" });
+      return;
+    }
+
     if (isBusy()) {
       await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
       return;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -115,6 +115,7 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
   const pendingWorkspaceButtons = new Map<number, KeyboardItem[]>();
   const pendingModelPicks = new Map<number, Array<{ provider: string; id: string }>>();
   const pendingModelButtons = new Map<number, KeyboardItem[]>();
+  const pendingModelExtraButtons = new Map<number, KeyboardItem[]>();
   const pendingTreeNavs = new Map<number, string>();
   const pendingTreeButtons = new Map<number, KeyboardItem[]>();
   const pendingTreeFilterButtons = new Map<number, KeyboardItem[]>();
@@ -927,12 +928,11 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
 
     const allModels = showAll ? models : await piSession.listModels(true);
     const hasScopedSubset = !showAll && models.length > 0 && models.length < allModels.length;
-    const keyboard = buildKeyboard(
-      modelButtons,
-      0,
-      "model",
-      hasScopedSubset ? [{ label: "Show all models", callbackData: "model_show_all" }] : [],
-    );
+    const extraButtons = hasScopedSubset
+      ? [{ label: "Show all models", callbackData: "model_show_all" }]
+      : [];
+    pendingModelExtraButtons.set(chatId, extraButtons);
+    const keyboard = buildKeyboard(modelButtons, 0, "model", extraButtons);
 
     const info = piSession.getInfo();
     const currentModelText = info.model ? `Current: ${info.model}` : "No model selected";
@@ -1182,7 +1182,13 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
 
   handlePageCallback(/^switch_page_(\d+)$/, "switch", pendingSessionButtons, "Expired, run /sessions again");
   handlePageCallback(/^newws_page_(\d+)$/, "newws", pendingWorkspaceButtons, "Expired, run /new again");
-  handlePageCallback(/^model_page_(\d+)$/, "model", pendingModelButtons, "Expired, run /model again");
+  handlePageCallback(
+    /^model_page_(\d+)$/,
+    "model",
+    pendingModelButtons,
+    "Expired, run /model again",
+    pendingModelExtraButtons,
+  );
   handlePageCallback(
     /^tree_page_(\d+)$/,
     "tree",
@@ -1338,6 +1344,7 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
     await ctx.answerCallbackQuery({ text: "Switching model..." });
     pendingModelPicks.delete(chatId);
     pendingModelButtons.delete(chatId);
+    pendingModelExtraButtons.delete(chatId);
 
     isSwitching = true;
     try {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -892,7 +892,79 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
     }
   });
 
-  bot.command("model", async (ctx) => {
+  const renderModelPicker = async (
+    chatId: number,
+    options?: { showAll?: boolean; messageId?: number },
+  ): Promise<void> => {
+    const showAll = options?.showAll ?? false;
+    const messageId = options?.messageId;
+    const models = await piSession.listModels(showAll);
+    if (models.length === 0) {
+      const message = "No models available.";
+      if (messageId) {
+        await safeEditMessage(bot, chatId, messageId, escapeHTML(message), { fallbackText: message });
+      } else {
+        await bot.api.sendMessage(chatId, escapeHTML(message), { parse_mode: "HTML" });
+      }
+      return;
+    }
+
+    pendingModelPicks.set(
+      chatId,
+      models.map((model) => ({ provider: model.provider, id: model.id })),
+    );
+
+    const modelButtons = models.map((model, index) => {
+      const prefix = model.current ? "✅ " : "";
+      const modelRef = `${model.provider}/${model.id}`;
+      const nameSuffix = model.name && model.name !== model.id ? ` · ${model.name}` : "";
+      return {
+        label: `${prefix}${modelRef}${nameSuffix}`,
+        callbackData: `model_${index}`,
+      };
+    });
+    pendingModelButtons.set(chatId, modelButtons);
+
+    const allModels = showAll ? models : await piSession.listModels(true);
+    const hasScopedSubset = !showAll && models.length > 0 && models.length < allModels.length;
+    const keyboard = buildKeyboard(
+      modelButtons,
+      0,
+      "model",
+      hasScopedSubset ? [{ label: "Show all models", callbackData: "model_show_all" }] : [],
+    );
+
+    const info = piSession.getInfo();
+    const currentModelText = info.model ? `Current: ${info.model}` : "No model selected";
+    const scopeHint = hasScopedSubset
+      ? "Showing the current Pi model scope."
+      : undefined;
+    const html = [
+      "<b>Select a model</b>",
+      escapeHTML(currentModelText),
+      scopeHint ? `<i>${escapeHTML(scopeHint)}</i>` : undefined,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n");
+    const fallbackText = ["Select a model", currentModelText, scopeHint]
+      .filter((line): line is string => Boolean(line))
+      .join("\n");
+
+    if (messageId) {
+      await safeEditMessage(bot, chatId, messageId, html, {
+        fallbackText,
+        replyMarkup: keyboard,
+      });
+      return;
+    }
+
+    await bot.api.sendMessage(chatId, html, {
+      parse_mode: "HTML",
+      reply_markup: keyboard,
+    });
+  };
+
+  const showModelPicker = async (ctx: Context): Promise<void> => {
     const chatId = ctx.chat?.id;
     if (!chatId) {
       return;
@@ -909,32 +981,11 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
       }
     }
 
-    const models = await piSession.listModels();
-    if (models.length === 0) {
-      await safeReply(ctx, escapeHTML("No models available."), {
-        fallbackText: "No models available.",
-      });
-      return;
-    }
+    await renderModelPicker(chatId);
+  };
 
-    pendingModelPicks.set(
-      chatId,
-      models.map((model) => ({ provider: model.provider, id: model.id })),
-    );
-
-    const modelButtons = models.map((model, index) => ({
-      label: `${model.current ? "✅ " : ""}${model.name}`,
-      callbackData: `model_${index}`,
-    }));
-    pendingModelButtons.set(chatId, modelButtons);
-
-    const info = piSession.getInfo();
-    const currentModelText = info.model ? `Current: ${info.model}` : "No model selected";
-
-    await safeReply(ctx, `<b>Select a model</b>\n${escapeHTML(currentModelText)}`, {
-      fallbackText: `Select a model\n${currentModelText}`,
-      replyMarkup: buildKeyboard(modelButtons, 0, "model"),
-    });
+  bot.command("model", async (ctx) => {
+    await showModelPicker(ctx);
   });
 
   bot.command("tree", async (ctx) => {
@@ -1245,6 +1296,23 @@ export function createBot(config: TelePiConfig, piSession: PiSessionService): Bo
     } finally {
       isSwitching = false;
     }
+  });
+
+  bot.callbackQuery("model_show_all", async (ctx) => {
+    const chatId = ctx.chat?.id;
+    const messageId = ctx.callbackQuery.message?.message_id;
+
+    if (!chatId || !messageId) {
+      return;
+    }
+
+    if (isBusy()) {
+      await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({ text: "Loading all models..." });
+    await renderModelPicker(chatId, { showAll: true, messageId });
   });
 
   bot.callbackQuery(/^model_(\d+)$/, async (ctx) => {

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -12,6 +12,7 @@ import {
   type SessionEntry,
 } from "@mariozechner/pi-coding-agent";
 import { resolveModelScope } from "../node_modules/@mariozechner/pi-coding-agent/dist/core/model-resolver.js";
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 
 import type { TelePiConfig } from "./config.js";
@@ -41,6 +42,14 @@ export interface PiSessionInfo {
   sessionName?: string;
   modelFallbackMessage?: string;
   model?: string;
+}
+
+export interface PiSessionModelOption {
+  provider: string;
+  id: string;
+  name: string;
+  current: boolean;
+  thinkingLevel?: ThinkingLevel;
 }
 
 interface PiSessionHandle {
@@ -306,9 +315,15 @@ export class PiSessionService {
     return { info: this.getInfo(), created };
   }
 
-  async listModels(showAll = false): Promise<Array<{ provider: string; id: string; name: string; current: boolean }>> {
+  async listModels(showAll = false): Promise<PiSessionModelOption[]> {
     const session = this.getSession();
     const currentModel = session.model;
+    const scopedThinkingLevels = new Map(
+      session.scopedModels.map((scoped) => [
+        `${scoped.model.provider}/${scoped.model.id}`,
+        scoped.thinkingLevel,
+      ]),
+    );
     const available = showAll || session.scopedModels.length === 0
       ? this.getModelRegistry().getAvailable()
       : session.scopedModels.map((scoped) => scoped.model);
@@ -320,16 +335,21 @@ export class PiSessionService {
       current: currentModel
         ? model.provider === currentModel.provider && model.id === currentModel.id
         : false,
+      thinkingLevel: scopedThinkingLevels.get(`${model.provider}/${model.id}`),
     }));
   }
 
-  async setModel(provider: string, modelId: string): Promise<string> {
+  async setModel(provider: string, modelId: string, thinkingLevel?: ThinkingLevel): Promise<string> {
+    const session = this.getSession();
     const modelRegistry = this.getModelRegistry();
     const model = modelRegistry.find(provider, modelId);
     if (!model) {
       throw new Error(`Model not found: ${provider}/${modelId}`);
     }
-    await this.getSession().setModel(model);
+    await session.setModel(model);
+    if (thinkingLevel !== undefined) {
+      session.setThinkingLevel(thinkingLevel);
+    }
     return `${model.provider}/${model.id}`;
   }
 

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -99,18 +99,27 @@ export async function createPiSession(
   overrideWorkspace?: string,
 ): Promise<PiSessionHandle> {
   const workspace = overrideWorkspace ?? config.workspace;
+  const sessionPath = overrideSessionPath ?? config.piSessionPath;
   const sessionManager = createSessionManager(config, workspace, overrideSessionPath);
   const authStorage = AuthStorage.create();
   const modelRegistry = new ModelRegistry(authStorage);
   const settingsManager = SettingsManager.create(workspace);
-  const model = resolveModelOverride(modelRegistry, config.piModel);
+  const configuredModel = resolveModelOverride(modelRegistry, config.piModel);
   const scopedModels = await resolveScopedModels(settingsManager, modelRegistry);
+  const { model, thinkingLevel } = resolveInitialModelSelection({
+    configuredModel,
+    scopedModels,
+    settingsManager,
+    modelRegistry,
+    hasExistingSession: Boolean(sessionPath),
+  });
 
   const { session, modelFallbackMessage } = await createAgentSession({
     cwd: workspace,
     authStorage,
     modelRegistry,
     model,
+    thinkingLevel,
     scopedModels,
     sessionManager,
     settingsManager,
@@ -131,14 +140,22 @@ async function createNewPiSession(config: TelePiConfig, workspace: string): Prom
   const authStorage = AuthStorage.create();
   const modelRegistry = new ModelRegistry(authStorage);
   const settingsManager = SettingsManager.create(workspace);
-  const model = resolveModelOverride(modelRegistry, config.piModel);
+  const configuredModel = resolveModelOverride(modelRegistry, config.piModel);
   const scopedModels = await resolveScopedModels(settingsManager, modelRegistry);
+  const { model, thinkingLevel } = resolveInitialModelSelection({
+    configuredModel,
+    scopedModels,
+    settingsManager,
+    modelRegistry,
+    hasExistingSession: false,
+  });
 
   const { session, modelFallbackMessage } = await createAgentSession({
     cwd: workspace,
     authStorage,
     modelRegistry,
     model,
+    thinkingLevel,
     scopedModels,
     sessionManager,
     settingsManager,
@@ -472,6 +489,36 @@ async function resolveScopedModels(
   }
 
   return resolveModelScope(modelPatterns, modelRegistry);
+}
+
+function resolveInitialModelSelection(options: {
+  configuredModel: Model<Api> | undefined;
+  scopedModels: Awaited<ReturnType<typeof resolveModelScope>>;
+  settingsManager: SettingsManager;
+  modelRegistry: ModelRegistry;
+  hasExistingSession: boolean;
+}): { model: Model<Api> | undefined; thinkingLevel: ThinkingLevel | undefined } {
+  const { configuredModel, scopedModels, settingsManager, modelRegistry, hasExistingSession } = options;
+
+  if (configuredModel || hasExistingSession || scopedModels.length === 0) {
+    return { model: configuredModel, thinkingLevel: undefined };
+  }
+
+  const defaultProvider = settingsManager.getDefaultProvider();
+  const defaultModelId = settingsManager.getDefaultModel();
+  const defaultModel = defaultProvider && defaultModelId
+    ? modelRegistry.find(defaultProvider, defaultModelId)
+    : undefined;
+
+  const selectedScopedModel = defaultModel
+    ? scopedModels.find((scoped) => scoped.model.provider === defaultModel.provider && scoped.model.id === defaultModel.id)
+    : undefined;
+  const fallbackScopedModel = selectedScopedModel ?? scopedModels[0];
+
+  return {
+    model: fallbackScopedModel?.model,
+    thinkingLevel: fallbackScopedModel?.thinkingLevel,
+  };
 }
 
 function createSessionManager(

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -7,9 +7,11 @@ import {
   createCodingTools,
   ModelRegistry,
   SessionManager,
+  SettingsManager,
   type AgentSession,
   type SessionEntry,
 } from "@mariozechner/pi-coding-agent";
+import { resolveModelScope } from "../node_modules/@mariozechner/pi-coding-agent/dist/core/model-resolver.js";
 import type { Api, Model } from "@mariozechner/pi-ai";
 
 import type { TelePiConfig } from "./config.js";
@@ -91,14 +93,18 @@ export async function createPiSession(
   const sessionManager = createSessionManager(config, workspace, overrideSessionPath);
   const authStorage = AuthStorage.create();
   const modelRegistry = new ModelRegistry(authStorage);
+  const settingsManager = SettingsManager.create(workspace);
   const model = resolveModelOverride(modelRegistry, config.piModel);
+  const scopedModels = await resolveScopedModels(settingsManager, modelRegistry);
 
   const { session, modelFallbackMessage } = await createAgentSession({
     cwd: workspace,
     authStorage,
     modelRegistry,
     model,
+    scopedModels,
     sessionManager,
+    settingsManager,
     tools: createCodingTools(workspace),
   });
   patchBashTimeout(session);
@@ -115,14 +121,18 @@ async function createNewPiSession(config: TelePiConfig, workspace: string): Prom
   const sessionManager = SessionManager.create(workspace);
   const authStorage = AuthStorage.create();
   const modelRegistry = new ModelRegistry(authStorage);
+  const settingsManager = SettingsManager.create(workspace);
   const model = resolveModelOverride(modelRegistry, config.piModel);
+  const scopedModels = await resolveScopedModels(settingsManager, modelRegistry);
 
   const { session, modelFallbackMessage } = await createAgentSession({
     cwd: workspace,
     authStorage,
     modelRegistry,
     model,
+    scopedModels,
     sessionManager,
+    settingsManager,
     tools: createCodingTools(workspace),
   });
   patchBashTimeout(session);
@@ -296,11 +306,12 @@ export class PiSessionService {
     return { info: this.getInfo(), created };
   }
 
-  async listModels(): Promise<Array<{ provider: string; id: string; name: string; current: boolean }>> {
+  async listModels(showAll = false): Promise<Array<{ provider: string; id: string; name: string; current: boolean }>> {
     const session = this.getSession();
     const currentModel = session.model;
-    const modelRegistry = this.getModelRegistry();
-    const available = modelRegistry.getAvailable();
+    const available = showAll || session.scopedModels.length === 0
+      ? this.getModelRegistry().getAvailable()
+      : session.scopedModels.map((scoped) => scoped.model);
 
     return available.map((model) => ({
       provider: model.provider,
@@ -429,6 +440,18 @@ export class PiSessionService {
   private getModelRegistry(): ModelRegistry {
     return this.getHandle().modelRegistry;
   }
+}
+
+async function resolveScopedModels(
+  settingsManager: SettingsManager,
+  modelRegistry: ModelRegistry,
+): Promise<Awaited<ReturnType<typeof resolveModelScope>>> {
+  const modelPatterns = settingsManager.getEnabledModels();
+  if (!modelPatterns || modelPatterns.length === 0) {
+    return [];
+  }
+
+  return resolveModelScope(modelPatterns, modelRegistry);
 }
 
 function createSessionManager(

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -764,6 +764,7 @@ describe("createBot", () => {
         id: "codex",
         name: "Codex",
         current: true,
+        thinkingLevel: "high",
       },
     ];
     const allModels = [
@@ -772,6 +773,7 @@ describe("createBot", () => {
         id: "codex",
         name: "Codex",
         current: false,
+        thinkingLevel: undefined,
       },
       ...scopedModels,
     ];
@@ -791,7 +793,7 @@ describe("createBot", () => {
     expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Showing the current Pi model scope.");
     expect(getReplyMarkupData(api)).toEqual(["model_0", "model_show_all"]);
     expect(getReplyMarkupTexts(api)).toEqual([
-      "✅ github-copilot/codex · Codex",
+      "✅ github-copilot/codex · Codex : high",
       "Show all models",
     ]);
     expect(listModels).toHaveBeenNthCalledWith(1, false);
@@ -804,13 +806,37 @@ describe("createBot", () => {
     expect(getEditedReplyMarkupData(api, 0)).toEqual(["model_0", "model_1"]);
     expect(getEditedReplyMarkupTexts(api, 0)).toEqual([
       "openai/codex · Codex",
-      "✅ github-copilot/codex · Codex",
+      "✅ github-copilot/codex · Codex : high",
     ]);
 
     await bot.handleUpdate(createCallbackUpdate("model_0"));
     expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Switching model..." });
-    expect(pi.service.setModel).toHaveBeenCalledWith("openai", "codex");
+    expect(pi.service.setModel).toHaveBeenCalledWith("openai", "codex", undefined);
     expect(api.editMessageText).toHaveBeenCalled();
+  });
+
+  it("applies the scoped thinking-level override when selecting a scoped model", async () => {
+    const listModels = vi.fn().mockResolvedValue([
+      {
+        provider: "github-copilot",
+        id: "codex",
+        name: "Codex",
+        current: true,
+        thinkingLevel: "high",
+      },
+    ]);
+
+    const { bot, pi } = setupBot({
+      piSessionOverrides: {
+        listModels,
+        setModel: vi.fn().mockResolvedValue("github-copilot/codex"),
+      },
+    });
+
+    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+    await bot.handleUpdate(createCallbackUpdate("model_0"));
+
+    expect(pi.service.setModel).toHaveBeenCalledWith("github-copilot", "codex", "high");
   });
 
   it("keeps the show-all button while paging through scoped models", async () => {
@@ -891,7 +917,7 @@ describe("createBot", () => {
     ]);
 
     await bot.handleUpdate(createCallbackUpdate("model_20"));
-    expect(pi.service.setModel).toHaveBeenCalledWith("provider20", "model-20");
+    expect(pi.service.setModel).toHaveBeenCalledWith("provider20", "model-20", undefined);
   });
 
   it("handles /tree command variants and missing sessions", async () => {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -813,6 +813,54 @@ describe("createBot", () => {
     expect(api.editMessageText).toHaveBeenCalled();
   });
 
+  it("keeps the show-all button while paging through scoped models", async () => {
+    const scopedModels = Array.from({ length: 7 }, (_, index) => ({
+      provider: "github-copilot",
+      id: `codex-${index}`,
+      name: `Codex ${index}`,
+      current: index === 0,
+    }));
+    const allModels = [
+      ...Array.from({ length: 2 }, (_, index) => ({
+        provider: "openai",
+        id: `gpt-${index}`,
+        name: `GPT ${index}`,
+        current: false,
+      })),
+      ...scopedModels,
+    ];
+    const listModels = vi.fn().mockImplementation((showAll?: boolean) =>
+      Promise.resolve(showAll ? allModels : scopedModels),
+    );
+
+    const { bot, api } = setupBot({
+      piSessionOverrides: {
+        listModels,
+      },
+    });
+
+    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+    expect(getReplyMarkupData(api)).toEqual([
+      "model_0",
+      "model_1",
+      "model_2",
+      "model_3",
+      "model_4",
+      "model_5",
+      "noop_page",
+      "model_page_1",
+      "model_show_all",
+    ]);
+
+    await bot.handleUpdate(createCallbackUpdate("model_page_1"));
+    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
+      "model_6",
+      "model_page_0",
+      "noop_page",
+      "model_show_all",
+    ]);
+  });
+
   it("paginates model pickers across all available models", async () => {
     const models = generateMockModels(21);
     const { bot, pi, api } = setupBot({

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -1402,6 +1402,12 @@ describe("createBot", () => {
     });
 
     api.answerCallbackQuery.mockClear();
+    await bot.handleUpdate(createCallbackUpdate("model_show_all"));
+    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+      text: "Expired, run /model again",
+    });
+
+    api.answerCallbackQuery.mockClear();
     await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
     expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
       text: "Expired, run /tree again",

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -385,12 +385,27 @@ function getReplyMarkupData(api: ReturnType<typeof setupBot>["api"], callIndex =
   return markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [];
 }
 
+function getReplyMarkupTexts(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
+  const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
+  return markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? [];
+}
+
 function getReplyMarkupButtons(
   api: ReturnType<typeof setupBot>["api"],
   callIndex = 0,
 ): Array<{ text: string; callback_data: string }> {
   const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
   return markup?.inline_keyboard?.flat() ?? [];
+}
+
+function getEditedReplyMarkupData(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
+  const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
+  return markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [];
+}
+
+function getEditedReplyMarkupTexts(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
+  const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
+  return markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? [];
 }
 
 function getEditedReplyMarkupButtons(
@@ -742,16 +757,59 @@ describe("createBot", () => {
     await pending;
   });
 
-  it("shows the model picker and handles model selection callbacks", async () => {
-    const { bot, pi, api } = setupBot();
+  it("shows scoped models by default, can expand to all models, and handles model selection", async () => {
+    const scopedModels = [
+      {
+        provider: "github-copilot",
+        id: "codex",
+        name: "Codex",
+        current: true,
+      },
+    ];
+    const allModels = [
+      {
+        provider: "openai",
+        id: "codex",
+        name: "Codex",
+        current: false,
+      },
+      ...scopedModels,
+    ];
+    const listModels = vi.fn().mockImplementation((showAll?: boolean) =>
+      Promise.resolve(showAll ? allModels : scopedModels),
+    );
+
+    const { bot, pi, api } = setupBot({
+      piSessionOverrides: {
+        listModels,
+        setModel: vi.fn().mockResolvedValue("openai/codex"),
+      },
+    });
 
     await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
     expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Select a model");
-    expect(getReplyMarkupData(api)).toEqual(["model_0", "model_1"]);
+    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Showing the current Pi model scope.");
+    expect(getReplyMarkupData(api)).toEqual(["model_0", "model_show_all"]);
+    expect(getReplyMarkupTexts(api)).toEqual([
+      "✅ github-copilot/codex · Codex",
+      "Show all models",
+    ]);
+    expect(listModels).toHaveBeenNthCalledWith(1, false);
+    expect(listModels).toHaveBeenNthCalledWith(2, true);
 
-    await bot.handleUpdate(createCallbackUpdate("model_1"));
+    await bot.handleUpdate(createCallbackUpdate("model_show_all"));
+    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Loading all models..." });
+    expect(api.editMessageText).toHaveBeenCalled();
+    expect(listModels).toHaveBeenNthCalledWith(3, true);
+    expect(getEditedReplyMarkupData(api, 0)).toEqual(["model_0", "model_1"]);
+    expect(getEditedReplyMarkupTexts(api, 0)).toEqual([
+      "openai/codex · Codex",
+      "✅ github-copilot/codex · Codex",
+    ]);
+
+    await bot.handleUpdate(createCallbackUpdate("model_0"));
     expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Switching model..." });
-    expect(pi.service.setModel).toHaveBeenCalledWith("openai", "gpt-4o");
+    expect(pi.service.setModel).toHaveBeenCalledWith("openai", "codex");
     expect(api.editMessageText).toHaveBeenCalled();
   });
 

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -101,6 +101,7 @@ const mockState = vi.hoisted(() => {
   const createAgentSession = vi.fn().mockImplementation(async (options: any) => ({
     session: createSession({
       model: options.model,
+      thinkingLevel: options.thinkingLevel,
       scopedModels: options.scopedModels,
       sessionFile: options.sessionManager?.sessionPath,
     }),
@@ -134,6 +135,8 @@ const mockState = vi.hoisted(() => {
   const SettingsManager = {
     create: vi.fn().mockImplementation(() => ({
       getEnabledModels: vi.fn().mockReturnValue(undefined),
+      getDefaultProvider: vi.fn().mockReturnValue(undefined),
+      getDefaultModel: vi.fn().mockReturnValue(undefined),
     })),
   };
 
@@ -490,6 +493,8 @@ describe("PiSessionService", () => {
   it("derives scoped models from pi settings when enabled models are configured", async () => {
     mockState.SettingsManager.create.mockReturnValueOnce({
       getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
+      getDefaultProvider: vi.fn().mockReturnValue(undefined),
+      getDefaultModel: vi.fn().mockReturnValue(undefined),
     });
 
     await PiSessionService.create(createConfig());
@@ -501,6 +506,65 @@ describe("PiSessionService", () => {
     expect(mockState.createAgentSession).toHaveBeenCalledWith(
       expect.objectContaining({
         scopedModels: [{ model: mockState.models[1] }],
+      }),
+    );
+  });
+
+  it("starts a new session on the first scoped model when no explicit model is configured", async () => {
+    mockState.SettingsManager.create.mockReturnValueOnce({
+      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
+      getDefaultProvider: vi.fn().mockReturnValue(undefined),
+      getDefaultModel: vi.fn().mockReturnValue(undefined),
+    });
+    mockState.resolveModelScope.mockResolvedValueOnce([{ model: mockState.models[1], thinkingLevel: "high" }]);
+
+    await PiSessionService.create(createConfig());
+
+    expect(mockState.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: mockState.models[1],
+        thinkingLevel: "high",
+        scopedModels: [{ model: mockState.models[1], thinkingLevel: "high" }],
+      }),
+    );
+  });
+
+  it("prefers the saved default model when it is within the scoped model set", async () => {
+    mockState.SettingsManager.create.mockReturnValueOnce({
+      getEnabledModels: vi.fn().mockReturnValue(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]),
+      getDefaultProvider: vi.fn().mockReturnValue("openai"),
+      getDefaultModel: vi.fn().mockReturnValue("gpt-4o"),
+    });
+    mockState.resolveModelScope.mockResolvedValueOnce([
+      { model: mockState.models[0] },
+      { model: mockState.models[1], thinkingLevel: "high" },
+    ]);
+
+    await PiSessionService.create(createConfig());
+
+    expect(mockState.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: mockState.models[1],
+        thinkingLevel: "high",
+      }),
+    );
+  });
+
+  it("does not override the model when opening an existing session file", async () => {
+    mockState.SettingsManager.create.mockReturnValueOnce({
+      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
+      getDefaultProvider: vi.fn().mockReturnValue(undefined),
+      getDefaultModel: vi.fn().mockReturnValue(undefined),
+    });
+    mockState.resolveModelScope.mockResolvedValueOnce([{ model: mockState.models[1], thinkingLevel: "high" }]);
+
+    await PiSessionService.create(createConfig({ piSessionPath: "/sessions/existing.jsonl" }));
+
+    expect(mockState.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: undefined,
+        thinkingLevel: undefined,
+        scopedModels: [{ model: mockState.models[1], thinkingLevel: "high" }],
       }),
     );
   });

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -42,6 +42,7 @@ const mockState = vi.hoisted(() => {
       sessionFile: options.sessionFile ?? `/tmp/session-${sessionCounter}.jsonl`,
       sessionName: options.sessionName,
       model: options.model ?? models[0],
+      thinkingLevel: options.thinkingLevel ?? "medium",
       scopedModels: options.scopedModels ?? [],
       isStreaming: false,
       agent: {
@@ -78,6 +79,9 @@ const mockState = vi.hoisted(() => {
       },
       setModel: vi.fn().mockImplementation(async (model) => {
         session.model = model;
+      }),
+      setThinkingLevel: vi.fn().mockImplementation((thinkingLevel) => {
+        session.thinkingLevel = thinkingLevel;
       }),
       subscribe: vi.fn().mockImplementation((callback) => {
         sessionSubscribers.set(session, callback);
@@ -430,12 +434,14 @@ describe("PiSessionService", () => {
         id: "claude-sonnet-4-5",
         name: "Claude Sonnet",
         current: true,
+        thinkingLevel: undefined,
       },
       {
         provider: "openai",
         id: "gpt-4o",
         name: "GPT-4o",
         current: false,
+        thinkingLevel: undefined,
       },
     ]);
   });
@@ -444,7 +450,7 @@ describe("PiSessionService", () => {
     const service = await PiSessionService.create(createConfig());
     const currentSession = mockState.createdSessions[0]?.session;
 
-    currentSession.scopedModels = [{ model: mockState.models[1] }];
+    currentSession.scopedModels = [{ model: mockState.models[1], thinkingLevel: "high" }];
 
     await expect(service.listModels()).resolves.toEqual([
       {
@@ -452,6 +458,7 @@ describe("PiSessionService", () => {
         id: "gpt-4o",
         name: "GPT-4o",
         current: false,
+        thinkingLevel: "high",
       },
     ]);
   });
@@ -460,7 +467,7 @@ describe("PiSessionService", () => {
     const service = await PiSessionService.create(createConfig());
     const currentSession = mockState.createdSessions[0]?.session;
 
-    currentSession.scopedModels = [{ model: mockState.models[1] }];
+    currentSession.scopedModels = [{ model: mockState.models[1], thinkingLevel: "high" }];
 
     await expect(service.listModels(true)).resolves.toEqual([
       {
@@ -468,12 +475,14 @@ describe("PiSessionService", () => {
         id: "claude-sonnet-4-5",
         name: "Claude Sonnet",
         current: true,
+        thinkingLevel: undefined,
       },
       {
         provider: "openai",
         id: "gpt-4o",
         name: "GPT-4o",
         current: false,
+        thinkingLevel: "high",
       },
     ]);
   });
@@ -506,6 +515,20 @@ describe("PiSessionService", () => {
       id: "gpt-4o",
       name: "GPT-4o",
     });
+    expect(currentSession.setThinkingLevel).not.toHaveBeenCalled();
+  });
+
+  it("applies a scoped thinking-level override when switching models", async () => {
+    const service = await PiSessionService.create(createConfig());
+    const currentSession = mockState.createdSessions[0]?.session;
+
+    await expect(service.setModel("openai", "gpt-4o", "high")).resolves.toBe("openai/gpt-4o");
+    expect(currentSession.setModel).toHaveBeenCalledWith({
+      provider: "openai",
+      id: "gpt-4o",
+      name: "GPT-4o",
+    });
+    expect(currentSession.setThinkingLevel).toHaveBeenCalledWith("high");
   });
 
   it("delegates tree access, navigation, and labels", async () => {

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -42,6 +42,7 @@ const mockState = vi.hoisted(() => {
       sessionFile: options.sessionFile ?? `/tmp/session-${sessionCounter}.jsonl`,
       sessionName: options.sessionName,
       model: options.model ?? models[0],
+      scopedModels: options.scopedModels ?? [],
       isStreaming: false,
       agent: {
         state: {
@@ -96,6 +97,7 @@ const mockState = vi.hoisted(() => {
   const createAgentSession = vi.fn().mockImplementation(async (options: any) => ({
     session: createSession({
       model: options.model,
+      scopedModels: options.scopedModels,
       sessionFile: options.sessionManager?.sessionPath,
     }),
     modelFallbackMessage: options.model ? undefined : "fallback-model",
@@ -125,6 +127,20 @@ const mockState = vi.hoisted(() => {
     listAll: vi.fn().mockResolvedValue(defaultSessions()),
   };
 
+  const SettingsManager = {
+    create: vi.fn().mockImplementation(() => ({
+      getEnabledModels: vi.fn().mockReturnValue(undefined),
+    })),
+  };
+
+  const resolveModelScope = vi.fn().mockImplementation(async (patterns: string[]) =>
+    patterns.map((pattern) => {
+      const [provider, id] = pattern.split("/");
+      const model = models.find((candidate) => candidate.provider === provider && candidate.id === id);
+      return { model: model ?? models[0] };
+    }),
+  );
+
   return {
     models,
     createdSessions,
@@ -134,6 +150,8 @@ const mockState = vi.hoisted(() => {
     AuthStorage,
     ModelRegistry,
     SessionManager,
+    SettingsManager,
+    resolveModelScope,
     getSubscriber: (session: object) => sessionSubscribers.get(session),
     reset: () => {
       sessionCounter = 0;
@@ -147,6 +165,8 @@ const mockState = vi.hoisted(() => {
       SessionManager.open.mockClear();
       SessionManager.listAll.mockReset();
       SessionManager.listAll.mockResolvedValue(defaultSessions());
+      SettingsManager.create.mockClear();
+      resolveModelScope.mockClear();
     },
   };
 });
@@ -157,6 +177,11 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
   AuthStorage: mockState.AuthStorage,
   ModelRegistry: mockState.ModelRegistry,
   SessionManager: mockState.SessionManager,
+  SettingsManager: mockState.SettingsManager,
+}));
+
+vi.mock("../node_modules/@mariozechner/pi-coding-agent/dist/core/model-resolver.js", () => ({
+  resolveModelScope: mockState.resolveModelScope,
 }));
 
 import { PiSessionService } from "../src/pi-session.js";
@@ -182,12 +207,14 @@ describe("PiSessionService", () => {
 
     expect(mockState.AuthStorage.create).toHaveBeenCalledTimes(1);
     expect(mockState.ModelRegistry).toHaveBeenCalledTimes(1);
+    expect(mockState.SettingsManager.create).toHaveBeenCalledWith("/workspace/base");
     expect(mockState.createCodingTools).toHaveBeenCalledWith("/workspace/base");
     expect(mockState.createAgentSession).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: "/workspace/base",
         tools: ["mock-tool"],
         model: undefined,
+        scopedModels: [],
       }),
     );
 
@@ -411,6 +438,62 @@ describe("PiSessionService", () => {
         current: false,
       },
     ]);
+  });
+
+  it("lists only scoped models when the session has a model scope", async () => {
+    const service = await PiSessionService.create(createConfig());
+    const currentSession = mockState.createdSessions[0]?.session;
+
+    currentSession.scopedModels = [{ model: mockState.models[1] }];
+
+    await expect(service.listModels()).resolves.toEqual([
+      {
+        provider: "openai",
+        id: "gpt-4o",
+        name: "GPT-4o",
+        current: false,
+      },
+    ]);
+  });
+
+  it("can list all models even when a scope is active", async () => {
+    const service = await PiSessionService.create(createConfig());
+    const currentSession = mockState.createdSessions[0]?.session;
+
+    currentSession.scopedModels = [{ model: mockState.models[1] }];
+
+    await expect(service.listModels(true)).resolves.toEqual([
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet",
+        current: true,
+      },
+      {
+        provider: "openai",
+        id: "gpt-4o",
+        name: "GPT-4o",
+        current: false,
+      },
+    ]);
+  });
+
+  it("derives scoped models from pi settings when enabled models are configured", async () => {
+    mockState.SettingsManager.create.mockReturnValueOnce({
+      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
+    });
+
+    await PiSessionService.create(createConfig());
+
+    expect(mockState.resolveModelScope).toHaveBeenCalledWith(
+      ["openai/gpt-4o"],
+      expect.anything(),
+    );
+    expect(mockState.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopedModels: [{ model: mockState.models[1] }],
+      }),
+    );
   });
 
   it("switches models via the underlying session", async () => {


### PR DESCRIPTION
## Summary
This updates the Telegram `/model` picker so it mirrors the active model scope from the current workspace settings instead of always showing the full global model list.

By default, the picker now shows the same scoped set a user would expect from their current configuration, while still offering a `Show all models` action when they want to step outside that scope.

## Why
Showing every available model in Telegram makes the picker noisy and can expose options that are intentionally filtered out by the current workspace settings.

Matching the configured scope keeps the Telegram experience aligned with the rest of the session setup and makes model switching easier in repos that define a restricted model set.

## Changes
- resolve scoped models from workspace settings when creating sessions
- use scoped models as the default source for `/model`
- add a `Show all models` option to expand to the full registry when needed
- preserve the `Show all models` action when paging through long model lists
- update the picker copy to explain when the scoped view is being shown
- add coverage for scoped, expanded, and paginated model selection flows
- adds provider of model to enable selection for different subscriptions (e.g. GPT-5.4 from OpenAi vs GPT-5.4 from GitHub Copilot)

## Implementation note
This currently relies on a package-internal `resolveModelScope` helper because the package entrypoint does not expose a public resolver yet.

That keeps the Telegram picker aligned with the current CLI behavior, but it is still a brittle integration point and would ideally be replaced by a public export or a more stable shared API later.

## Screenshots

Shows scoped models, pagination for them, switching to all models and paging through them.

![image](https://github.com/user-attachments/assets/a318b082-d60b-4947-832b-35781933da0e)
![image](https://github.com/user-attachments/assets/5f6e5301-f3d3-4266-a169-972ae380eaa6)
![image](https://github.com/user-attachments/assets/f383a86c-07b0-46e8-9df6-90da7997788a)
![image](https://github.com/user-attachments/assets/aace079e-3f71-4ce4-a961-fd901b9fd00d)