### PR TITLE
feat: add Linux systemd support with platform abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ TelePi is a Telegram bridge for the [Pi coding agent](https://github.com/badlogi
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)
 - Pi installed locally with working credentials in `~/.pi/agent/auth.json`
 
-## Quickstart (npm global install, macOS)
+## Quickstart (npm global install)
 
-This is the main install path for TelePi.
+This is the main install path for TelePi on macOS (`launchd`) and Linux (`systemd --user`).
 
 1. Install TelePi globally:
    ```bash
@@ -52,7 +52,8 @@ This is the main install path for TelePi.
    `telepi setup` will:
    - create or update `~/.config/telepi/config.env`
    - preserve any existing optional config values already present in that file
-   - install/update `~/Library/LaunchAgents/com.telepi.plist`
+   - on macOS, install/update `~/Library/LaunchAgents/com.telepi.plist`
+   - on Linux, install/update `~/.config/systemd/user/telepi.service` and run `systemctl --user daemon-reload && systemctl --user enable --now telepi.service`
    - install the Pi `/handoff` extension at `~/.pi/agent/extensions/telepi-handoff.ts`
 
    If you run setup non-interactively, you must either pass all three positional values or already have them configured; TelePi now fails clearly instead of writing placeholder values.
@@ -72,7 +73,7 @@ This is the main install path for TelePi.
    ```
 5. Open Telegram and send `/start` to your bot.
 
-Rerunning `telepi setup` after upgrades is safe; it refreshes the LaunchAgent and extension while preserving your config. After setup, `/handoff` automatically reuses the installed `launchd` service by default.
+Rerunning `telepi setup` after upgrades is safe; it refreshes the service unit and extension while preserving your config. After setup, `/handoff` automatically reuses the installed `launchd` service on macOS or `systemd --user` service on Linux by default.
 
 ## Development from Source
 
@@ -283,9 +284,10 @@ Pi auto-discovers it after symlinking (or run `/reload` in Pi).
 
 The extension supports three hand-off mode settings, controlled via shell environment variables:
 
-- `TELEPI_HANDOFF_MODE=auto` *(default)* — if `telepi setup` assets are present (`~/.config/telepi/config.env` plus the configured LaunchAgent plist), reuse `launchd`; otherwise use direct mode
-- `TELEPI_HANDOFF_MODE=direct` — always start a fresh direct TelePi process; best for source-checkout development or when the LaunchAgent is unloaded
-- `TELEPI_HANDOFF_MODE=launchd` — force `launchd` hand-off by setting `PI_SESSION_PATH` in the `launchd` user environment and restarting the configured LaunchAgent
+- `TELEPI_HANDOFF_MODE=auto` *(default)* — if `telepi setup` assets are present, reuse `launchd` on macOS or `systemd --user` on Linux; otherwise use direct mode
+- `TELEPI_HANDOFF_MODE=direct` — always start a fresh direct TelePi process; best for source-checkout development or when the installed service is unloaded
+- `TELEPI_HANDOFF_MODE=launchd` — force macOS `launchd` hand-off by setting `PI_SESSION_PATH` in the `launchd` user environment and restarting the configured LaunchAgent
+- `TELEPI_HANDOFF_MODE=systemd` — force Linux `systemd --user` hand-off by setting `PI_SESSION_PATH` in the user service manager and restarting `telepi.service`
 - `TELEPI_LAUNCHD_LABEL` *(optional, default: `com.telepi`)* — LaunchAgent label/plist name to restart in `launchd` mode or auto-detect
 
 #### Direct mode
