### PR TITLE
fix: resolve symlink in CLI entrypoint guard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getTelePiStatus, resolveTelePiInstallContext, setupTelePi } from "./install.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { getTelePiStatus, resolveTelePiInstallContext, setupTelePi } from "./install.js";
 import { startBot } from "./index.js";
@@ -130,10 +132,19 @@ async function runCli(): Promise<void> {
   }
 }
 
-const invokedAsScript = process.argv[1]
-  ? pathToFileURL(fileURLToPath(pathToFileURL(process.argv[1]).href)).href === import.meta.url
-  : false;
+function isEntrypoint(moduleUrl: string): boolean {
+  const argvPath = process.argv[1];
+  if (!argvPath) {
+    return false;
+  }
 
-if (invokedAsScript) {
+  try {
+    return fileURLToPath(moduleUrl) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+}
+
+if (isEntrypoint(import.meta.url)) {
   await runCli();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -107,7 +108,11 @@ function isEntrypoint(moduleUrl: string): boolean {
     return false;
   }
 
-  return fileURLToPath(moduleUrl) === path.resolve(argvPath);
+  try {
+    return fileURLToPath(moduleUrl) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
 }
 
 if (isEntrypoint(import.meta.url)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { realpathSync } from "node:fs";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createBot, registerCommands } from "./bot.js";


### PR DESCRIPTION
## Summary

Fixes #6 — the `telepi` CLI silently exits with code 0 when installed globally via npm because the entrypoint guard fails to match symlinked bin paths.

## Changes

- **`src/cli.ts`**: Replaced the `invokedAsScript` URL comparison (which compared the symlink path of `process.argv[1]` against the resolved `import.meta.url`) with an `isEntrypoint()` function that uses `fs.realpathSync()` to resolve symlinks before comparing.
- **`src/index.ts`**: Applied the same `realpathSync()` fix to the existing `isEntrypoint()` function (previously used `path.resolve()`, which does not follow symlinks).

## How to verify

```bash
# Install globally (creates symlink at ~/.local/share/npm/bin/telepi)
npm install -g @futurelab-studio/telepi

# Before fix: all commands produce no output
telepi version    # → (nothing, exit 0)

# After fix: works as expected
telepi version    # → 0.2.2
telepi help       # → prints usage
telepi status     # → prints status
```
---
*This PR was created by pi agent on behalf of S1M0N38.*