@@ -322,6 +324,29 @@ In `launchd` mode, `/handoff` only does two things: set `PI_SESSION_PATH` in `la
 
 > **Note:** `telepi setup` installs the plist with `KeepAlive`, so launchd will restart TelePi if it exits. To fully stop TelePi, unload the agent: `launchctl bootout gui/$UID/com.telepi`.
 
+#### systemd mode (default after `telepi setup` on Linux)
+
+On Linux, `telepi setup` installs a user service at `~/.config/systemd/user/telepi.service`, reloads the user daemon, enables the service, and starts/restarts it. `/handoff` auto-detects that service and runs:
+
+```bash
+systemctl --user set-environment PI_SESSION_PATH=/path/to/session.jsonl
+systemctl --user restart telepi.service
+```
+
+If `systemctl --user` is unavailable, make sure your distro has user systemd sessions enabled. On headless servers you may need lingering:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+Useful commands:
+
+```bash
+systemctl --user status telepi.service
+journalctl --user -u telepi.service -f
+systemctl --user stop telepi.service
+```
+
 ### Telegram → CLI (`/handback`)
 
 You're on your phone and want to get back to your terminal:
@@ -331,7 +356,7 @@ You're on your phone and want to get back to your terminal:
    ```
    cd '/Users/you/myproject' && pi --session '/Users/you/.pi/agent/sessions/.../session.jsonl'
    ```
-3. On macOS, the command is **copied to your clipboard** automatically
+3. On macOS and Linux desktops with `wl-copy`, `xclip`, or `xsel`, the command is **copied to your clipboard** automatically
 4. **In your terminal**, paste and run — Pi CLI opens with the full conversation, including everything from Telegram
 5. TelePi stays alive — send any message in Telegram to start a fresh session
 
@@ -390,10 +415,17 @@ Installed mode (`telepi setup`) creates or manages these user-level files:
 ~/.config/telepi/
 └── config.env                     ← generated from .env.example and updated by telepi setup
 
-~/Library/LaunchAgents/
+~/Library/LaunchAgents/            (macOS)
 └── com.telepi.plist              ← launchd service generated by telepi setup
 
-~/Library/Logs/TelePi/
+~/.config/systemd/user/            (Linux)
+└── telepi.service                 ← systemd user service generated by telepi setup
+
+~/Library/Logs/TelePi/             (macOS)
+├── telepi.out.log
+└── telepi.err.log
+
+~/.local/state/telepi/logs/        (Linux)
 ├── telepi.out.log
 └── telepi.err.log
 
@@ -415,6 +447,8 @@ TelePi/
 │   └── telepi-handoff.ts         ← Pi CLI extension source
 ├── launchd/
 │   └── com.telepi.plist          ← launchd template used by telepi setup
+├── systemd/
+│   └── telepi.service            ← systemd user-service template used by telepi setup
 ├── scripts/
 │   └── package-release.mjs       ← builds release tarballs + sha256 checksums
 ├── src/
@@ -438,6 +472,9 @@ TelePi/
 │   │   ├── config.ts             ← config-file setup/update helpers
 │   │   ├── extension.ts          ← extension install/status helpers
 │   │   ├── launchd.ts            ← LaunchAgent plist and launchctl helpers
+│   │   ├── platform.ts           ← platform detection and install context resolution
+│   │   ├── service-manager.ts    ← shared launchd/systemd service manager interface
+│   │   ├── systemd.ts            ← systemd unit and systemctl helpers
 │   │   └── shared.ts             ← shared install types/constants
 │   ├── model-scope.ts            ← model filtering and grouping
 │   ├── pi-session.ts             ← Pi SDK session wrapper

--- a/extensions/telepi-handoff.ts
+++ b/extensions/telepi-handoff.ts
@@ -3,26 +3,20 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-type HandoffMode = "direct" | "launchd";
+type HandoffMode = "direct" | "launchd" | "systemd";
 
 export type DirectLaunchTarget =
-  | {
-      kind: "installed";
-      homeDirectory: string;
-      installedConfigPath: string;
-    }
-  | {
-      kind: "source";
-      telePiDir: string;
-    }
-  | {
-      kind: "unavailable";
-      reason: "missing-installed-config" | "missing-telepi";
-      installedConfigPath: string;
-    };
+  | { kind: "installed"; homeDirectory: string; installedConfigPath: string }
+  | { kind: "source"; telePiDir: string }
+  | { kind: "unavailable"; reason: "missing-installed-config" | "missing-telepi"; installedConfigPath: string };
 
 const DEFAULT_LAUNCHD_LABEL = "com.telepi";
+const DEFAULT_SYSTEMD_SERVICE = "telepi.service";
 const DIRECT_LOG_PATH = "/tmp/telepi.log";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function shellQuote(value: string): string {
   return value.replace(/'/g, "'\\''");
@@ -30,20 +24,6 @@ function shellQuote(value: string): string {
 
 function getLaunchdLabel(env: NodeJS.ProcessEnv = process.env): string {
   return env.TELEPI_LAUNCHD_LABEL?.trim() || DEFAULT_LAUNCHD_LABEL;
-}
-
-export function resolveHandoffMode(env: NodeJS.ProcessEnv = process.env): HandoffMode | undefined {
-  const raw = env.TELEPI_HANDOFF_MODE?.trim().toLowerCase();
-  if (!raw || raw === "auto") {
-    return hasInstalledLaunchdFlow(env) ? "launchd" : "direct";
-  }
-  if (raw === "direct") {
-    return "direct";
-  }
-  if (raw === "launchd") {
-    return "launchd";
-  }
-  return undefined;
 }
 
 export function getHomeDirectory(env: NodeJS.ProcessEnv = process.env): string {
@@ -61,10 +41,32 @@ export function getInstalledLaunchAgentPath(
   return path.join(homeDirectory, "Library", "LaunchAgents", `${launchdLabel}.plist`);
 }
 
-export function hasInstalledLaunchdFlow(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (process.platform !== "darwin") {
-    return false;
+export function getInstalledSystemdServicePath(homeDirectory = getHomeDirectory()): string {
+  return path.join(homeDirectory, ".config", "systemd", "user", DEFAULT_SYSTEMD_SERVICE);
+}
+
+// ---------------------------------------------------------------------------
+// Mode detection
+// ---------------------------------------------------------------------------
+
+export function resolveHandoffMode(env: NodeJS.ProcessEnv = process.env): HandoffMode | undefined {
+  const raw = env.TELEPI_HANDOFF_MODE?.trim().toLowerCase();
+
+  if (!raw || raw === "auto") {
+    if (hasInstalledLaunchdFlow(env)) return "launchd";
+    if (hasInstalledSystemdFlow(env)) return "systemd";
+    return "direct";
   }
+
+  if (raw === "direct") return "direct";
+  if (raw === "launchd") return "launchd";
+  if (raw === "systemd") return "systemd";
+
+  return undefined;
+}
+
+export function hasInstalledLaunchdFlow(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (process.platform !== "darwin") return false;
 
   const homeDirectory = getHomeDirectory(env);
   return (
@@ -72,6 +74,20 @@ export function hasInstalledLaunchdFlow(env: NodeJS.ProcessEnv = process.env): b
     existsSync(getInstalledLaunchAgentPath(homeDirectory, getLaunchdLabel(env)))
   );
 }
+
+export function hasInstalledSystemdFlow(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (process.platform !== "linux") return false;
+
+  const homeDirectory = getHomeDirectory(env);
+  return (
+    existsSync(getInstalledConfigPath(homeDirectory)) &&
+    existsSync(getInstalledSystemdServicePath(homeDirectory))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Direct launch target
+// ---------------------------------------------------------------------------
 
 export function resolveDirectLaunchTarget(options: {
   hasGlobalTelePi: boolean;
@@ -84,52 +100,33 @@ export function resolveDirectLaunchTarget(options: {
   const telePiDir = options.telePiDir?.trim();
 
   if (options.hasGlobalTelePi && existsSync(installedConfigPath)) {
-    return {
-      kind: "installed",
-      homeDirectory,
-      installedConfigPath,
-    };
+    return { kind: "installed", homeDirectory, installedConfigPath };
   }
-
-  if (telePiDir) {
-    return {
-      kind: "source",
-      telePiDir,
-    };
-  }
-
+  if (telePiDir) return { kind: "source", telePiDir };
   if (options.hasGlobalTelePi) {
-    return {
-      kind: "unavailable",
-      reason: "missing-installed-config",
-      installedConfigPath,
-    };
+    return { kind: "unavailable", reason: "missing-installed-config", installedConfigPath };
   }
-
-  return {
-    kind: "unavailable",
-    reason: "missing-telepi",
-    installedConfigPath,
-  };
+  return { kind: "unavailable", reason: "missing-telepi", installedConfigPath };
 }
 
 async function hasGlobalTelePiCommand(pi: ExtensionAPI): Promise<boolean> {
   try {
-    const result = await pi.exec("bash", ["-lc", "command -v telepi >/dev/null 2>&1"], {
-      timeout: 3000,
-    });
+    const result = await pi.exec("bash", ["-lc", "command -v telepi >/dev/null 2>&1"], { timeout: 3000 });
     return result.code === 0;
   } catch {
     return false;
   }
 }
 
+// ---------------------------------------------------------------------------
+// Handoff command handler
+// ---------------------------------------------------------------------------
+
 export default function (pi: ExtensionAPI) {
   pi.registerCommand("handoff", {
     description: "Hand off this session to TelePi (Telegram)",
     handler: async (_args, ctx) => {
       const sessionFile = ctx.sessionManager.getSessionFile();
-
       if (!sessionFile) {
         ctx.ui.notify("Cannot hand off an in-memory session. Save the session first.", "error");
         return;
@@ -137,145 +134,207 @@ export default function (pi: ExtensionAPI) {
 
       const handoffMode = resolveHandoffMode();
       if (!handoffMode) {
-        ctx.ui.notify(
-          "Invalid TELEPI_HANDOFF_MODE. Expected one of: auto, direct, launchd",
-          "error",
-        );
+        ctx.ui.notify("Invalid TELEPI_HANDOFF_MODE. Expected one of: auto, direct, launchd, systemd", "error");
         return;
       }
 
       const safeSessionFile = shellQuote(sessionFile);
       let launched = false;
 
+      // 1) launchd (macOS)
       if (handoffMode === "launchd") {
-        const launchdLabel = getLaunchdLabel();
-        const safeLaunchdLabel = shellQuote(launchdLabel);
+        launched = await handoffViaLaunchd(pi, ctx, sessionFile, safeSessionFile);
+      }
+      // 2) systemd (Linux)
+      else if (handoffMode === "systemd") {
+        launched = await handoffViaSystemd(pi, ctx, sessionFile, safeSessionFile);
+      }
+      // 3) direct
+      else {
+        launched = await handoffViaDirect(pi, ctx, sessionFile, safeSessionFile);
+      }
 
-        ctx.ui.notify(
-          `Handing off to TelePi via launchd...\nSession: ${sessionFile}\nJob: ${launchdLabel}`,
-          "info",
-        );
+      if (launched) ctx.shutdown();
+    },
+  });
+}
 
-        try {
-          const result = await pi.exec(
+// ---------------------------------------------------------------------------
+// Handoff implementations
+// ---------------------------------------------------------------------------
+
+async function handoffViaLaunchd(
+  pi: ExtensionAPI,
+  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
+  sessionFile: string,
+  safeSessionFile: string,
+): Promise<boolean> {
+  const launchdLabel = getLaunchdLabel();
+  const safeLaunchdLabel = shellQuote(launchdLabel);
+
+  ctx.ui.notify(`Handing off to TelePi via launchd...\nSession: ${sessionFile}\nJob: ${launchdLabel}`, "info");
+
+  try {
+    const result = await pi.exec(
+      "bash",
+      ["-lc", [
+        `session_file='${safeSessionFile}'`,
+        `label='${safeLaunchdLabel}'`,
+        `launchctl setenv PI_SESSION_PATH "$session_file"`,
+        `launchctl kickstart -k "gui/$UID/$label"`,
+      ].join("\n")],
+      { timeout: 5000 },
+    );
+
+    if (result.code === 0) {
+      ctx.ui.notify(`TelePi restarted via launchd job ${launchdLabel}. Check Telegram!`, "info");
+      return true;
+    }
+
+    ctx.ui.notify(
+      "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
+        `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
+        `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
+      "warning",
+    );
+    return false;
+  } catch {
+    ctx.ui.notify(
+      "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
+        `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
+        `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
+      "warning",
+    );
+    return false;
+  }
+}
+
+async function handoffViaSystemd(
+  pi: ExtensionAPI,
+  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
+  sessionFile: string,
+  safeSessionFile: string,
+): Promise<boolean> {
+  ctx.ui.notify(`Handing off to TelePi via systemd...\nSession: ${sessionFile}`, "info");
+
+  try {
+    const result = await pi.exec(
+      "bash",
+      ["-lc", [
+        `session_file='${safeSessionFile}'`,
+        `systemctl --user set-environment PI_SESSION_PATH="$session_file"`,
+        `systemctl --user restart telepi.service`,
+      ].join("\n")],
+      { timeout: 5000 },
+    );
+
+    if (result.code === 0) {
+      ctx.ui.notify("TelePi restarted via systemd. Check Telegram!", "info");
+      return true;
+    }
+
+    ctx.ui.notify(
+      "Could not restart TelePi via systemd. Try manually:\n" +
+        `systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
+        `systemctl --user restart telepi.service`,
+      "warning",
+    );
+    return false;
+  } catch {
+    ctx.ui.notify(
+      "Could not restart TelePi via systemd. Try manually:\n" +
+        `systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
+        `systemctl --user restart telepi.service`,
+      "warning",
+    );
+    return false;
+  }
+}
+
+async function handoffViaDirect(
+  pi: ExtensionAPI,
+  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
+  sessionFile: string,
+  safeSessionFile: string,
+): Promise<boolean> {
+  const telePiDir = process.env.TELEPI_DIR?.trim();
+  const hasGlobalTelePi = await hasGlobalTelePiCommand(pi);
+  const target = resolveDirectLaunchTarget({ hasGlobalTelePi, telePiDir });
+
+  if (target.kind === "unavailable") {
+    if (target.reason === "missing-installed-config") {
+      ctx.ui.notify(
+        "TelePi is installed globally, but its installed config is missing:\n" +
+          `  ${target.installedConfigPath}\n\n` +
+          "Run `telepi setup` to create it, or point TELEPI_DIR at a source checkout.",
+        "error",
+      );
+    } else {
+      ctx.ui.notify(
+        "TelePi is not available for direct hand-off. Either install it globally:\n" +
+          "  npm install -g @benedict2310/telepi\n" +
+          "  telepi setup\n\n" +
+          "Or point TELEPI_DIR at a source checkout:\n" +
+          "  export TELEPI_DIR=/path/to/TelePi\n\n" +
+          "Or use systemd mode (Linux) / launchd mode (macOS) with:\n" +
+          "  export TELEPI_HANDOFF_MODE=systemd   # Linux\n" +
+          "  export TELEPI_HANDOFF_MODE=launchd   # macOS",
+        "error",
+      );
+    }
+    return false;
+  }
+
+  ctx.ui.notify(`Handing off to TelePi...\nSession: ${sessionFile}`, "info");
+
+  if (target.kind === "source") {
+    await pi.exec("bash", ["-lc", 'pkill -f "tsx.*TelePi" 2>/dev/null || true'], { timeout: 3000 }).catch(() => {});
+  }
+
+  try {
+    const result =
+      target.kind === "installed"
+        ? await pi.exec(
             "bash",
-            [
-              "-lc",
-              `session_file='${safeSessionFile}'
-label='${safeLaunchdLabel}'
-launchctl setenv PI_SESSION_PATH "$session_file"
-launchctl kickstart -k "gui/$UID/$label"`,
-            ],
+            ["-lc", [
+              `cd '${shellQuote(target.homeDirectory)}'`,
+              `telepi_command="$(command -v telepi)"`,
+              `PI_SESSION_PATH='${safeSessionFile}' TELEPI_CONFIG='${shellQuote(target.installedConfigPath)}' nohup "$telepi_command" start > '${DIRECT_LOG_PATH}' 2>&1 &`,
+              `echo $!`,
+            ].join("\n")],
+            { timeout: 5000 },
+          )
+        : await pi.exec(
+            "bash",
+            ["-lc", [
+              `cd '${shellQuote(target.telePiDir)}'`,
+              `PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > '${DIRECT_LOG_PATH}' 2>&1 &`,
+              `echo $!`,
+            ].join("\n")],
             { timeout: 5000 },
           );
 
-          if (result.code === 0) {
-            ctx.ui.notify(`TelePi restarted via launchd job ${launchdLabel}. Check Telegram!`, "info");
-            launched = true;
-          } else {
-            ctx.ui.notify(
-              "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
-                `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
-                `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
-              "warning",
-            );
-          }
-        } catch {
-          // pi.exec() only throws on OS-level failure (e.g. timeout); non-zero exit codes are
-          // handled above via result.code. This catch is a last-resort safety net.
-          ctx.ui.notify(
-            "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
-              `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
-              `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
-            "warning",
-          );
-        }
-      } else {
-        const telePiDir = process.env.TELEPI_DIR?.trim();
-        const hasGlobalTelePi = await hasGlobalTelePiCommand(pi);
-        const directLaunchTarget = resolveDirectLaunchTarget({ hasGlobalTelePi, telePiDir });
-
-        if (directLaunchTarget.kind === "unavailable") {
-          if (directLaunchTarget.reason === "missing-installed-config") {
-            ctx.ui.notify(
-              "TelePi is installed globally, but its installed config is missing:\n" +
-                `  ${directLaunchTarget.installedConfigPath}\n\n` +
-                "Run `telepi setup` to create it, or point TELEPI_DIR at a source checkout.",
-              "error",
-            );
-            return;
-          }
-
-          ctx.ui.notify(
-            "TelePi is not available for direct hand-off. Either install it globally:\n" +
-              "  npm install -g @benedict2310/telepi\n" +
-              "  telepi setup\n\n" +
-              "Or point TELEPI_DIR at a source checkout:\n" +
-              "  export TELEPI_DIR=/path/to/TelePi\n\n" +
-              "Or switch to launchd mode with:\n" +
-              "  export TELEPI_HANDOFF_MODE=launchd",
-            "error",
-          );
-          return;
-        }
-
-        ctx.ui.notify(`Handing off to TelePi...\nSession: ${sessionFile}`, "info");
-
-        if (directLaunchTarget.kind === "source") {
-          await pi.exec("bash", ["-lc", 'pkill -f "tsx.*TelePi" 2>/dev/null || true'], {
-            timeout: 3000,
-          }).catch(() => {});
-        }
-
-        try {
-          const result =
-            directLaunchTarget.kind === "installed"
-              ? await pi.exec(
-                  "bash",
-                  [
-                    "-lc",
-                    `cd '${shellQuote(directLaunchTarget.homeDirectory)}'
-telepi_command="$(command -v telepi)"
-PI_SESSION_PATH='${safeSessionFile}' TELEPI_CONFIG='${shellQuote(directLaunchTarget.installedConfigPath)}' nohup "$telepi_command" start > '${DIRECT_LOG_PATH}' 2>&1 & echo $!`,
-                  ],
-                  { timeout: 5000 },
-                )
-              : await pi.exec(
-                  "bash",
-                  [
-                    "-lc",
-                    `cd '${shellQuote(directLaunchTarget.telePiDir)}'
-PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > '${DIRECT_LOG_PATH}' 2>&1 & echo $!`,
-                  ],
-                  { timeout: 5000 },
-                );
-          const pid = result.stdout.trim();
-          if (pid && result.code === 0) {
-            ctx.ui.notify(
-              directLaunchTarget.kind === "installed"
-                ? `TelePi started via installed \`telepi\` (PID: ${pid}). Check Telegram!`
-                : `TelePi started from source checkout (PID: ${pid}). Check Telegram!`,
-              "info",
-            );
-            launched = true;
-          } else {
-            ctx.ui.notify(`TelePi may have failed to start. Check ${DIRECT_LOG_PATH}`, "warning");
-          }
-        } catch {
-          ctx.ui.notify(
-            directLaunchTarget.kind === "installed"
-              ? "Could not auto-launch TelePi. Start it manually:\n" +
-                  `TELEPI_CONFIG="${directLaunchTarget.installedConfigPath}" PI_SESSION_PATH="${sessionFile}" telepi start`
-              : `Could not auto-launch TelePi. Start it manually:\n` +
-                  `cd "${directLaunchTarget.telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
-            "warning",
-          );
-        }
-      }
-
-      if (launched) {
-        ctx.shutdown();
-      }
-    },
-  });
+    const pid = result.stdout.trim();
+    if (pid && result.code === 0) {
+      ctx.ui.notify(
+        target.kind === "installed"
+          ? `TelePi started via installed \`telepi\` (PID: ${pid}). Check Telegram!`
+          : `TelePi started from source checkout (PID: ${pid}). Check Telegram!`,
+        "info",
+      );
+      return true;
+    }
+    ctx.ui.notify(`TelePi may have failed to start. Check ${DIRECT_LOG_PATH}`, "warning");
+    return false;
+  } catch {
+    ctx.ui.notify(
+      target.kind === "installed"
+        ? "Could not auto-launch TelePi. Start it manually:\n" +
+          `TELEPI_CONFIG="${target.installedConfigPath}" PI_SESSION_PATH="${sessionFile}" telepi start`
+        : `Could not auto-launch TelePi. Start it manually:\n` +
+          `cd "${target.telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
+      "warning",
+    );
+    return false;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mariozechner/pi-coding-agent": "0.70.2",
         "grammy": "^1.35.0",
         "minimatch": "^10.2.4",
-        "sherpa-onnx-node": "^1.12.32"
+        "sherpa-onnx-node": "1.12.32"
       },
       "bin": {
         "telepi": "dist/cli.js"
@@ -30,7 +30,7 @@
       },
       "optionalDependencies": {
         "parakeet-coreml": "^2.2.0",
-        "sherpa-onnx-node": "^1.12.32"
+        "sherpa-onnx-node": "1.12.32"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@grammyjs/auto-retry": "^2.0.2",
         "@mariozechner/pi-coding-agent": "0.70.2",
         "grammy": "^1.35.0",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "sherpa-onnx-node": "^1.12.32"
       },
       "bin": {
         "telepi": "dist/cli.js"
@@ -29,7 +30,7 @@
       },
       "optionalDependencies": {
         "parakeet-coreml": "^2.2.0",
-        "sherpa-onnx-node": "1.12.32"
+        "sherpa-onnx-node": "^1.12.32"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dist",
     "extensions/telepi-handoff.ts",
     "launchd/com.telepi.plist",
+    "systemd/telepi.service",
     "README.md",
     ".env.example",
     "LICENSE"
@@ -57,7 +58,7 @@
   },
   "optionalDependencies": {
     "parakeet-coreml": "^2.2.0",
-    "sherpa-onnx-node": "1.12.32"
+    "sherpa-onnx-node": "^1.12.32"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "optionalDependencies": {
     "parakeet-coreml": "^2.2.0",
-    "sherpa-onnx-node": "^1.12.32"
+    "sherpa-onnx-node": "1.12.32"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/bot/commands/sessions.ts
+++ b/src/bot/commands/sessions.ts
@@ -236,18 +236,11 @@ export function createSessionCommandHandlers(deps: {
       const piContinueCommand = `cd ${shellEscape(workspace)} && pi -c`;
 
       let copiedToClipboard = false;
-      if (process.platform === "darwin") {
-        try {
-          const { spawnSync } = await import("node:child_process");
-          const result = spawnSync("pbcopy", [], {
-            input: piCommand,
-            timeout: 2000,
-            stdio: ["pipe", "ignore", "ignore"],
-          });
-          copiedToClipboard = result.status === 0;
-        } catch {
-          // Ignore clipboard failures.
-        }
+      try {
+        const { copyToClipboard: copyToClipboardUtil } = await import("../../install/clipboard.js");
+        copiedToClipboard = await copyToClipboardUtil(piCommand);
+      } catch {
+        // Ignore clipboard failures.
       }
 
       const plainText = [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,9 @@ const HELP_TEXT = `TelePi CLI
 Usage:
   telepi                              Start the bot
   telepi start                        Start the bot
-  telepi setup                        Interactive macOS setup (TTY only)
+  telepi setup                        Interactive setup (TTY only)
   telepi setup <bot_token> <userids> <workspace>
-                                      Fast macOS setup without prompts
+                                      Fast setup without prompts
   telepi status                       Show installed-mode status
   telepi version                      Print the TelePi version
   telepi help                         Show this help
@@ -72,46 +72,67 @@ export async function runSetupCommand(args: string[]): Promise<void> {
       ? "updated"
       : "unchanged";
 
+  const platform = result.context.platform;
+  const serviceLabel = platform === "linux" ? "Service" : "LaunchAgent";
+
   console.log(`TelePi ${result.context.version}`);
   console.log(`Config: ${result.context.configPath} (${configState})`);
-  console.log(
-    `LaunchAgent: ${result.context.launchAgentPath} (${result.launchAgentUpdated ? "updated" : "unchanged"})`,
-  );
+
+  if (platform === "linux" && result.context.serviceUnitPath) {
+    console.log(
+      `Service: ${result.context.serviceUnitPath} (${result.unitUpdated ? "updated" : "unchanged"})`,
+    );
+  } else if (platform === "darwin" && result.context.launchAgentPath) {
+    console.log(
+      `${serviceLabel}: ${result.context.launchAgentPath} (${result.unitUpdated ? "updated" : "unchanged"})`,
+    );
+  }
+
   console.log(
     `Extension: ${result.context.extensionDestinationPath} (${result.extensionInstalledAs})`,
   );
 
-  if (result.launchdActions.length > 0) {
-    console.log(`launchd: ${result.launchdActions.join(" -> ")}`);
+  if (result.serviceActions.length > 0) {
+    const actionLabel = platform === "linux" ? "systemctl" : "launchd";
+    console.log(`${actionLabel}: ${result.serviceActions.join(" -> ")}`);
   }
-  if (result.launchdWarning) {
-    console.warn(`launchd warning: ${result.launchdWarning}`);
+  if (result.serviceWarning) {
+    const warningLabel = platform === "linux" ? "systemd" : "launchd";
+    console.warn(`${warningLabel} warning: ${result.serviceWarning}`);
   }
 }
 
 export function runStatusCommand(): void {
   const status = getTelePiStatus(import.meta.url);
-  const configSourceLabels: Record<typeof status.configSource, string> = {
+  const platform = resolveTelePiInstallContext(import.meta.url).platform;
+
+  const configSourceLabels: Record<string, string> = {
+    "service-env": platform === "linux" ? "systemd TELEPI_CONFIG" : "launchd TELEPI_CONFIG",
+    "service-cwd": platform === "linux" ? "systemd working-directory .env" : "launchd working-directory .env",
     "launchd-env": "launchd TELEPI_CONFIG",
     "launchd-cwd": "launchd working-directory .env",
     "installed-default": "installed default",
   };
-  const launchdSummary = status.launchAgent.loaded
-    ? `loaded${status.launchAgent.state ? ` (${status.launchAgent.state})` : ""}${status.launchAgent.pid ? ` pid=${status.launchAgent.pid}` : ""}`
-    : status.launchAgent.detail;
+
+  const serviceSummary = status.service.loaded
+    ? `loaded${status.service.state ? ` (${status.service.state})` : ""}${status.service.pid ? ` pid=${status.service.pid}` : ""}`
+    : status.service.detail;
+
   const extensionSummary =
     status.extension.mode === "symlink" && status.extension.targetPath
       ? `${status.extension.detail} -> ${status.extension.targetPath}`
       : status.extension.detail;
 
+  const serviceLabel = platform === "linux" ? "systemd" : "launchd";
+  const unitLabel = platform === "linux" ? "unit" : "plist";
+  const unitPresent = status.service.unitExists ? `${unitLabel} present` : `${unitLabel} missing`;
+
   console.log(`TelePi ${status.version}`);
-  console.log(`Config path: ${status.resolvedConfigPath} [${configSourceLabels[status.configSource]}]`);
+  console.log(`Config path: ${status.resolvedConfigPath} [${configSourceLabels[status.configSource] ?? status.configSource}]`);
   console.log(`Config exists: ${status.configExists ? "yes" : "no"}`);
-  console.log(
-    `launchd: ${launchdSummary} (${status.launchAgent.plistExists ? "plist present" : "plist missing"})`,
-  );
-  if (status.launchAgent.error) {
-    console.log(`launchd detail: ${status.launchAgent.error}`);
+  console.log(`${serviceLabel}: ${serviceSummary} (${unitPresent})`);
+  if (status.service.error) {
+    console.log(`${serviceLabel} detail: ${status.service.error}`);
   }
   console.log(`Extension: ${extensionSummary}`);
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,24 +1,17 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-import { getDefaultTelePiConfigPath, getHomeDirectory } from "./paths.js";
-import { ensureTelePiConfig } from "./install/config.js";
+import { ensureTelePiConfig, getServiceConfigSource } from "./install/config.js";
 import { getExtensionStatus, installExtension } from "./install/extension.js";
 import {
   buildLaunchAgentPlist,
   getInstalledConfigStatus,
-  getLaunchAgentStatus,
-  reconcileLaunchAgent,
-  writeLaunchAgentPlist,
 } from "./install/launchd.js";
+import { resolveTelePiInstallContext, getServiceManager } from "./install/platform.js";
 import {
-  TELEPI_EXTENSION_FILENAME,
-  TELEPI_LAUNCH_AGENT_FILENAME,
-  TELEPI_LAUNCHD_LABEL,
   type ExtensionInstallMode,
   type ExtensionStatus,
-  type LaunchAgentStatus,
+  type ServiceStatus,
   type TelePiConfigSetupResult,
   type TelePiConfigSetupValues,
   type TelePiInstallContext,
@@ -28,11 +21,13 @@ import {
   type TelePiStatusConfigSource,
 } from "./install/shared.js";
 
+// Re-exports for public facade
 export { TELEPI_LAUNCHD_LABEL } from "./install/shared.js";
 export type {
   ExtensionInstallMode,
   ExtensionStatus,
   LaunchAgentStatus,
+  ServiceStatus,
   TelePiConfigSetupResult,
   TelePiConfigSetupValues,
   TelePiInstallContext,
@@ -43,89 +38,89 @@ export type {
 } from "./install/shared.js";
 export { ensureTelePiConfig } from "./install/config.js";
 export { buildLaunchAgentPlist } from "./install/launchd.js";
+export { resolveTelePiInstallContext, detectPlatform } from "./install/platform.js";
 
-export function resolveTelePiInstallContext(cliModuleUrl: string): TelePiInstallContext {
-  const rawCliEntrypointPath = fileURLToPath(cliModuleUrl);
-  const packageRoot = path.resolve(path.dirname(rawCliEntrypointPath), "..");
-  const cliEntrypointPath = resolveInstalledCliEntrypointPath(packageRoot, rawCliEntrypointPath);
-  const homeDirectory = getHomeDirectory();
-  const launchAgentDomain = resolveLaunchAgentDomain();
-
-  return {
-    packageRoot,
-    cliEntrypointPath,
-    envExamplePath: path.join(packageRoot, ".env.example"),
-    launchdTemplatePath: path.join(packageRoot, "launchd", TELEPI_LAUNCH_AGENT_FILENAME),
-    extensionSourcePath: path.join(packageRoot, "extensions", TELEPI_EXTENSION_FILENAME),
-    configPath: getDefaultTelePiConfigPath(homeDirectory),
-    launchAgentPath: path.join(homeDirectory, "Library", "LaunchAgents", TELEPI_LAUNCH_AGENT_FILENAME),
-    launchAgentLabel: TELEPI_LAUNCHD_LABEL,
-    launchAgentDomain,
-    launchAgentServiceTarget: launchAgentDomain
-      ? `${launchAgentDomain}/${TELEPI_LAUNCHD_LABEL}`
-      : undefined,
-    launchAgentLogsDirectory: path.join(homeDirectory, "Library", "Logs", "TelePi"),
-    launchAgentStdoutPath: path.join(homeDirectory, "Library", "Logs", "TelePi", "telepi.out.log"),
-    launchAgentStderrPath: path.join(homeDirectory, "Library", "Logs", "TelePi", "telepi.err.log"),
-    extensionDestinationPath: path.join(
-      homeDirectory,
-      ".pi",
-      "agent",
-      "extensions",
-      TELEPI_EXTENSION_FILENAME,
-    ),
-    nodeExecutablePath: process.execPath,
-    workingDirectory: homeDirectory,
-    pathEnvironment: process.env.PATH,
-    version: readPackageVersion(packageRoot),
-  };
-}
+// ---- getTelePiStatus ----
 
 export function getTelePiStatus(cliModuleUrl: string): TelePiStatus {
   const context = resolveTelePiInstallContext(cliModuleUrl);
-  const configInfo = getInstalledConfigStatus(context);
+
+  // Config source resolution
+  let configInfo: { resolvedPath: string; source: TelePiStatusConfigSource };
+  if (context.platform === "darwin") {
+    configInfo = getInstalledConfigStatus(context);
+  } else {
+    configInfo = getServiceConfigSource(context);
+  }
+
+  // Service status via platform-agnostic ServiceManager
+  const serviceMgr = getServiceManager(context.platform);
+  const serviceStatus: ServiceStatus = serviceMgr.getStatus(context);
 
   return {
     version: context.version,
     resolvedConfigPath: configInfo.resolvedPath,
     configExists: existsSync(configInfo.resolvedPath),
     configSource: configInfo.source,
-    launchAgent: getLaunchAgentStatus(context),
+    service: serviceStatus,
+    launchAgent: serviceStatus,
     extension: getExtensionStatus(context),
   };
 }
+
+// ---- setupTelePi ----
 
 export async function setupTelePi(
   cliModuleUrl: string,
   options: TelePiSetupOptions = {},
 ): Promise<TelePiSetupResult> {
-  if (process.platform !== "darwin") {
-    throw new Error("telepi setup is currently only supported on macOS.");
-  }
-
   const context = resolveTelePiInstallContext(cliModuleUrl);
   ensureInstallInputsExist(context);
 
+  // Create all necessary directories
   mkdirSync(path.dirname(context.configPath), { recursive: true });
-  mkdirSync(path.dirname(context.launchAgentPath), { recursive: true });
-  mkdirSync(context.launchAgentLogsDirectory, { recursive: true });
+
+  if (context.platform === "darwin" && context.launchAgentPath) {
+    mkdirSync(path.dirname(context.launchAgentPath), { recursive: true });
+    if (context.launchAgentLogsDirectory) {
+      mkdirSync(context.launchAgentLogsDirectory, { recursive: true });
+    }
+  }
+
+  if (context.platform === "linux") {
+    if (context.serviceUnitPath) {
+      mkdirSync(path.dirname(context.serviceUnitPath), { recursive: true });
+    }
+    if (context.serviceUnitLogsDirectory) {
+      mkdirSync(context.serviceUnitLogsDirectory, { recursive: true });
+    }
+  }
+
   mkdirSync(path.dirname(context.extensionDestinationPath), { recursive: true });
 
+  // Setup steps
   const configResult = await ensureTelePiConfig(context, options);
-  const launchAgentUpdated = writeLaunchAgentPlist(context);
+
+  const serviceMgr = getServiceManager(context.platform);
+  const unitUpdated = serviceMgr.writeUnitFile(context);
+  const { actions: serviceActions, warning: serviceWarning } = serviceMgr.reconcile(context);
   const extensionInstalledAs = installExtension(context);
-  const { actions: launchdActions, warning: launchdWarning } = reconcileLaunchAgent(context);
 
   return {
     context,
     configCreated: configResult.created,
     configUpdated: configResult.updated,
-    launchAgentUpdated,
+    unitUpdated,
+    launchAgentUpdated: unitUpdated,
     extensionInstalledAs,
-    launchdActions,
-    launchdWarning,
+    serviceActions,
+    launchdActions: serviceActions,
+    serviceWarning,
+    launchdWarning: serviceWarning,
   };
 }
+
+// ---- internal helpers ----
 
 function ensureInstallInputsExist(context: TelePiInstallContext): void {
   if (path.extname(context.cliEntrypointPath) === ".ts") {
@@ -134,44 +129,23 @@ function ensureInstallInputsExist(context: TelePiInstallContext): void {
     );
   }
 
-  for (const filePath of [
+  const requiredPaths = [
     context.envExamplePath,
-    context.launchdTemplatePath,
     context.extensionSourcePath,
     context.cliEntrypointPath,
-  ]) {
+  ];
+
+  if (context.platform === "darwin" && context.launchdTemplatePath) {
+    requiredPaths.push(context.launchdTemplatePath);
+  }
+
+  if (context.platform === "linux" && context.systemdTemplatePath) {
+    requiredPaths.push(context.systemdTemplatePath);
+  }
+
+  for (const filePath of requiredPaths) {
     if (!existsSync(filePath)) {
       throw new Error(`Required install asset is missing: ${filePath}`);
     }
   }
-}
-
-function readPackageVersion(packageRoot: string): string {
-  const packageJsonPath = path.join(packageRoot, "package.json");
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: string };
-  return packageJson.version ?? "0.0.0";
-}
-
-function resolveInstalledCliEntrypointPath(packageRoot: string, rawCliEntrypointPath: string): string {
-  if (path.extname(rawCliEntrypointPath) !== ".ts") {
-    return rawCliEntrypointPath;
-  }
-
-  const builtCliEntrypointPath = path.join(packageRoot, "dist", "cli.js");
-  return existsSync(builtCliEntrypointPath) ? builtCliEntrypointPath : rawCliEntrypointPath;
-}
-
-function resolveLaunchAgentDomain(): string | undefined {
-  const uid = process.getuid?.();
-  if (typeof uid === "number") {
-    return `gui/${uid}`;
-  }
-
-  const rawUid = process.env.UID?.trim();
-  if (!rawUid) {
-    return undefined;
-  }
-
-  const parsedUid = Number(rawUid);
-  return Number.isInteger(parsedUid) ? `gui/${parsedUid}` : undefined;
 }

--- a/src/install/clipboard.ts
+++ b/src/install/clipboard.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Copy text to the system clipboard using the best available platform utility.
+ * Returns true on success.
+ *
+ * - **macOS**: Uses `pbcopy` (built-in)
+ * - **Linux**: Tries `wl-copy` (Wayland), then `xclip -selection clipboard` (X11),
+ *   then `xsel --clipboard` (X11 fallback).  Returns false if none are available.
+ * - **Other platforms**: Returns `false` silently.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (process.platform === "darwin") {
+    return copyViaCommand("pbcopy", [], text);
+  }
+
+  if (process.platform === "linux") {
+    // Wayland first (modern), then X11
+    if (copyViaCommand("wl-copy", [], text)) return true;
+    if (copyViaCommand("xclip", ["-selection", "clipboard"], text)) return true;
+    if (copyViaCommand("xsel", ["--clipboard"], text)) return true;
+    return false;
+  }
+
+  return false;
+}
+
+/** Spawn a command, pipe text to stdin, return true on zero exit code. */
+function copyViaCommand(command: string, args: string[], text: string): boolean {
+  try {
+    const result = spawnSync(command, args, {
+      input: text,
+      timeout: 2000,
+      encoding: "utf8",
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/install/config.ts
+++ b/src/install/config.ts
@@ -17,6 +17,85 @@ import {
   TELEPI_SETUP_PLACEHOLDER_WORKSPACE,
 } from "./shared.js";
 
+export type ServiceConfigSource =
+  | "service-env"
+  | "service-cwd"
+  | "installed-default";
+
+/**
+ * Determine the resolved config path and its source for an installed TelePi service.
+ * On macOS, reads the launchd plist; on Linux, reads the systemd unit file;
+ * falls back to the installed default config path.
+ */
+export function getServiceConfigSource(
+  context: TelePiInstallContext,
+): { resolvedPath: string; source: ServiceConfigSource } {
+  if (context.platform === "linux" && context.serviceUnitPath) {
+    const unitContents = readSystemdUnitFile(context);
+    if (unitContents) {
+      const workingDirectory = readSystemdWorkingDirectory(unitContents) ?? context.workingDirectory;
+      const envVars = readSystemdEnvironmentVariables(unitContents);
+      const explicitConfigPath = envVars.TELEPI_CONFIG
+        ? resolvePathFromCwd(envVars.TELEPI_CONFIG, workingDirectory)
+        : undefined;
+
+      if (explicitConfigPath) {
+        return { resolvedPath: explicitConfigPath, source: "service-env" };
+      }
+
+      const localConfigPath = path.join(workingDirectory, ".env");
+      if (existsSync(localConfigPath)) {
+        return { resolvedPath: localConfigPath, source: "service-cwd" };
+      }
+    }
+
+    return { resolvedPath: context.configPath, source: "installed-default" };
+  }
+
+  // macOS: use the launchd-based config resolution from launchd.ts
+  return { resolvedPath: context.configPath, source: "installed-default" };
+}
+
+function readSystemdUnitFile(context: TelePiInstallContext): string | undefined {
+  if (!context.serviceUnitPath || !existsSync(context.serviceUnitPath)) {
+    return undefined;
+  }
+  return readFileSync(context.serviceUnitPath, "utf8");
+}
+
+function readSystemdWorkingDirectory(unitContents: string): string | undefined {
+  const match = unitContents.match(/^WorkingDirectory\s*=\s*(.+)$/m);
+  return match?.[1]?.trim();
+}
+
+function readSystemdEnvironmentVariables(unitContents: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  const envPattern = /^Environment\s*=\s*(.+)$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = envPattern.exec(unitContents)) !== null) {
+    const assignment = match[1]!.trim();
+    // Environment= can have multiple KEY=VALUE pairs separated by space,
+    // or a single quoted string. Parse KEY=VALUE pairs.
+    for (const pair of parseEnvironmentAssignments(assignment)) {
+      values[pair.key] = pair.value;
+    }
+  }
+  return values;
+}
+
+function parseEnvironmentAssignments(assignment: string): Array<{ key: string; value: string }> {
+  const pairs: Array<{ key: string; value: string }> = [];
+  // Handle quoted values and space-separated KEY=VALUE pairs
+  const regex = /(\w+)=(?:"([^"]*?)"|'([^']*?)'|(\S+))/g;
+  let pairMatch: RegExpExecArray | null;
+  while ((pairMatch = regex.exec(assignment)) !== null) {
+    const key = pairMatch[1]!;
+    const value = pairMatch[2] ?? pairMatch[3] ?? pairMatch[4] ?? "";
+    pairs.push({ key, value });
+  }
+  return pairs;
+}
+
 export async function ensureTelePiConfig(
   context: TelePiInstallContext,
   options: TelePiSetupOptions = {},

--- a/src/install/launchd.ts
+++ b/src/install/launchd.ts
@@ -6,17 +6,19 @@ import { resolvePathFromCwd } from "../paths.js";
 import type {
   LaunchAgentStatus,
   LaunchctlResult,
+  ServiceStatus,
   TelePiInstallContext,
 } from "./shared.js";
+import type { ServiceManager } from "./service-manager.js";
 
 export function buildLaunchAgentPlist(context: TelePiInstallContext): string {
-  const template = readFileSync(context.launchdTemplatePath, "utf8");
+  const template = readFileSync(context.launchdTemplatePath!, "utf8");
   const replacements: Array<[string, string]> = [
     ["/ABSOLUTE/PATH/TO/WORKDIR", escapeXml(context.workingDirectory)],
     ["/ABSOLUTE/PATH/TO/node", escapeXml(context.nodeExecutablePath)],
     ["/ABSOLUTE/PATH/TO/TelePi/dist/cli.js", escapeXml(context.cliEntrypointPath)],
-    ["/ABSOLUTE/PATH/TO/telepi.out.log", escapeXml(context.launchAgentStdoutPath)],
-    ["/ABSOLUTE/PATH/TO/telepi.err.log", escapeXml(context.launchAgentStderrPath)],
+    ["/ABSOLUTE/PATH/TO/telepi.out.log", escapeXml(context.launchAgentStdoutPath!)],
+    ["/ABSOLUTE/PATH/TO/telepi.err.log", escapeXml(context.launchAgentStderrPath!)],
     ["__TELEPI_PATH_ENV_BLOCK__", buildEnvironmentVariablesBlock(context)],
   ];
 
@@ -28,15 +30,15 @@ export function buildLaunchAgentPlist(context: TelePiInstallContext): string {
 
 export function writeLaunchAgentPlist(context: TelePiInstallContext): boolean {
   const nextContents = buildLaunchAgentPlist(context);
-  const previousContents = existsSync(context.launchAgentPath)
-    ? readFileSync(context.launchAgentPath, "utf8")
+  const previousContents = existsSync(context.launchAgentPath!)
+    ? readFileSync(context.launchAgentPath!, "utf8")
     : undefined;
 
   if (previousContents === nextContents) {
     return false;
   }
 
-  writeFileSync(context.launchAgentPath, nextContents, "utf8");
+  writeFileSync(context.launchAgentPath!, nextContents, "utf8");
   return true;
 }
 
@@ -66,13 +68,13 @@ export function reconcileLaunchAgent(context: TelePiInstallContext): {
     };
   }
 
-  runCommand("launchctl", ["bootout", context.launchAgentDomain, context.launchAgentPath]);
-  actions.push(`bootout ${context.launchAgentDomain} ${context.launchAgentPath}`);
+  runCommand("launchctl", ["bootout", context.launchAgentDomain, context.launchAgentPath!]);
+  actions.push(`bootout ${context.launchAgentDomain} ${context.launchAgentPath!}`);
 
   const bootstrap = runCommand("launchctl", [
     "bootstrap",
     context.launchAgentDomain,
-    context.launchAgentPath,
+    context.launchAgentPath!,
   ]);
   if (bootstrap.status !== 0) {
     return {
@@ -80,7 +82,7 @@ export function reconcileLaunchAgent(context: TelePiInstallContext): {
       warning: formatLaunchctlFailure("bootstrap", bootstrap),
     };
   }
-  actions.push(`bootstrap ${context.launchAgentDomain} ${context.launchAgentPath}`);
+  actions.push(`bootstrap ${context.launchAgentDomain} ${context.launchAgentPath!}`);
 
   const enable = runCommand("launchctl", ["enable", context.launchAgentServiceTarget]);
   if (enable.status === 0) {
@@ -99,11 +101,12 @@ export function reconcileLaunchAgent(context: TelePiInstallContext): {
   };
 }
 
-export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgentStatus {
-  const plistExists = existsSync(context.launchAgentPath);
+export function getLaunchAgentStatus(context: TelePiInstallContext): ServiceStatus {
+  const plistExists = context.launchAgentPath ? existsSync(context.launchAgentPath) : false;
 
   if (process.platform !== "darwin") {
     return {
+      unitExists: plistExists,
       plistExists,
       loaded: false,
       state: undefined,
@@ -115,6 +118,7 @@ export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgent
 
   if (!context.launchAgentServiceTarget) {
     return {
+      unitExists: plistExists,
       plistExists,
       loaded: false,
       state: undefined,
@@ -127,6 +131,7 @@ export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgent
   const result = runCommand("launchctl", ["print", context.launchAgentServiceTarget]);
   if (result.error) {
     return {
+      unitExists: plistExists,
       plistExists,
       loaded: false,
       state: undefined,
@@ -138,6 +143,7 @@ export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgent
 
   if (result.status !== 0) {
     return {
+      unitExists: plistExists,
       plistExists,
       loaded: false,
       state: undefined,
@@ -149,6 +155,7 @@ export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgent
 
   const output = `${result.stdout}\n${result.stderr}`;
   return {
+    unitExists: plistExists,
     plistExists,
     loaded: true,
     state: matchValue(output, /\bstate = ([^\n]+)/),
@@ -159,7 +166,7 @@ export function getLaunchAgentStatus(context: TelePiInstallContext): LaunchAgent
 }
 
 export function readLaunchAgentPlist(context: TelePiInstallContext): string | undefined {
-  if (!existsSync(context.launchAgentPath)) {
+  if (!context.launchAgentPath || !existsSync(context.launchAgentPath)) {
     return undefined;
   }
 
@@ -322,4 +329,14 @@ function escapeXml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
+}
+
+/** Creates a ServiceManager wrapping the existing launchd helpers. */
+export function createLaunchdManager(): ServiceManager {
+  return {
+    buildUnitFile: buildLaunchAgentPlist,
+    writeUnitFile: writeLaunchAgentPlist,
+    reconcile: reconcileLaunchAgent,
+    getStatus: getLaunchAgentStatus,
+  };
 }

--- a/src/install/platform.ts
+++ b/src/install/platform.ts
@@ -1,0 +1,165 @@
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { getDefaultTelePiConfigPath, getHomeDirectory } from "../paths.js";
+import { createLaunchdManager } from "./launchd.js";
+import type { ServiceManager } from "./service-manager.js";
+import {
+  TELEPI_EXTENSION_FILENAME,
+  TELEPI_LAUNCH_AGENT_FILENAME,
+  TELEPI_LAUNCHD_LABEL,
+  TELEPI_SERVICE_UNIT_FILENAME,
+  TELEPI_SYSTEMD_LOG_DIR_RELATIVE,
+  TELEPI_SYSTEMD_USER_DIR_RELATIVE,
+  type PlatformIdentifier,
+  type TelePiInstallContext,
+} from "./shared.js";
+import { createSystemdManager } from "./systemd.js";
+
+/** Auto-detect the runtime platform. Throws on unsupported platforms. */
+export function detectPlatform(): PlatformIdentifier {
+  if (process.platform === "darwin") return "darwin";
+  if (process.platform === "linux") return "linux";
+
+  throw new Error(
+    `telepi setup is only supported on macOS and Linux. Current platform: ${process.platform}`,
+  );
+}
+
+/** Resolve the full install context for the current platform. */
+export function resolveTelePiInstallContext(cliModuleUrl: string): TelePiInstallContext {
+  const rawCliEntrypointPath = fileURLToPath(cliModuleUrl);
+  const packageRoot = path.resolve(path.dirname(rawCliEntrypointPath), "..");
+  const cliEntrypointPath = resolveInstalledCliEntrypointPath(packageRoot, rawCliEntrypointPath);
+  const homeDirectory = getHomeDirectory();
+  const platform = detectPlatform();
+
+  const common = {
+    platform,
+    packageRoot,
+    cliEntrypointPath,
+    envExamplePath: path.join(packageRoot, ".env.example"),
+    extensionSourcePath: path.join(packageRoot, "extensions", TELEPI_EXTENSION_FILENAME),
+    configPath: getDefaultTelePiConfigPath(homeDirectory),
+    extensionDestinationPath: path.join(homeDirectory, ".pi", "agent", "extensions", TELEPI_EXTENSION_FILENAME),
+    nodeExecutablePath: process.execPath,
+    workingDirectory: homeDirectory,
+    pathEnvironment: sanitizePath(process.env.PATH),
+    version: readPackageVersion(packageRoot),
+  };
+
+  if (platform === "darwin") {
+    const launchAgentDomain = resolveLaunchAgentDomain();
+    return {
+      ...common,
+      launchdTemplatePath: path.join(packageRoot, "launchd", TELEPI_LAUNCH_AGENT_FILENAME),
+      launchAgentPath: path.join(homeDirectory, "Library", "LaunchAgents", TELEPI_LAUNCH_AGENT_FILENAME),
+      launchAgentLabel: TELEPI_LAUNCHD_LABEL,
+      launchAgentDomain,
+      launchAgentServiceTarget: launchAgentDomain ? `${launchAgentDomain}/${TELEPI_LAUNCHD_LABEL}` : undefined,
+      launchAgentLogsDirectory: path.join(homeDirectory, "Library", "Logs", "TelePi"),
+      launchAgentStdoutPath: path.join(homeDirectory, "Library", "Logs", "TelePi", "telepi.out.log"),
+      launchAgentStderrPath: path.join(homeDirectory, "Library", "Logs", "TelePi", "telepi.err.log"),
+    };
+  }
+
+  // platform === "linux"
+  return {
+    ...common,
+    systemdTemplatePath: path.join(packageRoot, "systemd", TELEPI_SERVICE_UNIT_FILENAME),
+    serviceUnitPath: path.join(homeDirectory, TELEPI_SYSTEMD_USER_DIR_RELATIVE, TELEPI_SERVICE_UNIT_FILENAME),
+    serviceUnitName: "telepi",
+    serviceUnitLogsDirectory: path.join(homeDirectory, TELEPI_SYSTEMD_LOG_DIR_RELATIVE),
+    serviceUnitStdoutPath: path.join(homeDirectory, TELEPI_SYSTEMD_LOG_DIR_RELATIVE, "telepi.out.log"),
+    serviceUnitStderrPath: path.join(homeDirectory, TELEPI_SYSTEMD_LOG_DIR_RELATIVE, "telepi.err.log"),
+  };
+}
+
+/**
+ * Synchronous factory returning the correct ServiceManager for the given platform.
+ */
+export function getServiceManager(platform: PlatformIdentifier): ServiceManager {
+  if (platform === "darwin") return createLaunchdManager();
+  if (platform === "linux") return createSystemdManager();
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+/**
+ * Return a platform-appropriate shell command to install a system dependency.
+ *
+ * macOS → `brew install <name>`
+ * Linux  → `sudo apt install <name>` / `sudo dnf install <name>` /
+ *          `sudo pacman -S <name>` / generic fallback
+ */
+export function getPlatformInstallHint(packageName: string): string {
+  if (process.platform === "darwin") {
+    return `brew install ${packageName}`;
+  }
+
+  if (process.platform === "linux") {
+    if (commandExists("apt")) return `sudo apt install ${packageName}`;
+    if (commandExists("dnf")) return `sudo dnf install ${packageName}`;
+    if (commandExists("pacman")) return `sudo pacman -S ${packageName}`;
+    return `Install ${packageName} using your package manager`;
+  }
+
+  return `Install ${packageName} using your package manager`;
+}
+
+function commandExists(command: string): boolean {
+  const result = spawnSync("which", [command], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 2000,
+  });
+  return result.status === 0;
+}
+
+/** Sanitize PATH: filter out entries that are clearly not paths (contain spaces or quotes). */
+function sanitizePath(rawPath: string | undefined): string | undefined {
+  if (!rawPath) return undefined;
+
+  const entries = rawPath.split(":");
+  const clean = entries.filter((entry) => {
+    const trimmed = entry.trim();
+    // Reject entries that are clearly not paths:
+    // empty, contain spaces, contain double-quotes, or just a dot
+    if (!trimmed) return false;
+    if (trimmed === ".") return false;
+    if (trimmed.includes('"')) return false;
+    if (trimmed.includes(" ")) return false;
+    if (trimmed.includes(":")) return false; // "bin":Unknown
+    if (trimmed.startsWith("npm")) return false; // npm error output
+    if (trimmed.startsWith("To see")) return false;
+    return true;
+  }).join(":");
+
+  return clean || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolveInstalledCliEntrypointPath(packageRoot: string, raw: string): string {
+  if (path.extname(raw) !== ".ts") return raw;
+  const built = path.join(packageRoot, "dist", "cli.js");
+  return existsSync(built) ? built : raw;
+}
+
+function resolveLaunchAgentDomain(): string | undefined {
+  const uid = process.getuid?.();
+  if (typeof uid === "number") return `gui/${uid}`;
+  const rawUid = process.env.UID?.trim();
+  if (!rawUid) return undefined;
+  const parsed = Number(rawUid);
+  return Number.isInteger(parsed) ? `gui/${parsed}` : undefined;
+}
+
+function readPackageVersion(packageRoot: string): string {
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const raw = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: string };
+  return raw.version ?? "0.0.0";
+}

--- a/src/install/service-manager.ts
+++ b/src/install/service-manager.ts
@@ -1,0 +1,43 @@
+import type { ServiceStatus, TelePiInstallContext } from "./shared.js";
+
+/** Result of installing (writing) a service unit file to disk. */
+export interface ServiceInstallResult {
+  /** Whether the unit file was written (created or updated). */
+  unitFileUpdated: boolean;
+  /** Ordered list of actions taken (e.g. daemon-reload, enable, start). */
+  actions: string[];
+  /** Non-fatal warning, if any. */
+  warning: string | undefined;
+}
+
+/** Result of reconciling (restarting/reloading) a running service. */
+export interface ServiceReconcileResult {
+  /** Ordered list of actions taken. */
+  actions: string[];
+  /** Non-fatal warning, if any. */
+  warning: string | undefined;
+}
+
+/**
+ * Platform-agnostic abstraction over service lifecycle operations.
+ *
+ * Implementations:
+ *  - `LaunchdManager` in {@link launchd.ts} (macOS)
+ *  - `SystemdManager` in {@link systemd.ts} (Linux)
+ */
+export interface ServiceManager {
+  /** Build the platform-specific service unit file content from context. Does NOT write to disk. */
+  buildUnitFile(context: TelePiInstallContext): string;
+
+  /**
+   * Write the service unit file to disk if it has changed.
+   * Returns true if the file was written (created or updated).
+   */
+  writeUnitFile(context: TelePiInstallContext): boolean;
+
+  /** Reload/restart the service so that any config changes take effect. */
+  reconcile(context: TelePiInstallContext): ServiceReconcileResult;
+
+  /** Query the current status of the installed service. */
+  getStatus(context: TelePiInstallContext): ServiceStatus;
+}

--- a/src/install/shared.ts
+++ b/src/install/shared.ts
@@ -1,9 +1,15 @@
 export const TELEPI_LAUNCHD_LABEL = "com.telepi";
 export const TELEPI_LAUNCH_AGENT_FILENAME = `${TELEPI_LAUNCHD_LABEL}.plist`;
+export const TELEPI_SERVICE_NAME = "telepi";
+export const TELEPI_SERVICE_UNIT_FILENAME = `${TELEPI_SERVICE_NAME}.service`;
 export const TELEPI_EXTENSION_FILENAME = "telepi-handoff.ts";
 export const TELEPI_SETUP_PLACEHOLDER_BOT_TOKEN = "your-bot-token-here";
 export const TELEPI_SETUP_PLACEHOLDER_ALLOWED_USER_IDS = "123456789";
 export const TELEPI_SETUP_PLACEHOLDER_WORKSPACE = "/absolute/path/to/your/main/project";
+export const TELEPI_SYSTEMD_LOG_DIR_RELATIVE = ".local/state/telepi/logs";
+export const TELEPI_SYSTEMD_USER_DIR_RELATIVE = ".config/systemd/user";
+
+export type PlatformIdentifier = "darwin" | "linux";
 
 export type LaunchctlResult = {
   status: number | null;
@@ -13,27 +19,43 @@ export type LaunchctlResult = {
 };
 
 export interface TelePiInstallContext {
+  platform: PlatformIdentifier;
   packageRoot: string;
   cliEntrypointPath: string;
   envExamplePath: string;
-  launchdTemplatePath: string;
   extensionSourcePath: string;
   configPath: string;
-  launchAgentPath: string;
-  launchAgentLabel: string;
-  launchAgentDomain: string | undefined;
-  launchAgentServiceTarget: string | undefined;
-  launchAgentLogsDirectory: string;
-  launchAgentStdoutPath: string;
-  launchAgentStderrPath: string;
   extensionDestinationPath: string;
   nodeExecutablePath: string;
   workingDirectory: string;
   pathEnvironment: string | undefined;
   version: string;
+  // macOS launchd-specific fields
+  launchdTemplatePath?: string;
+  launchAgentPath?: string;
+  launchAgentLabel?: string;
+  launchAgentDomain?: string;
+  launchAgentServiceTarget?: string;
+  launchAgentLogsDirectory?: string;
+  launchAgentStdoutPath?: string;
+  launchAgentStderrPath?: string;
+  // Linux systemd-specific fields
+  systemdTemplatePath?: string;
+  serviceUnitPath?: string;
+  serviceUnitName?: string;
+  serviceUnitLogsDirectory?: string;
+  serviceUnitStdoutPath?: string;
+  serviceUnitStderrPath?: string;
 }
 
-export interface LaunchAgentStatus {
+/**
+ * @deprecated Use ServiceStatus instead. Kept for backward compatibility.
+ */
+export type LaunchAgentStatus = ServiceStatus;
+
+export interface ServiceStatus {
+  unitExists: boolean;
+  /** @deprecated Use unitExists instead. Kept for backward compatibility. */
   plistExists: boolean;
   loaded: boolean;
   state: string | undefined;
@@ -51,14 +73,21 @@ export interface ExtensionStatus {
   targetPath: string | undefined;
 }
 
-export type TelePiStatusConfigSource = "launchd-env" | "launchd-cwd" | "installed-default";
+export type TelePiStatusConfigSource =
+  | "service-env"
+  | "service-cwd"
+  | "launchd-env"
+  | "launchd-cwd"
+  | "installed-default";
 
 export interface TelePiStatus {
   version: string;
   resolvedConfigPath: string;
   configExists: boolean;
   configSource: TelePiStatusConfigSource;
-  launchAgent: LaunchAgentStatus;
+  service: ServiceStatus;
+  /** @deprecated Use service instead. Kept for backward compatibility. */
+  launchAgent: ServiceStatus;
   extension: ExtensionStatus;
 }
 
@@ -91,8 +120,14 @@ export interface TelePiSetupResult {
   context: TelePiInstallContext;
   configCreated: boolean;
   configUpdated: boolean;
+  unitUpdated: boolean;
+  /** @deprecated Use unitUpdated instead. Kept for backward compatibility. */
   launchAgentUpdated: boolean;
   extensionInstalledAs: "symlink" | "copy";
+  serviceActions: string[];
+  /** @deprecated Use serviceActions instead. Kept for backward compatibility. */
   launchdActions: string[];
+  serviceWarning: string | undefined;
+  /** @deprecated Use serviceWarning instead. Kept for backward compatibility. */
   launchdWarning: string | undefined;
 }

--- a/src/install/systemd.ts
+++ b/src/install/systemd.ts
@@ -1,0 +1,207 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { ServiceManager } from "./service-manager.js";
+import type { ServiceStatus, TelePiInstallContext } from "./shared.js";
+
+export function createSystemdManager(): ServiceManager {
+  return {
+    buildUnitFile,
+    writeUnitFile,
+    reconcile,
+    getStatus,
+  };
+}
+
+/** Render the systemd unit file from the template. Exported for testing. */
+export function buildSystemdUnit(context: TelePiInstallContext): string {
+  return buildUnitFile(context);
+}
+
+/** Write the systemd unit file to disk. Exported for testing. */
+export function writeSystemdUnit(context: TelePiInstallContext): boolean {
+  return writeUnitFile(context);
+}
+
+function buildUnitFile(context: TelePiInstallContext): string {
+  if (!context.systemdTemplatePath || !existsSync(context.systemdTemplatePath)) {
+    throw new Error("systemd unit template not found");
+  }
+
+  let template = readFileSync(context.systemdTemplatePath, "utf8");
+
+  template = template.replace(/__TELEPI_WORKDIR__/g, escapeSystemdValue(context.workingDirectory));
+  template = template.replace(/__TELEPI_NODE_PATH__/g, escapeSystemdValue(context.nodeExecutablePath));
+  template = template.replace(/__TELEPI_CLI_PATH__/g, escapeSystemdValue(context.cliEntrypointPath));
+  template = template.replace(/__TELEPI_CONFIG__/g, escapeSystemdValue(context.configPath));
+  template = template.replace(
+    /__TELEPI_PATH_ENV__/g,
+    escapeSystemdValue(context.pathEnvironment ?? ""),
+  );
+  template = template.replace(
+    /__TELEPI_LOG_DIR__/g,
+    escapeSystemdValue(context.serviceUnitLogsDirectory ?? ""),
+  );
+
+  return template;
+}
+
+function writeUnitFile(context: TelePiInstallContext): boolean {
+  if (!context.serviceUnitPath) {
+    return false;
+  }
+
+  const nextContents = buildUnitFile(context);
+  const previousContents = existsSync(context.serviceUnitPath)
+    ? readFileSync(context.serviceUnitPath, "utf8")
+    : undefined;
+
+  if (previousContents === nextContents) {
+    return false;
+  }
+
+  const dir = path.dirname(context.serviceUnitPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeFileSync(context.serviceUnitPath, nextContents, "utf8");
+  return true;
+}
+
+function reconcile(context: TelePiInstallContext): { actions: string[]; warning: string | undefined } {
+  const actions: string[] = [];
+
+  // Check if systemctl --user is available
+  const check = spawnSync("systemctl", ["--user"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (check.error || check.status !== 0) {
+    return {
+      actions,
+      warning:
+        "systemctl --user is not available. " +
+        "Ensure you have a user systemd session (loginctl enable-linger or run under a desktop session).",
+    };
+  }
+
+  // daemon-reload
+  runSystemctl(actions, ["--user", "daemon-reload"]);
+
+  // enable
+  runSystemctl(actions, ["--user", "enable", "telepi.service"]);
+
+  // restart (or start if not yet running)
+  const restart = spawnSync("systemctl", ["--user", "restart", "telepi.service"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (restart.status === 0) {
+    actions.push("restart telepi.service");
+  } else {
+    // Try start as fallback
+    const start = spawnSync("systemctl", ["--user", "start", "telepi.service"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (start.status === 0) {
+      actions.push("start telepi.service");
+    } else {
+      const detail = (restart.stderr || start.stderr || "").trim();
+      return {
+        actions,
+        warning: detail
+          ? `systemctl restart/start telepi.service failed: ${detail}`
+          : "systemctl restart/start telepi.service failed.",
+      };
+    }
+  }
+
+  return { actions, warning: undefined };
+}
+
+function getStatus(context: TelePiInstallContext): ServiceStatus {
+  const unitExists = context.serviceUnitPath ? existsSync(context.serviceUnitPath) : false;
+
+  if (!unitExists) {
+    return {
+      unitExists: false,
+      plistExists: false,
+      loaded: false,
+      state: "not installed",
+      pid: undefined,
+      detail: "not installed",
+      error: undefined,
+    };
+  }
+
+  const result = spawnSync(
+    "systemctl",
+    ["--user", "show", "telepi.service", "--property=ActiveState,MainPID"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  if (result.error) {
+    return {
+      unitExists,
+      plistExists: false,
+      loaded: false,
+      state: undefined,
+      pid: undefined,
+      detail: "systemctl unavailable",
+      error: result.error.message,
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      unitExists,
+      plistExists: false,
+      loaded: false,
+      state: undefined,
+      pid: undefined,
+      detail: "installed but not loaded",
+      error: (result.stderr || result.stdout || "").trim() || undefined,
+    };
+  }
+
+  const output = result.stdout;
+  const stateMatch = output.match(/^ActiveState=(.+)$/m);
+  const pidMatch = output.match(/^MainPID=(\d+)$/m);
+
+  const state = stateMatch?.[1]?.trim();
+  const pidRaw = pidMatch?.[1]?.trim();
+  const pid = pidRaw ? Number(pidRaw) : undefined;
+
+  return {
+    unitExists,
+    plistExists: false,
+    loaded: state === "active",
+    state,
+    pid: pid && pid > 0 ? pid : undefined,
+    detail: state === "active" ? "loaded" : state ?? "unknown",
+    error: undefined,
+  };
+}
+
+// --- internal helpers ---
+
+function runSystemctl(actions: string[], args: string[]): void {
+  const result = spawnSync("systemctl", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status === 0) {
+    const label = args.slice(1).join(" ");
+    actions.push(label);
+  }
+}
+
+function escapeSystemdValue(value: string): string {
+  // systemd unit values: no special escaping needed for simple paths.
+  // Backslashes and spaces should be quoted, but our paths are safe.
+  return value;
+}

--- a/src/install/systemd.ts
+++ b/src/install/systemd.ts
@@ -31,18 +31,18 @@ function buildUnitFile(context: TelePiInstallContext): string {
 
   let template = readFileSync(context.systemdTemplatePath, "utf8");
 
-  template = template.replace(/__TELEPI_WORKDIR__/g, escapeSystemdValue(context.workingDirectory));
-  template = template.replace(/__TELEPI_NODE_PATH__/g, escapeSystemdValue(context.nodeExecutablePath));
-  template = template.replace(/__TELEPI_CLI_PATH__/g, escapeSystemdValue(context.cliEntrypointPath));
-  template = template.replace(/__TELEPI_CONFIG__/g, escapeSystemdValue(context.configPath));
-  template = template.replace(
-    /__TELEPI_PATH_ENV__/g,
-    escapeSystemdValue(context.pathEnvironment ?? ""),
-  );
-  template = template.replace(
-    /__TELEPI_LOG_DIR__/g,
-    escapeSystemdValue(context.serviceUnitLogsDirectory ?? ""),
-  );
+  const stdoutPath = context.serviceUnitStdoutPath
+    ?? path.join(context.serviceUnitLogsDirectory ?? "", "telepi.out.log");
+  const stderrPath = context.serviceUnitStderrPath
+    ?? path.join(context.serviceUnitLogsDirectory ?? "", "telepi.err.log");
+
+  template = template.replace(/__TELEPI_WORKDIR__/g, formatSystemdValue(context.workingDirectory));
+  template = template.replace(/__TELEPI_NODE_PATH__/g, formatSystemdValue(context.nodeExecutablePath));
+  template = template.replace(/__TELEPI_CLI_PATH__/g, formatSystemdValue(context.cliEntrypointPath));
+  template = template.replace(/__TELEPI_CONFIG_ENV__/g, formatSystemdEnvironment("TELEPI_CONFIG", context.configPath));
+  template = template.replace(/__TELEPI_PATH_ENV__/g, formatSystemdEnvironment("PATH", context.pathEnvironment ?? ""));
+  template = template.replace(/__TELEPI_STDOUT_PATH__/g, formatSystemdValue(stdoutPath));
+  template = template.replace(/__TELEPI_STDERR_PATH__/g, formatSystemdValue(stderrPath));
 
   return template;
 }
@@ -200,8 +200,14 @@ function runSystemctl(actions: string[], args: string[]): void {
   }
 }
 
-function escapeSystemdValue(value: string): string {
-  // systemd unit values: no special escaping needed for simple paths.
-  // Backslashes and spaces should be quoted, but our paths are safe.
-  return value;
+function formatSystemdEnvironment(name: string, value: string): string {
+  return formatSystemdValue(`${name}=${value}`);
+}
+
+function formatSystemdValue(value: string): string {
+  if (!/[\s"\\]/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -30,3 +30,27 @@ export function resolvePathFromCwd(filePath: string, cwd: string = process.cwd()
 export function getDefaultTelePiConfigPath(homeDirectory: string = getHomeDirectory()): string {
   return path.join(homeDirectory, DEFAULT_CONFIG_DIRNAME, DEFAULT_CONFIG_FILENAME);
 }
+
+/**
+ * Returns the default systemd user directory path.
+ * Typically ~/.config/systemd/user on Linux.
+ */
+export function getDefaultSystemdUserDir(homeDirectory: string = getHomeDirectory()): string {
+  return path.join(homeDirectory, ".config", "systemd", "user");
+}
+
+/**
+ * Returns the default TelePi log directory for the given platform.
+ * macOS: ~/Library/Logs/TelePi
+ * Linux: ~/.local/state/telepi/logs
+ */
+export function getDefaultLogDir(
+  homeDirectory: string = getHomeDirectory(),
+  platform: "darwin" | "linux",
+): string {
+  if (platform === "darwin") {
+    return path.join(homeDirectory, "Library", "Logs", "TelePi");
+  }
+
+  return path.join(homeDirectory, ".local", "state", "telepi", "logs");
+}

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -4,6 +4,8 @@ import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import { getPlatformInstallHint } from "./install/platform.js";
+
 export interface TranscriptionResult {
   text: string;
   backend: "parakeet" | "sherpa-onnx" | "openai";
@@ -58,16 +60,16 @@ const SHERPA_ONNX_MODEL_DIR_ENV = "SHERPA_ONNX_MODEL_DIR";
 const SHERPA_ONNX_NUM_THREADS_ENV = "SHERPA_ONNX_NUM_THREADS";
 const SHERPA_MODEL_DOCS_URL =
   "https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-transducer/nemo-transducer-models.html";
-const FFMPEG_INSTALL_MESSAGE = "ffmpeg not found. Install it with: brew install ffmpeg";
+const FFMPEG_INSTALL_MESSAGE = `ffmpeg not found. Install it with: ${getPlatformInstallHint("ffmpeg")}`;
 const NO_BACKEND_ERROR = `Voice messages require a transcription backend.
 
 Option 1: Install Parakeet CoreML for local transcription on Apple Silicon (free, private, ~1.5GB download):
   npm install parakeet-coreml
-Also requires ffmpeg: brew install ffmpeg
+Also requires ffmpeg: ${getPlatformInstallHint("ffmpeg")}
 
 Option 2: Install Sherpa-ONNX for local/offline Parakeet transcription on Intel-based Macs, where parakeet-coreml is not supported (also works on Apple Silicon):
   npm install sherpa-onnx-node
-  Also requires ffmpeg: brew install ffmpeg
+  Also requires ffmpeg: ${getPlatformInstallHint("ffmpeg")}
   Download the Intel Mac-friendly Parakeet model from:
     ${SHERPA_MODEL_DOCS_URL}
   Set ${SHERPA_ONNX_MODEL_DIR_ENV}=/path/to/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8

--- a/systemd/telepi.service
+++ b/systemd/telepi.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TelePi Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=__TELEPI_WORKDIR__
+ExecStart=__TELEPI_NODE_PATH__ __TELEPI_CLI_PATH__ start
+Environment=TELEPI_CONFIG=__TELEPI_CONFIG__
+Environment=PATH=__TELEPI_PATH_ENV__
+StandardOutput=append:__TELEPI_LOG_DIR__/telepi.out.log
+StandardError=append:__TELEPI_LOG_DIR__/telepi.err.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/systemd/telepi.service
+++ b/systemd/telepi.service
@@ -6,10 +6,10 @@ After=network.target
 Type=simple
 WorkingDirectory=__TELEPI_WORKDIR__
 ExecStart=__TELEPI_NODE_PATH__ __TELEPI_CLI_PATH__ start
-Environment=TELEPI_CONFIG=__TELEPI_CONFIG__
-Environment=PATH=__TELEPI_PATH_ENV__
-StandardOutput=append:__TELEPI_LOG_DIR__/telepi.out.log
-StandardError=append:__TELEPI_LOG_DIR__/telepi.err.log
+Environment=__TELEPI_CONFIG_ENV__
+Environment=__TELEPI_PATH_ENV__
+StandardOutput=append:__TELEPI_STDOUT_PATH__
+StandardError=append:__TELEPI_STDERR_PATH__
 Restart=on-failure
 RestartSec=5
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4,6 +4,7 @@ const mockState = vi.hoisted(() => ({
   startBot: vi.fn().mockResolvedValue(undefined),
   setupTelePi: vi.fn().mockResolvedValue({
     context: {
+      platform: "darwin" as const,
       version: "1.2.3",
       configPath: "/tmp/config.env",
       launchAgentPath: "/tmp/com.telepi.plist",
@@ -11,9 +12,12 @@ const mockState = vi.hoisted(() => ({
     },
     configCreated: true,
     configUpdated: false,
+    unitUpdated: true,
     launchAgentUpdated: true,
-    extensionInstalledAs: "symlink",
+    extensionInstalledAs: "symlink" as const,
+    serviceActions: ["bootout", "bootstrap"],
     launchdActions: ["bootout", "bootstrap"],
+    serviceWarning: undefined,
     launchdWarning: undefined,
   }),
   getTelePiStatus: vi.fn().mockReturnValue({
@@ -21,21 +25,31 @@ const mockState = vi.hoisted(() => ({
     resolvedConfigPath: "/tmp/config.env",
     configExists: true,
     configSource: "installed-default",
-    launchAgent: {
+    service: {
+      unitExists: true,
+      plistExists: true,
       loaded: true,
       state: "running",
       pid: 123,
       detail: "loaded",
+      error: undefined,
+    },
+    launchAgent: {
+      unitExists: true,
       plistExists: true,
+      loaded: true,
+      state: "running",
+      pid: 123,
+      detail: "loaded",
       error: undefined,
     },
     extension: {
-      mode: "symlink",
+      mode: "symlink" as const,
       detail: "installed",
       targetPath: "/tmp/telepi-handoff.ts",
     },
   }),
-  resolveTelePiInstallContext: vi.fn().mockReturnValue({ version: "1.2.3" }),
+  resolveTelePiInstallContext: vi.fn().mockReturnValue({ version: "1.2.3", platform: "darwin" }),
 }));
 
 vi.mock("../src/index.js", () => ({ startBot: mockState.startBot }));
@@ -91,9 +105,52 @@ describe("telepi CLI", () => {
     await main(["help"]);
 
     expect(mockState.getTelePiStatus).toHaveBeenCalledTimes(1);
-    expect(mockState.resolveTelePiInstallContext).toHaveBeenCalledTimes(1);
     expect(logSpy.mock.calls.some((call) => String(call[0]).includes("Config path:"))).toBe(true);
     expect(logSpy.mock.calls.some((call) => String(call[0]).includes("TelePi CLI"))).toBe(true);
+  });
+
+  it("uses systemd labels in status output on Linux", () => {
+    mockState.resolveTelePiInstallContext.mockReturnValue({ version: "1.2.3", platform: "linux" });
+    mockState.getTelePiStatus.mockReturnValue({
+      version: "1.2.3",
+      resolvedConfigPath: "/tmp/config.env",
+      configExists: true,
+      configSource: "service-env",
+      service: {
+        unitExists: true,
+        plistExists: false,
+        loaded: true,
+        state: "active",
+        pid: 9999,
+        detail: "loaded",
+        error: undefined,
+      },
+      launchAgent: {
+        unitExists: true,
+        plistExists: false,
+        loaded: true,
+        state: "active",
+        pid: 9999,
+        detail: "loaded",
+        error: undefined,
+      },
+      extension: {
+        mode: "symlink" as const,
+        detail: "symlinked",
+        targetPath: "/tmp/telepi-handoff.ts",
+      },
+    });
+
+    runStatusCommand();
+
+    const output = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("systemd:");
+    expect(output).toContain("loaded (active) pid=9999");
+    expect(output).toContain("unit present");
+    expect(output).toContain("systemd TELEPI_CONFIG");
+
+    // Restore mocks for other tests
+    mockState.resolveTelePiInstallContext.mockReturnValue({ version: "1.2.3", platform: "darwin" });
   });
 
   it("validates unexpected arguments and unknown commands", async () => {

--- a/test/handoff-extension.test.ts
+++ b/test/handoff-extension.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import {
   getInstalledConfigPath,
   getInstalledLaunchAgentPath,
+  getInstalledSystemdServicePath,
+  hasInstalledSystemdFlow,
   resolveDirectLaunchTarget,
   resolveHandoffMode,
 } from "../extensions/telepi-handoff.ts";
@@ -41,6 +43,8 @@ describe("handoff extension helpers", () => {
     process.env = originalEnv;
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
   });
+
+  // --- macOS / launchd tests ---
 
   it("defaults to launchd after telepi setup assets are present", () => {
     mkdirSync(path.dirname(getInstalledConfigPath()), { recursive: true });
@@ -88,5 +92,76 @@ describe("handoff extension helpers", () => {
       homeDirectory: homeDir,
       installedConfigPath: getInstalledConfigPath(),
     });
+  });
+
+  // --- Linux / systemd tests ---
+
+  it("defaults to systemd on Linux when config + service unit exist", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    mkdirSync(path.dirname(getInstalledConfigPath()), { recursive: true });
+    mkdirSync(path.dirname(getInstalledSystemdServicePath()), { recursive: true });
+    writeFileSync(getInstalledConfigPath(), "TELEGRAM_BOT_TOKEN=test\n");
+    writeFileSync(getInstalledSystemdServicePath(), "[Service]\nExecStart=telepi start\n");
+
+    expect(resolveHandoffMode()).toBe("systemd");
+  });
+
+  it("defaults to direct on Linux when no installed service exists", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    process.env.TELEPI_DIR = "/tmp/TelePi";
+
+    expect(resolveHandoffMode()).toBe("direct");
+  });
+
+  it("allows explicit systemd mode via env var", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    process.env.TELEPI_HANDOFF_MODE = "systemd";
+
+    expect(resolveHandoffMode()).toBe("systemd");
+  });
+
+  it("returns undefined for unknown handoff mode", () => {
+    process.env.TELEPI_HANDOFF_MODE = "invalid_mode";
+
+    expect(resolveHandoffMode()).toBeUndefined();
+  });
+
+  it("getInstalledSystemdServicePath returns correct path", () => {
+    const result = getInstalledSystemdServicePath(homeDir);
+
+    expect(result).toBe(path.join(homeDir, ".config", "systemd", "user", "telepi.service"));
+  });
+
+  it("hasInstalledSystemdFlow returns false on macOS", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    expect(hasInstalledSystemdFlow()).toBe(false);
+  });
+
+  it("hasInstalledSystemdFlow returns false on Linux without assets", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    expect(hasInstalledSystemdFlow()).toBe(false);
+  });
+
+  it("hasInstalledSystemdFlow returns true on Linux with config + service unit", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    mkdirSync(path.dirname(getInstalledConfigPath()), { recursive: true });
+    mkdirSync(path.dirname(getInstalledSystemdServicePath()), { recursive: true });
+    writeFileSync(getInstalledConfigPath(), "TELEGRAM_BOT_TOKEN=test\n");
+    writeFileSync(getInstalledSystemdServicePath(), "dummy content\n");
+
+    expect(hasInstalledSystemdFlow()).toBe(true);
+  });
+
+  it("handoff extension source references systemd mode", () => {
+    const source = readFileSync(new URL("../extensions/telepi-handoff.ts", import.meta.url), "utf8");
+
+    expect(source).toContain("systemd");
+    expect(source).toContain("handoffViaSystemd");
+    expect(source).toContain("systemctl --user set-environment");
+    expect(source).toContain("systemctl --user restart telepi.service");
   });
 });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -10,6 +10,7 @@ import {
   resolveTelePiInstallContext,
   setupTelePi,
 } from "../src/install.js";
+import { getServiceConfigSource } from "../src/install/config.js";
 
 describe("install helpers", () => {
   const originalCwd = process.cwd();
@@ -27,6 +28,7 @@ describe("install helpers", () => {
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
     mkdirSync(path.join(packageRoot, "launchd"), { recursive: true });
+    mkdirSync(path.join(packageRoot, "systemd"), { recursive: true });
     mkdirSync(path.join(packageRoot, "extensions"), { recursive: true });
 
     writeFileSync(path.join(packageRoot, "package.json"), '{"version":"9.9.9"}\n');
@@ -55,6 +57,28 @@ describe("install helpers", () => {
     );
     writeFileSync(path.join(packageRoot, "extensions", "telepi-handoff.ts"), "export default {};\n");
     writeFileSync(path.join(packageRoot, "dist", "cli.js"), "#!/usr/bin/env node\n");
+    writeFileSync(
+      path.join(packageRoot, "systemd", "telepi.service"),
+      [
+        "[Unit]",
+        "Description=TelePi Telegram Bot",
+        "After=network.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        "WorkingDirectory=__TELEPI_WORKDIR__",
+        "ExecStart=__TELEPI_NODE_PATH__ __TELEPI_CLI_PATH__ start",
+        "Environment=TELEPI_CONFIG=__TELEPI_CONFIG__",
+        "Environment=PATH=__TELEPI_PATH_ENV__",
+        "StandardOutput=append:__TELEPI_LOG_DIR__/telepi.out.log",
+        "StandardError=append:__TELEPI_LOG_DIR__/telepi.err.log",
+        "Restart=on-failure",
+        "RestartSec=5",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
 
     process.chdir(packageRoot);
     process.env = {
@@ -74,11 +98,13 @@ describe("install helpers", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves installed-mode paths from the CLI entrypoint", () => {
+  it("resolves installed-mode paths from the CLI entrypoint on macOS", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
 
     const context = resolveTelePiInstallContext(cliModuleUrl);
 
+    expect(context.platform).toBe("darwin");
     expect(context.packageRoot).toBe(packageRoot);
     expect(context.cliEntrypointPath).toBe(path.join(packageRoot, "dist", "cli.js"));
     expect(context.configPath).toBe(path.join(homeDir, ".config", "telepi", "config.env"));
@@ -92,6 +118,7 @@ describe("install helpers", () => {
   });
 
   it("renders a launchd plist that starts the CLI via node", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
     const context = resolveTelePiInstallContext(cliModuleUrl);
 
@@ -284,18 +311,22 @@ describe("install helpers", () => {
   });
 
   it("reports the launchd TELEPI_CONFIG path instead of the caller cwd", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
     const context = resolveTelePiInstallContext(cliModuleUrl);
     const callerCwd = path.join(tempDir, "caller-cwd");
 
     mkdirSync(callerCwd, { recursive: true });
     mkdirSync(path.dirname(context.configPath), { recursive: true });
-    mkdirSync(path.dirname(context.launchAgentPath), { recursive: true });
+    if (context.launchAgentPath) {
+      mkdirSync(path.dirname(context.launchAgentPath), { recursive: true });
+    }
     writeFileSync(path.join(callerCwd, ".env"), "TELEGRAM_BOT_TOKEN=from-caller\n");
     writeFileSync(context.configPath, "TELEGRAM_BOT_TOKEN=from-installed\n");
-    writeFileSync(context.launchAgentPath, buildLaunchAgentPlist(context));
+    if (context.launchAgentPath) {
+      writeFileSync(context.launchAgentPath, buildLaunchAgentPlist(context));
+    }
     process.chdir(callerCwd);
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
 
     const status = getTelePiStatus(cliModuleUrl);
 
@@ -346,6 +377,119 @@ describe("install helpers", () => {
     await expect(setupTelePi(pathToFileURL(srcCliPath).href)).rejects.toThrow(
       `telepi setup requires a built CLI entrypoint at ${path.join(packageRoot, "dist", "cli.js")}`,
     );
+  });
+
+  // --- Linux-specific tests ---
+
+  it("resolves Linux context with systemd fields and no launchd fields", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+
+    const context = resolveTelePiInstallContext(cliModuleUrl);
+
+    expect(context.platform).toBe("linux");
+    // Linux-specific fields populated
+    expect(context.systemdTemplatePath).toContain("telepi.service");
+    expect(context.serviceUnitPath).toContain(".config/systemd/user/telepi.service");
+    expect(context.serviceUnitName).toBe("telepi");
+    expect(context.serviceUnitLogsDirectory).toContain(".local/state/telepi/logs");
+    expect(context.serviceUnitStdoutPath).toContain("telepi.out.log");
+    expect(context.serviceUnitStderrPath).toContain("telepi.err.log");
+    // macOS fields NOT populated on Linux
+    expect(context.launchdTemplatePath).toBeUndefined();
+    expect(context.launchAgentPath).toBeUndefined();
+    expect(context.launchAgentLabel).toBeUndefined();
+  });
+
+  it("resolves macOS context with launchd fields and no systemd fields", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+
+    const context = resolveTelePiInstallContext(cliModuleUrl);
+
+    expect(context.platform).toBe("darwin");
+    expect(context.launchdTemplatePath).toContain("com.telepi.plist");
+    expect(context.launchAgentPath).toContain("LaunchAgents/com.telepi.plist");
+    expect(context.launchAgentLabel).toBe("com.telepi");
+    // Linux fields NOT populated on macOS
+    expect(context.systemdTemplatePath).toBeUndefined();
+    expect(context.serviceUnitPath).toBeUndefined();
+    expect(context.serviceUnitName).toBeUndefined();
+  });
+
+  it("throws for unsupported platforms", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+
+    expect(() => resolveTelePiInstallContext(cliModuleUrl)).toThrow(
+      "telepi setup is only supported on macOS and Linux",
+    );
+  });
+
+  it("getTelePiStatus on Linux returns service field with systemd status", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+
+    const status = getTelePiStatus(cliModuleUrl);
+
+    expect(status.service).toBeDefined();
+    expect(status.service.unitExists).toBe(false); // service not installed yet
+    expect(status.service.loaded).toBe(false);
+    // field names are platform-neutral
+    expect(status.configSource).toBe("installed-default");
+    expect(status.extension.mode).toBe("missing");
+  });
+
+  it("getServiceConfigSource returns service-env when TELEPI_CONFIG is in systemd unit", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+    const ctx = resolveTelePiInstallContext(cliModuleUrl);
+
+    // Write a systemd unit file with explicit TELEPI_CONFIG
+    if (ctx.serviceUnitPath) {
+      mkdirSync(path.dirname(ctx.serviceUnitPath), { recursive: true });
+      writeFileSync(ctx.serviceUnitPath, [
+        "[Service]",
+        `Environment=TELEPI_CONFIG=${ctx.configPath}`,
+        `WorkingDirectory=${ctx.workingDirectory}`,
+      ].join("\n"));
+    }
+
+    const info = getServiceConfigSource(ctx);
+    expect(info.source).toBe("service-env");
+    expect(info.resolvedPath).toBe(ctx.configPath);
+  });
+
+  it("getServiceConfigSource returns service-cwd when .env exists in working dir", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+    const ctx = resolveTelePiInstallContext(cliModuleUrl);
+
+    // Write a unit file without TELEPI_CONFIG, but with .env in working dir
+    if (ctx.serviceUnitPath) {
+      mkdirSync(path.dirname(ctx.serviceUnitPath), { recursive: true });
+      writeFileSync(ctx.serviceUnitPath, [
+        "[Service]",
+        `WorkingDirectory=${ctx.workingDirectory}`,
+      ].join("\n"));
+    }
+    writeFileSync(path.join(ctx.workingDirectory, ".env"), "TELEGRAM_BOT_TOKEN=test\n");
+
+    const info = getServiceConfigSource(ctx);
+    expect(info.source).toBe("service-cwd");
+    expect(info.resolvedPath).toBe(path.join(ctx.workingDirectory, ".env"));
+  });
+
+  it("getServiceConfigSource returns installed-default when no unit or .env exists", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+    const ctx = resolveTelePiInstallContext(cliModuleUrl);
+    // Don't create any service unit file
+    ctx.serviceUnitPath = path.join(tmpdir(), "nonexistent", "telepi.service");
+
+    const info = getServiceConfigSource(ctx);
+    expect(info.source).toBe("installed-default");
+    expect(info.resolvedPath).toBe(ctx.configPath);
   });
 });
 

--- a/test/install/clipboard.test.ts
+++ b/test/install/clipboard.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "../../src/install/clipboard.js";
+
+describe("copyToClipboard", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("returns false on unsupported platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    const result = await copyToClipboard("test text");
+
+    expect(result).toBe(false);
+  });
+
+  it("attempts pbcopy on macOS", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    // pbcopy exists on macOS — the call will actually run.
+    // The result depends on whether we're on a real Mac.
+    const result = await copyToClipboard("test text");
+
+    // On a real Mac with pbcopy, this would be true.
+    // On other platforms with mocked darwin, spawnSync will error → false.
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("attempts wl-copy, xclip, xsel on Linux in priority order", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    const result = await copyToClipboard("test text");
+
+    // On a headless/non-Linux test runner, none of these will exist → false.
+    // On a Linux desktop with one installed, could be true.
+    // We just verify it doesn't throw.
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("handles empty string gracefully", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    const result = await copyToClipboard("");
+
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("handles special characters without breaking", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    const result = await copyToClipboard("line1\nline2 'quoted' \"double\" $PATH");
+
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("is used by sessions.ts handback instead of inline pbcopy", () => {
+    // Verify sessions.ts no longer contains the old darwin-only pbcopy pattern.
+    const sessionsSource = readFileSync(
+      new URL("../../src/bot/commands/sessions.ts", import.meta.url),
+      "utf8",
+    );
+
+    // Old pattern should be gone
+    expect(sessionsSource).not.toContain('process.platform === "darwin"');
+    expect(sessionsSource).not.toContain('spawnSync("pbcopy"');
+
+    // New pattern should be present
+    expect(sessionsSource).toContain("copyToClipboard");
+    expect(sessionsSource).toContain('../../install/clipboard.js');
+  });
+});

--- a/test/install/platform.test.ts
+++ b/test/install/platform.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getPlatformInstallHint } from "../../src/install/platform.js";
+
+describe("getPlatformInstallHint", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+
+  it("returns brew install on macOS", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    const hint = getPlatformInstallHint("ffmpeg");
+
+    expect(hint).toBe("brew install ffmpeg");
+  });
+
+  it("returns a Linux package manager command on Linux", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    const hint = getPlatformInstallHint("ffmpeg");
+
+    // On any system, the hint should not contain "brew"
+    expect(hint).not.toContain("brew");
+
+    // It should mention installing ffmpeg
+    expect(hint.toLowerCase()).toContain("ffmpeg");
+    // Either contains "install" or "pacman -s"
+    const hasInstall = hint.toLowerCase().includes("install") || hint.toLowerCase().includes("pacman -s");
+    expect(hasInstall).toBe(true);
+
+    // Should be one of: apt, dnf, pacman, or generic fallback
+    const isApt = hint.includes("sudo apt install");
+    const isDnf = hint.includes("sudo dnf install");
+    const isPacman = hint.includes("sudo pacman -S");
+    const isGeneric = hint.includes("using your package manager");
+    expect(isApt || isDnf || isPacman || isGeneric).toBe(true);
+  });
+
+  it("returns generic hint on unsupported platforms", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    const hint = getPlatformInstallHint("git");
+
+    expect(hint).toContain("git");
+    expect(hint).toContain("package manager");
+    expect(hint).not.toContain("brew");
+    expect(hint).not.toContain("sudo");
+  });
+
+  it("works for different package names besides ffmpeg", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    expect(getPlatformInstallHint("node")).toBe("brew install node");
+    expect(getPlatformInstallHint("python3")).toBe("brew install python3");
+  });
+
+  it("returns a string (never throws)", () => {
+    // On any platform, the function should never throw
+    for (const platform of ["darwin", "linux", "win32", "freebsd"]) {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
+      const hint = getPlatformInstallHint("test-pkg");
+      expect(typeof hint).toBe("string");
+      expect(hint.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/install/systemd.test.ts
+++ b/test/install/systemd.test.ts
@@ -1,0 +1,237 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resolveTelePiInstallContext } from "../../src/install.js";
+import {
+  buildSystemdUnit,
+  writeSystemdUnit,
+  createSystemdManager,
+} from "../../src/install/systemd.js";
+import type { TelePiInstallContext } from "../../src/install/shared.js";
+
+describe("SystemdManager", () => {
+  const originalPlatform = process.platform;
+  let tempDir: string;
+  let homeDir: string;
+  let packageRoot: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "telepi-systemd-"));
+    homeDir = path.join(tempDir, "home");
+    packageRoot = path.join(tempDir, "package");
+
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    mkdirSync(path.join(packageRoot, "systemd"), { recursive: true });
+    mkdirSync(path.join(packageRoot, "extensions"), { recursive: true });
+
+    writeFileSync(path.join(packageRoot, "package.json"), '{"version":"0.5.0"}\n');
+    writeFileSync(path.join(packageRoot, "dist", "cli.js"), "#!/usr/bin/env node\n");
+    writeFileSync(path.join(packageRoot, "extensions", "telepi-handoff.ts"), "export default {};\n");
+    writeFileSync(
+      path.join(packageRoot, ".env.example"),
+      "TELEGRAM_BOT_TOKEN=dev-token\nTELEGRAM_ALLOWED_USER_IDS=1\nTELEPI_WORKSPACE=/tmp/ws\n",
+    );
+    writeFileSync(
+      path.join(packageRoot, "systemd", "telepi.service"),
+      [
+        "[Unit]",
+        "Description=TelePi Telegram Bot",
+        "After=network.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        "WorkingDirectory=__TELEPI_WORKDIR__",
+        "ExecStart=__TELEPI_NODE_PATH__ __TELEPI_CLI_PATH__ start",
+        "Environment=TELEPI_CONFIG=__TELEPI_CONFIG__",
+        "Environment=PATH=__TELEPI_PATH_ENV__",
+        "StandardOutput=append:__TELEPI_LOG_DIR__/telepi.out.log",
+        "StandardError=append:__TELEPI_LOG_DIR__/telepi.err.log",
+        "Restart=on-failure",
+        "RestartSec=5",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+      ].join("\n"),
+    );
+
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+
+  function createLinuxContext(): TelePiInstallContext {
+    const cliModuleUrl = pathToFileURL(path.join(packageRoot, "dist", "cli.js")).href;
+    return resolveTelePiInstallContext(cliModuleUrl);
+  }
+
+  describe("buildSystemdUnit", () => {
+    it("renders a systemd unit file with correct paths from context", () => {
+      const ctx = createLinuxContext();
+
+      const unit = buildSystemdUnit(ctx);
+
+      expect(unit).toContain("[Unit]");
+      expect(unit).toContain("[Service]");
+      expect(unit).toContain("[Install]");
+      expect(unit).toContain(`WorkingDirectory=${ctx.workingDirectory}`);
+      expect(unit).toContain(`ExecStart=${ctx.nodeExecutablePath} ${ctx.cliEntrypointPath} start`);
+      expect(unit).toContain(`Environment=TELEPI_CONFIG=${ctx.configPath}`);
+      if (ctx.pathEnvironment) {
+        expect(unit).toContain(`Environment=PATH=${ctx.pathEnvironment}`);
+      }
+      expect(unit).not.toContain("__TELEPI_WORKDIR__");
+      expect(unit).not.toContain("__TELEPI_NODE_PATH__");
+      expect(unit).not.toContain("__TELEPI_CLI_PATH__");
+      expect(unit).not.toContain("__TELEPI_CONFIG__");
+      expect(unit).not.toContain("__TELEPI_PATH_ENV__");
+      expect(unit).not.toContain("__TELEPI_LOG_DIR__");
+      expect(unit).toContain("Restart=on-failure");
+      expect(unit).toContain("RestartSec=5");
+      expect(unit).toContain("WantedBy=default.target");
+    });
+
+    it("handles missing PATH environment gracefully", () => {
+      const ctx = createLinuxContext();
+      ctx.pathEnvironment = undefined;
+
+      const unit = buildSystemdUnit(ctx);
+
+      expect(unit).toContain("Environment=PATH=");
+    });
+
+    it("throws when template is missing", () => {
+      const ctx = createLinuxContext();
+      rmSync(path.join(packageRoot, "systemd", "telepi.service"));
+
+      expect(() => buildSystemdUnit(ctx)).toThrow("systemd unit template not found");
+    });
+  });
+
+  describe("writeSystemdUnit", () => {
+    it("writes the unit file and creates the parent directory", () => {
+      const ctx = createLinuxContext();
+
+      // Remove the pre-existing directory to test auto-creation
+      if (ctx.serviceUnitPath) {
+        rmSync(path.dirname(ctx.serviceUnitPath), { recursive: true, force: true });
+      }
+
+      const written = writeSystemdUnit(ctx);
+
+      expect(written).toBe(true);
+      const contents = readFileSync(ctx.serviceUnitPath!, "utf8");
+      expect(contents).toContain(`WorkingDirectory=${ctx.workingDirectory}`);
+    });
+
+    it("returns false when the unit file has not changed", () => {
+      const ctx = createLinuxContext();
+      writeSystemdUnit(ctx); // first write
+
+      const writtenAgain = writeSystemdUnit(ctx); // second write — idempotent
+
+      expect(writtenAgain).toBe(false);
+    });
+
+    it("returns false when serviceUnitPath is undefined", () => {
+      const ctx = createLinuxContext();
+      ctx.serviceUnitPath = undefined;
+
+      const written = writeSystemdUnit(ctx);
+
+      expect(written).toBe(false);
+    });
+
+    it("returns true when the unit file changes after context update", () => {
+      const ctx = createLinuxContext();
+      writeSystemdUnit(ctx);
+
+      // Change a path that affects the rendered output
+      ctx.workingDirectory = path.join(tempDir, "new-workdir");
+      const written = writeSystemdUnit(ctx);
+
+      expect(written).toBe(true);
+      const contents = readFileSync(ctx.serviceUnitPath!, "utf8");
+      expect(contents).toContain(`WorkingDirectory=${ctx.workingDirectory}`);
+    });
+  });
+
+  describe("reconcile", () => {
+    it("returns a result with actions or warning from reconcile", () => {
+      const manager = createSystemdManager();
+      const ctx = createLinuxContext();
+
+      const result = manager.reconcile(ctx);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.actions)).toBe(true);
+      expect(typeof result.warning === "string" || result.warning === undefined).toBe(true);
+    });
+  });
+
+  describe("ServiceManager interface", () => {
+    it("exposes all required methods", () => {
+      const manager = createSystemdManager();
+      const ctx = createLinuxContext();
+
+      expect(typeof manager.buildUnitFile).toBe("function");
+      expect(typeof manager.writeUnitFile).toBe("function");
+      expect(typeof manager.reconcile).toBe("function");
+      expect(typeof manager.getStatus).toBe("function");
+
+      const unit = manager.buildUnitFile(ctx);
+      expect(typeof unit).toBe("string");
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns not-installed status when unit file does not exist", () => {
+      const manager = createSystemdManager();
+      const ctx = createLinuxContext();
+      ctx.serviceUnitPath = path.join(tmpdir(), "nonexistent", "telepi.service");
+
+      const status = manager.getStatus(ctx);
+
+      expect(status.unitExists).toBe(false);
+      expect(status.loaded).toBe(false);
+      expect(status.state).toBe("not installed");
+      expect(status.detail).toBe("not installed");
+    });
+
+    it("returns installed-but-not-loaded when unit file exists but systemctl fails or is unavailable", () => {
+      const manager = createSystemdManager();
+      const ctx = createLinuxContext();
+      writeSystemdUnit(ctx);
+
+      const status = manager.getStatus(ctx);
+
+      // unit exists on disk
+      expect(status.unitExists).toBe(true);
+      // status depends on systemctl availability on the test runner
+      // Expected: not loaded (service not installed in real systemd)
+      expect(typeof status.detail).toBe("string");
+    });
+
+    it("returns ServiceStatus shape with all required fields", () => {
+      const manager = createSystemdManager();
+      const ctx = createLinuxContext();
+
+      const status = manager.getStatus(ctx);
+
+      // All fields present with correct types
+      expect(typeof status.unitExists).toBe("boolean");
+      expect(typeof status.plistExists).toBe("boolean");
+      expect(typeof status.loaded).toBe("boolean");
+      expect(status.state === undefined || typeof status.state === "string").toBe(true);
+      expect(status.pid === undefined || typeof status.pid === "number").toBe(true);
+      expect(typeof status.detail).toBe("string");
+      expect(status.error === undefined || typeof status.error === "string").toBe(true);
+    });
+  });
+});

--- a/test/install/systemd.test.ts
+++ b/test/install/systemd.test.ts
@@ -46,10 +46,10 @@ describe("SystemdManager", () => {
         "Type=simple",
         "WorkingDirectory=__TELEPI_WORKDIR__",
         "ExecStart=__TELEPI_NODE_PATH__ __TELEPI_CLI_PATH__ start",
-        "Environment=TELEPI_CONFIG=__TELEPI_CONFIG__",
-        "Environment=PATH=__TELEPI_PATH_ENV__",
-        "StandardOutput=append:__TELEPI_LOG_DIR__/telepi.out.log",
-        "StandardError=append:__TELEPI_LOG_DIR__/telepi.err.log",
+        "Environment=__TELEPI_CONFIG_ENV__",
+        "Environment=__TELEPI_PATH_ENV__",
+        "StandardOutput=append:__TELEPI_STDOUT_PATH__",
+        "StandardError=append:__TELEPI_STDERR_PATH__",
         "Restart=on-failure",
         "RestartSec=5",
         "",
@@ -89,9 +89,10 @@ describe("SystemdManager", () => {
       expect(unit).not.toContain("__TELEPI_WORKDIR__");
       expect(unit).not.toContain("__TELEPI_NODE_PATH__");
       expect(unit).not.toContain("__TELEPI_CLI_PATH__");
-      expect(unit).not.toContain("__TELEPI_CONFIG__");
+      expect(unit).not.toContain("__TELEPI_CONFIG_ENV__");
       expect(unit).not.toContain("__TELEPI_PATH_ENV__");
-      expect(unit).not.toContain("__TELEPI_LOG_DIR__");
+      expect(unit).not.toContain("__TELEPI_STDOUT_PATH__");
+      expect(unit).not.toContain("__TELEPI_STDERR_PATH__");
       expect(unit).toContain("Restart=on-failure");
       expect(unit).toContain("RestartSec=5");
       expect(unit).toContain("WantedBy=default.target");
@@ -104,6 +105,26 @@ describe("SystemdManager", () => {
       const unit = buildSystemdUnit(ctx);
 
       expect(unit).toContain("Environment=PATH=");
+    });
+
+    it("quotes systemd values that contain whitespace", () => {
+      const ctx = createLinuxContext();
+      ctx.workingDirectory = path.join(tempDir, "work dir");
+      ctx.nodeExecutablePath = path.join(tempDir, "node dir", "node");
+      ctx.cliEntrypointPath = path.join(tempDir, "TelePi checkout", "dist", "cli.js");
+      ctx.configPath = path.join(tempDir, "config dir", "config.env");
+      ctx.pathEnvironment = `${path.join(tempDir, "bin dir")}:/usr/bin`;
+      ctx.serviceUnitStdoutPath = path.join(tempDir, "log dir", "telepi.out.log");
+      ctx.serviceUnitStderrPath = path.join(tempDir, "log dir", "telepi.err.log");
+
+      const unit = buildSystemdUnit(ctx);
+
+      expect(unit).toContain(`WorkingDirectory="${ctx.workingDirectory}"`);
+      expect(unit).toContain(`ExecStart="${ctx.nodeExecutablePath}" "${ctx.cliEntrypointPath}" start`);
+      expect(unit).toContain(`Environment="TELEPI_CONFIG=${ctx.configPath}"`);
+      expect(unit).toContain(`Environment="PATH=${ctx.pathEnvironment}"`);
+      expect(unit).toContain(`StandardOutput=append:"${ctx.serviceUnitStdoutPath}"`);
+      expect(unit).toContain(`StandardError=append:"${ctx.serviceUnitStderrPath}"`);
     });
 
     it("throws when template is missing", () => {

--- a/test/voice.decode.test.ts
+++ b/test/voice.decode.test.ts
@@ -18,7 +18,10 @@ function createSpawnMock(onSpawn: (child: FakeChildProcess) => void) {
 
 async function importVoiceWithSpawn(spawnMock: ReturnType<typeof createSpawnMock>) {
   vi.resetModules();
-  vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+  vi.doMock("node:child_process", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:child_process")>();
+    return { ...actual, spawn: spawnMock };
+  });
   return await import("../src/voice.js");
 }
 
@@ -122,6 +125,6 @@ describe("voice decoding", () => {
       },
     }));
 
-    await expect(voice.transcribeAudio("/tmp/missing.ogg")).rejects.toThrow("brew install ffmpeg");
+    await expect(voice.transcribeAudio("/tmp/missing.ogg")).rejects.toThrow("ffmpeg");
   });
 });

--- a/test/voice.test.ts
+++ b/test/voice.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getPlatformInstallHint } from "../src/install/platform.js";
 import {
   _resetImportHook,
   _setDecodeHook,
@@ -333,7 +334,7 @@ describe("voice transcription", () => {
 
     await expect(transcribeAudio(audioPath)).rejects.toThrow("Voice messages require a transcription backend.");
     await expect(transcribeAudio(audioPath)).rejects.toThrow("npm install parakeet-coreml");
-    await expect(transcribeAudio(audioPath)).rejects.toThrow("brew install ffmpeg");
+    await expect(transcribeAudio(audioPath)).rejects.toThrow("ffmpeg");
     await expect(transcribeAudio(audioPath)).rejects.toThrow("sherpa-onnx-node");
     await expect(transcribeAudio(audioPath)).rejects.toThrow("SHERPA_ONNX_MODEL_DIR");
     await expect(transcribeAudio(audioPath)).rejects.toThrow("OPENAI_API_KEY=sk-");
@@ -589,7 +590,7 @@ describe("voice transcription", () => {
       throw new Error("ffmpeg not found. Install it with: brew install ffmpeg");
     });
 
-    await expect(transcribeAudio(audioPath)).rejects.toThrow("brew install ffmpeg");
+    await expect(transcribeAudio(audioPath)).rejects.toThrow("ffmpeg");
   });
 
   it("propagates parakeet engine initialization failures", async () => {


### PR DESCRIPTION
- Add ServiceManager interface and platform dispatch (launchd/systemd)
- Add SystemdManager: buildUnitFile, writeUnitFile, reconcile, getStatus
- Add systemd unit template (systemd/telepi.service)
- Add cross-platform clipboard utility (pbcopy/wl-copy/xclip/xsel)
- Add platform-aware dependency hints (apt/dnf/pacman/brew)
- Add PATH sanitization in platform context resolver
- Extend handoff extension with systemd mode
- Add XDG path helpers for Linux
- 40 new tests, 365 total passing
- macOS behavior unchanged, all existing tests pass