### PR TITLE
fix: migrate from @mariozechner to @earendil-works Pi SDK namespace

### DIFF
--- a/extensions/telepi-handoff.ts
+++ b/extensions/telepi-handoff.ts
@@ -1,14 +1,18 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 type HandoffMode = "direct" | "launchd" | "systemd";
 
 export type DirectLaunchTarget =
-  | { kind: "installed"; homeDirectory: string; installedConfigPath: string }
-  | { kind: "source"; telePiDir: string }
-  | { kind: "unavailable"; reason: "missing-installed-config" | "missing-telepi"; installedConfigPath: string };
+	| { kind: "installed"; homeDirectory: string; installedConfigPath: string }
+	| { kind: "source"; telePiDir: string }
+	| {
+			kind: "unavailable";
+			reason: "missing-installed-config" | "missing-telepi";
+			installedConfigPath: string;
+	  };
 
 const DEFAULT_LAUNCHD_LABEL = "com.telepi";
 const DEFAULT_SYSTEMD_SERVICE = "telepi.service";
@@ -19,70 +23,91 @@ const DIRECT_LOG_PATH = "/tmp/telepi.log";
 // ---------------------------------------------------------------------------
 
 function shellQuote(value: string): string {
-  return value.replace(/'/g, "'\\''");
+	return value.replace(/'/g, "'\\''");
 }
 
 function getLaunchdLabel(env: NodeJS.ProcessEnv = process.env): string {
-  return env.TELEPI_LAUNCHD_LABEL?.trim() || DEFAULT_LAUNCHD_LABEL;
+	return env.TELEPI_LAUNCHD_LABEL?.trim() || DEFAULT_LAUNCHD_LABEL;
 }
 
 export function getHomeDirectory(env: NodeJS.ProcessEnv = process.env): string {
-  return env.HOME?.trim() || homedir();
+	return env.HOME?.trim() || homedir();
 }
 
-export function getInstalledConfigPath(homeDirectory = getHomeDirectory()): string {
-  return path.join(homeDirectory, ".config", "telepi", "config.env");
+export function getInstalledConfigPath(
+	homeDirectory = getHomeDirectory(),
+): string {
+	return path.join(homeDirectory, ".config", "telepi", "config.env");
 }
 
 export function getInstalledLaunchAgentPath(
-  homeDirectory = getHomeDirectory(),
-  launchdLabel = getLaunchdLabel(),
+	homeDirectory = getHomeDirectory(),
+	launchdLabel = getLaunchdLabel(),
 ): string {
-  return path.join(homeDirectory, "Library", "LaunchAgents", `${launchdLabel}.plist`);
+	return path.join(
+		homeDirectory,
+		"Library",
+		"LaunchAgents",
+		`${launchdLabel}.plist`,
+	);
 }
 
-export function getInstalledSystemdServicePath(homeDirectory = getHomeDirectory()): string {
-  return path.join(homeDirectory, ".config", "systemd", "user", DEFAULT_SYSTEMD_SERVICE);
+export function getInstalledSystemdServicePath(
+	homeDirectory = getHomeDirectory(),
+): string {
+	return path.join(
+		homeDirectory,
+		".config",
+		"systemd",
+		"user",
+		DEFAULT_SYSTEMD_SERVICE,
+	);
 }
 
 // ---------------------------------------------------------------------------
 // Mode detection
 // ---------------------------------------------------------------------------
 
-export function resolveHandoffMode(env: NodeJS.ProcessEnv = process.env): HandoffMode | undefined {
-  const raw = env.TELEPI_HANDOFF_MODE?.trim().toLowerCase();
+export function resolveHandoffMode(
+	env: NodeJS.ProcessEnv = process.env,
+): HandoffMode | undefined {
+	const raw = env.TELEPI_HANDOFF_MODE?.trim().toLowerCase();
 
-  if (!raw || raw === "auto") {
-    if (hasInstalledLaunchdFlow(env)) return "launchd";
-    if (hasInstalledSystemdFlow(env)) return "systemd";
-    return "direct";
-  }
+	if (!raw || raw === "auto") {
+		if (hasInstalledLaunchdFlow(env)) return "launchd";
+		if (hasInstalledSystemdFlow(env)) return "systemd";
+		return "direct";
+	}
 
-  if (raw === "direct") return "direct";
-  if (raw === "launchd") return "launchd";
-  if (raw === "systemd") return "systemd";
+	if (raw === "direct") return "direct";
+	if (raw === "launchd") return "launchd";
+	if (raw === "systemd") return "systemd";
 
-  return undefined;
+	return undefined;
 }
 
-export function hasInstalledLaunchdFlow(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (process.platform !== "darwin") return false;
+export function hasInstalledLaunchdFlow(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	if (process.platform !== "darwin") return false;
 
-  const homeDirectory = getHomeDirectory(env);
-  return (
-    existsSync(getInstalledConfigPath(homeDirectory)) &&
-    existsSync(getInstalledLaunchAgentPath(homeDirectory, getLaunchdLabel(env)))
-  );
+	const homeDirectory = getHomeDirectory(env);
+	return (
+		existsSync(getInstalledConfigPath(homeDirectory)) &&
+		existsSync(getInstalledLaunchAgentPath(homeDirectory, getLaunchdLabel(env)))
+	);
 }
 
-export function hasInstalledSystemdFlow(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (process.platform !== "linux") return false;
+export function hasInstalledSystemdFlow(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	if (process.platform !== "linux") return false;
 
-  const homeDirectory = getHomeDirectory(env);
-  return (
-    existsSync(getInstalledConfigPath(homeDirectory)) &&
-    existsSync(getInstalledSystemdServicePath(homeDirectory))
-  );
+	const homeDirectory = getHomeDirectory(env);
+	return (
+		existsSync(getInstalledConfigPath(homeDirectory)) &&
+		existsSync(getInstalledSystemdServicePath(homeDirectory))
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -90,32 +115,40 @@ export function hasInstalledSystemdFlow(env: NodeJS.ProcessEnv = process.env): b
 // ---------------------------------------------------------------------------
 
 export function resolveDirectLaunchTarget(options: {
-  hasGlobalTelePi: boolean;
-  telePiDir: string | undefined;
-  env?: NodeJS.ProcessEnv;
+	hasGlobalTelePi: boolean;
+	telePiDir: string | undefined;
+	env?: NodeJS.ProcessEnv;
 }): DirectLaunchTarget {
-  const env = options.env ?? process.env;
-  const homeDirectory = getHomeDirectory(env);
-  const installedConfigPath = getInstalledConfigPath(homeDirectory);
-  const telePiDir = options.telePiDir?.trim();
+	const env = options.env ?? process.env;
+	const homeDirectory = getHomeDirectory(env);
+	const installedConfigPath = getInstalledConfigPath(homeDirectory);
+	const telePiDir = options.telePiDir?.trim();
 
-  if (options.hasGlobalTelePi && existsSync(installedConfigPath)) {
-    return { kind: "installed", homeDirectory, installedConfigPath };
-  }
-  if (telePiDir) return { kind: "source", telePiDir };
-  if (options.hasGlobalTelePi) {
-    return { kind: "unavailable", reason: "missing-installed-config", installedConfigPath };
-  }
-  return { kind: "unavailable", reason: "missing-telepi", installedConfigPath };
+	if (options.hasGlobalTelePi && existsSync(installedConfigPath)) {
+		return { kind: "installed", homeDirectory, installedConfigPath };
+	}
+	if (telePiDir) return { kind: "source", telePiDir };
+	if (options.hasGlobalTelePi) {
+		return {
+			kind: "unavailable",
+			reason: "missing-installed-config",
+			installedConfigPath,
+		};
+	}
+	return { kind: "unavailable", reason: "missing-telepi", installedConfigPath };
 }
 
 async function hasGlobalTelePiCommand(pi: ExtensionAPI): Promise<boolean> {
-  try {
-    const result = await pi.exec("bash", ["-lc", "command -v telepi >/dev/null 2>&1"], { timeout: 3000 });
-    return result.code === 0;
-  } catch {
-    return false;
-  }
+	try {
+		const result = await pi.exec(
+			"bash",
+			["-lc", "command -v telepi >/dev/null 2>&1"],
+			{ timeout: 3000 },
+		);
+		return result.code === 0;
+	} catch {
+		return false;
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -123,40 +156,61 @@ async function hasGlobalTelePiCommand(pi: ExtensionAPI): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 export default function (pi: ExtensionAPI) {
-  pi.registerCommand("handoff", {
-    description: "Hand off this session to TelePi (Telegram)",
-    handler: async (_args, ctx) => {
-      const sessionFile = ctx.sessionManager.getSessionFile();
-      if (!sessionFile) {
-        ctx.ui.notify("Cannot hand off an in-memory session. Save the session first.", "error");
-        return;
-      }
+	pi.registerCommand("handoff", {
+		description: "Hand off this session to TelePi (Telegram)",
+		handler: async (_args, ctx) => {
+			const sessionFile = ctx.sessionManager.getSessionFile();
+			if (!sessionFile) {
+				ctx.ui.notify(
+					"Cannot hand off an in-memory session. Save the session first.",
+					"error",
+				);
+				return;
+			}
 
-      const handoffMode = resolveHandoffMode();
-      if (!handoffMode) {
-        ctx.ui.notify("Invalid TELEPI_HANDOFF_MODE. Expected one of: auto, direct, launchd, systemd", "error");
-        return;
-      }
+			const handoffMode = resolveHandoffMode();
+			if (!handoffMode) {
+				ctx.ui.notify(
+					"Invalid TELEPI_HANDOFF_MODE. Expected one of: auto, direct, launchd, systemd",
+					"error",
+				);
+				return;
+			}
 
-      const safeSessionFile = shellQuote(sessionFile);
-      let launched = false;
+			const safeSessionFile = shellQuote(sessionFile);
+			let launched = false;
 
-      // 1) launchd (macOS)
-      if (handoffMode === "launchd") {
-        launched = await handoffViaLaunchd(pi, ctx, sessionFile, safeSessionFile);
-      }
-      // 2) systemd (Linux)
-      else if (handoffMode === "systemd") {
-        launched = await handoffViaSystemd(pi, ctx, sessionFile, safeSessionFile);
-      }
-      // 3) direct
-      else {
-        launched = await handoffViaDirect(pi, ctx, sessionFile, safeSessionFile);
-      }
+			// 1) launchd (macOS)
+			if (handoffMode === "launchd") {
+				launched = await handoffViaLaunchd(
+					pi,
+					ctx,
+					sessionFile,
+					safeSessionFile,
+				);
+			}
+			// 2) systemd (Linux)
+			else if (handoffMode === "systemd") {
+				launched = await handoffViaSystemd(
+					pi,
+					ctx,
+					sessionFile,
+					safeSessionFile,
+				);
+			}
+			// 3) direct
+			else {
+				launched = await handoffViaDirect(
+					pi,
+					ctx,
+					sessionFile,
+					safeSessionFile,
+				);
+			}
 
-      if (launched) ctx.shutdown();
-    },
-  });
+			if (launched) ctx.shutdown();
+		},
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -164,177 +218,217 @@ export default function (pi: ExtensionAPI) {
 // ---------------------------------------------------------------------------
 
 async function handoffViaLaunchd(
-  pi: ExtensionAPI,
-  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
-  sessionFile: string,
-  safeSessionFile: string,
+	pi: ExtensionAPI,
+	ctx: {
+		ui: {
+			notify: (msg: string, severity: "info" | "warning" | "error") => void;
+		};
+	},
+	sessionFile: string,
+	safeSessionFile: string,
 ): Promise<boolean> {
-  const launchdLabel = getLaunchdLabel();
-  const safeLaunchdLabel = shellQuote(launchdLabel);
+	const launchdLabel = getLaunchdLabel();
+	const safeLaunchdLabel = shellQuote(launchdLabel);
 
-  ctx.ui.notify(`Handing off to TelePi via launchd...\nSession: ${sessionFile}\nJob: ${launchdLabel}`, "info");
+	ctx.ui.notify(
+		`Handing off to TelePi via launchd...\nSession: ${sessionFile}\nJob: ${launchdLabel}`,
+		"info",
+	);
 
-  try {
-    const result = await pi.exec(
-      "bash",
-      ["-lc", [
-        `session_file='${safeSessionFile}'`,
-        `label='${safeLaunchdLabel}'`,
-        `launchctl setenv PI_SESSION_PATH "$session_file"`,
-        `launchctl kickstart -k "gui/$UID/$label"`,
-      ].join("\n")],
-      { timeout: 5000 },
-    );
+	try {
+		const result = await pi.exec(
+			"bash",
+			[
+				"-lc",
+				[
+					`session_file='${safeSessionFile}'`,
+					`label='${safeLaunchdLabel}'`,
+					`launchctl setenv PI_SESSION_PATH "$session_file"`,
+					`launchctl kickstart -k "gui/$UID/$label"`,
+				].join("\n"),
+			],
+			{ timeout: 5000 },
+		);
 
-    if (result.code === 0) {
-      ctx.ui.notify(`TelePi restarted via launchd job ${launchdLabel}. Check Telegram!`, "info");
-      return true;
-    }
+		if (result.code === 0) {
+			ctx.ui.notify(
+				`TelePi restarted via launchd job ${launchdLabel}. Check Telegram!`,
+				"info",
+			);
+			return true;
+		}
 
-    ctx.ui.notify(
-      "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
-        `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
-        `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
-      "warning",
-    );
-    return false;
-  } catch {
-    ctx.ui.notify(
-      "Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
-        `launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
-        `launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
-      "warning",
-    );
-    return false;
-  }
+		ctx.ui.notify(
+			"Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
+				`launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
+				`launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
+			"warning",
+		);
+		return false;
+	} catch {
+		ctx.ui.notify(
+			"Could not restart TelePi via launchd. Verify the LaunchAgent is loaded and try manually:\n" +
+				`launchctl setenv PI_SESSION_PATH '${safeSessionFile}'\n` +
+				`launchctl kickstart -k gui/$UID/'${safeLaunchdLabel}'`,
+			"warning",
+		);
+		return false;
+	}
 }
 
 async function handoffViaSystemd(
-  pi: ExtensionAPI,
-  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
-  sessionFile: string,
-  safeSessionFile: string,
+	pi: ExtensionAPI,
+	ctx: {
+		ui: {
+			notify: (msg: string, severity: "info" | "warning" | "error") => void;
+		};
+	},
+	sessionFile: string,
+	safeSessionFile: string,
 ): Promise<boolean> {
-  ctx.ui.notify(`Handing off to TelePi via systemd...\nSession: ${sessionFile}`, "info");
+	ctx.ui.notify(
+		`Handing off to TelePi via systemd...\nSession: ${sessionFile}`,
+		"info",
+	);
 
-  try {
-    const result = await pi.exec(
-      "bash",
-      ["-lc", [
-        `session_file='${safeSessionFile}'`,
-        `systemctl --user set-environment PI_SESSION_PATH="$session_file"`,
-        `systemctl --user restart telepi.service`,
-      ].join("\n")],
-      { timeout: 5000 },
-    );
+	try {
+		const result = await pi.exec(
+			"bash",
+			[
+				"-lc",
+				[
+					`session_file='${safeSessionFile}'`,
+					`systemctl --user set-environment PI_SESSION_PATH="$session_file"`,
+					`systemctl --user restart telepi.service`,
+				].join("\n"),
+			],
+			{ timeout: 5000 },
+		);
 
-    if (result.code === 0) {
-      ctx.ui.notify("TelePi restarted via systemd. Check Telegram!", "info");
-      return true;
-    }
+		if (result.code === 0) {
+			ctx.ui.notify("TelePi restarted via systemd. Check Telegram!", "info");
+			return true;
+		}
 
-    ctx.ui.notify(
-      "Could not restart TelePi via systemd. Try manually:\n" +
-        `systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
-        `systemctl --user restart telepi.service`,
-      "warning",
-    );
-    return false;
-  } catch {
-    ctx.ui.notify(
-      "Could not restart TelePi via systemd. Try manually:\n" +
-        `systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
-        `systemctl --user restart telepi.service`,
-      "warning",
-    );
-    return false;
-  }
+		ctx.ui.notify(
+			"Could not restart TelePi via systemd. Try manually:\n" +
+				`systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
+				`systemctl --user restart telepi.service`,
+			"warning",
+		);
+		return false;
+	} catch {
+		ctx.ui.notify(
+			"Could not restart TelePi via systemd. Try manually:\n" +
+				`systemctl --user set-environment PI_SESSION_PATH='${safeSessionFile}'\n` +
+				`systemctl --user restart telepi.service`,
+			"warning",
+		);
+		return false;
+	}
 }
 
 async function handoffViaDirect(
-  pi: ExtensionAPI,
-  ctx: { ui: { notify: (msg: string, severity: "info" | "warning" | "error") => void } },
-  sessionFile: string,
-  safeSessionFile: string,
+	pi: ExtensionAPI,
+	ctx: {
+		ui: {
+			notify: (msg: string, severity: "info" | "warning" | "error") => void;
+		};
+	},
+	sessionFile: string,
+	safeSessionFile: string,
 ): Promise<boolean> {
-  const telePiDir = process.env.TELEPI_DIR?.trim();
-  const hasGlobalTelePi = await hasGlobalTelePiCommand(pi);
-  const target = resolveDirectLaunchTarget({ hasGlobalTelePi, telePiDir });
+	const telePiDir = process.env.TELEPI_DIR?.trim();
+	const hasGlobalTelePi = await hasGlobalTelePiCommand(pi);
+	const target = resolveDirectLaunchTarget({ hasGlobalTelePi, telePiDir });
 
-  if (target.kind === "unavailable") {
-    if (target.reason === "missing-installed-config") {
-      ctx.ui.notify(
-        "TelePi is installed globally, but its installed config is missing:\n" +
-          `  ${target.installedConfigPath}\n\n` +
-          "Run `telepi setup` to create it, or point TELEPI_DIR at a source checkout.",
-        "error",
-      );
-    } else {
-      ctx.ui.notify(
-        "TelePi is not available for direct hand-off. Either install it globally:\n" +
-          "  npm install -g @benedict2310/telepi\n" +
-          "  telepi setup\n\n" +
-          "Or point TELEPI_DIR at a source checkout:\n" +
-          "  export TELEPI_DIR=/path/to/TelePi\n\n" +
-          "Or use systemd mode (Linux) / launchd mode (macOS) with:\n" +
-          "  export TELEPI_HANDOFF_MODE=systemd   # Linux\n" +
-          "  export TELEPI_HANDOFF_MODE=launchd   # macOS",
-        "error",
-      );
-    }
-    return false;
-  }
+	if (target.kind === "unavailable") {
+		if (target.reason === "missing-installed-config") {
+			ctx.ui.notify(
+				"TelePi is installed globally, but its installed config is missing:\n" +
+					`  ${target.installedConfigPath}\n\n` +
+					"Run `telepi setup` to create it, or point TELEPI_DIR at a source checkout.",
+				"error",
+			);
+		} else {
+			ctx.ui.notify(
+				"TelePi is not available for direct hand-off. Either install it globally:\n" +
+					"  npm install -g @benedict2310/telepi\n" +
+					"  telepi setup\n\n" +
+					"Or point TELEPI_DIR at a source checkout:\n" +
+					"  export TELEPI_DIR=/path/to/TelePi\n\n" +
+					"Or use systemd mode (Linux) / launchd mode (macOS) with:\n" +
+					"  export TELEPI_HANDOFF_MODE=systemd   # Linux\n" +
+					"  export TELEPI_HANDOFF_MODE=launchd   # macOS",
+				"error",
+			);
+		}
+		return false;
+	}
 
-  ctx.ui.notify(`Handing off to TelePi...\nSession: ${sessionFile}`, "info");
+	ctx.ui.notify(`Handing off to TelePi...\nSession: ${sessionFile}`, "info");
 
-  if (target.kind === "source") {
-    await pi.exec("bash", ["-lc", 'pkill -f "tsx.*TelePi" 2>/dev/null || true'], { timeout: 3000 }).catch(() => {});
-  }
+	if (target.kind === "source") {
+		await pi
+			.exec("bash", ["-lc", 'pkill -f "tsx.*TelePi" 2>/dev/null || true'], {
+				timeout: 3000,
+			})
+			.catch(() => {});
+	}
 
-  try {
-    const result =
-      target.kind === "installed"
-        ? await pi.exec(
-            "bash",
-            ["-lc", [
-              `cd '${shellQuote(target.homeDirectory)}'`,
-              `telepi_command="$(command -v telepi)"`,
-              `PI_SESSION_PATH='${safeSessionFile}' TELEPI_CONFIG='${shellQuote(target.installedConfigPath)}' nohup "$telepi_command" start > '${DIRECT_LOG_PATH}' 2>&1 &`,
-              `echo $!`,
-            ].join("\n")],
-            { timeout: 5000 },
-          )
-        : await pi.exec(
-            "bash",
-            ["-lc", [
-              `cd '${shellQuote(target.telePiDir)}'`,
-              `PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > '${DIRECT_LOG_PATH}' 2>&1 &`,
-              `echo $!`,
-            ].join("\n")],
-            { timeout: 5000 },
-          );
+	try {
+		const result =
+			target.kind === "installed"
+				? await pi.exec(
+						"bash",
+						[
+							"-lc",
+							[
+								`cd '${shellQuote(target.homeDirectory)}'`,
+								`telepi_command="$(command -v telepi)"`,
+								`PI_SESSION_PATH='${safeSessionFile}' TELEPI_CONFIG='${shellQuote(target.installedConfigPath)}' nohup "$telepi_command" start > '${DIRECT_LOG_PATH}' 2>&1 &`,
+								`echo $!`,
+							].join("\n"),
+						],
+						{ timeout: 5000 },
+					)
+				: await pi.exec(
+						"bash",
+						[
+							"-lc",
+							[
+								`cd '${shellQuote(target.telePiDir)}'`,
+								`PI_SESSION_PATH='${safeSessionFile}' nohup npx tsx src/index.ts > '${DIRECT_LOG_PATH}' 2>&1 &`,
+								`echo $!`,
+							].join("\n"),
+						],
+						{ timeout: 5000 },
+					);
 
-    const pid = result.stdout.trim();
-    if (pid && result.code === 0) {
-      ctx.ui.notify(
-        target.kind === "installed"
-          ? `TelePi started via installed \`telepi\` (PID: ${pid}). Check Telegram!`
-          : `TelePi started from source checkout (PID: ${pid}). Check Telegram!`,
-        "info",
-      );
-      return true;
-    }
-    ctx.ui.notify(`TelePi may have failed to start. Check ${DIRECT_LOG_PATH}`, "warning");
-    return false;
-  } catch {
-    ctx.ui.notify(
-      target.kind === "installed"
-        ? "Could not auto-launch TelePi. Start it manually:\n" +
-          `TELEPI_CONFIG="${target.installedConfigPath}" PI_SESSION_PATH="${sessionFile}" telepi start`
-        : `Could not auto-launch TelePi. Start it manually:\n` +
-          `cd "${target.telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
-      "warning",
-    );
-    return false;
-  }
+		const pid = result.stdout.trim();
+		if (pid && result.code === 0) {
+			ctx.ui.notify(
+				target.kind === "installed"
+					? `TelePi started via installed \`telepi\` (PID: ${pid}). Check Telegram!`
+					: `TelePi started from source checkout (PID: ${pid}). Check Telegram!`,
+				"info",
+			);
+			return true;
+		}
+		ctx.ui.notify(
+			`TelePi may have failed to start. Check ${DIRECT_LOG_PATH}`,
+			"warning",
+		);
+		return false;
+	} catch {
+		ctx.ui.notify(
+			target.kind === "installed"
+				? "Could not auto-launch TelePi. Start it manually:\n" +
+						`TELEPI_CONFIG="${target.installedConfigPath}" PI_SESSION_PATH="${sessionFile}" telepi start`
+				: `Could not auto-launch TelePi. Start it manually:\n` +
+						`cd "${target.telePiDir}" && PI_SESSION_PATH="${sessionFile}" npx tsx src/index.ts`,
+			"warning",
+		);
+		return false;
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-coding-agent": "^0.80.3",
         "@grammyjs/auto-retry": "^2.0.2",
-        "@mariozechner/pi-coding-agent": "0.70.2",
         "grammy": "^1.35.0",
-        "minimatch": "^10.2.4",
-        "sherpa-onnx-node": "1.12.32"
+        "minimatch": "^10.2.4"
       },
       "bin": {
         "telepi": "dist/cli.js"
@@ -48,9 +49,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -67,20 +68,6 @@
         }
       }
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -94,44 +81,6 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -168,96 +117,25 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1037.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1037.0.tgz",
-      "integrity": "sha512-Evla4DUdBf1pQpQa7pbfquj7jRaRktkI0qGoWBJBXWB9wQISzJ8OEI4sHugk/W6SF47C7hMP/o3Z/XBrfnejCw==",
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/credential-provider-node": "^3.972.36",
-        "@aws-sdk/eventstream-handler-node": "^3.972.14",
-        "@aws-sdk/middleware-eventstream": "^3.972.10",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.35",
-        "@aws-sdk/middleware-websocket": "^3.972.16",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/token-providers": "3.1037.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.21",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
-        "@smithy/eventstream-serde-node": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.5",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -265,24 +143,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
-      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
+      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.19",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -290,15 +162,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
-      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
+      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -306,45 +178,55 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
-      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
+      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
-      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/credential-provider-env": "^3.972.31",
-        "@aws-sdk/credential-provider-http": "^3.972.33",
-        "@aws-sdk/credential-provider-login": "^3.972.35",
-        "@aws-sdk/credential-provider-process": "^3.972.31",
-        "@aws-sdk/credential-provider-sso": "^3.972.35",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
+      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-login": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -352,18 +234,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
-      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
+      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -371,22 +251,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
-      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
+      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.31",
-        "@aws-sdk/credential-provider-http": "^3.972.33",
-        "@aws-sdk/credential-provider-ini": "^3.972.35",
-        "@aws-sdk/credential-provider-process": "^3.972.31",
-        "@aws-sdk/credential-provider-sso": "^3.972.35",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-ini": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -394,16 +273,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
-      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
+      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -411,18 +289,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
-      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
+      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/token-providers": "3.1036.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/token-providers": "3.1079.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -430,17 +307,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
-      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
+      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -448,17 +324,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
-      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
+      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -466,14 +341,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
-      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.25.tgz",
+      "integrity": "sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/eventstream-codec": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -481,103 +356,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
-      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.21.tgz",
+      "integrity": "sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
-      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
-      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@smithy/core": "^3.23.17",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.4",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -585,22 +371,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
-      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.35.tgz",
+      "integrity": "sha512-7/ZAlq5o5A9FnRsQEftZvcct9LVZf1YaYmWR3eOzyJAdKU66YpOKy5ahUVvyBvCTLyO4Ej4yWIk8dllWNXPBsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-format-url": "^3.972.10",
-        "@smithy/eventstream-codec": "^4.2.14",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -608,82 +389,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
-      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
+      "version": "3.997.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
+      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.35",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.21",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.5",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
-      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -691,16 +437,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1037.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1037.0.tgz",
-      "integrity": "sha512-csxa484KboWLs3f8jFQ5v9RwH8FVf0fQ+SO3GSXyu4Jtinhh4qXmOWLSVX30RBpB933dZaKGHGEXzEEY88NqRw==",
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -709,55 +454,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
-      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -765,62 +467,24 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
-      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.35",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
-      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -828,9 +492,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -873,9 +537,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -905,14 +569,1877 @@
         "node": ">=18"
       }
     },
-    "node_modules/@borewit/text-codec": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.3",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
+      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.1.38",
+        "undici": "8.5.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.3",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "./dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1358,9 +2885,10 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
-      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -1524,315 +3052,43 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
-      "integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.3",
-        "@mariozechner/clipboard-darwin-universal": "0.3.3",
-        "@mariozechner/clipboard-darwin-x64": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.3",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
-      "integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
-      "integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
-      "integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
-      "integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
-      "integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
-      "integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
-      "integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
-      "integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
-      "integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
-      "integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.70.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.2.tgz",
-      "integrity": "sha512-g1hIdKyDwmQOoBGO0R4OhpemKeMENeK0vE5FJtuQKqEcsdCAkVBgZAK6aZUARYZVxMA718JS6WPLFWoddzjD7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.70.2",
-        "typebox": "^1.1.24"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.70.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.2.tgz",
-      "integrity": "sha512-+30LRPjXsXF+oI96DvGWMbdPGeqoLJvadh6UPev7wx2DzhC9FEqXkQcoMZ0usbCm7E9pl8ua8a9s/pQ5ikaUbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.70.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.2.tgz",
-      "integrity": "sha512-asfNqV89HKAmKvJ1wENBY/UQMIf77kLtkzBrvXnMQV4YbH7D/6KT+VeVzPG6zm5PAZP2UtdLY9B9Cge7IxH37w==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.70.2",
-        "@mariozechner/pi-ai": "^0.70.2",
-        "@mariozechner/pi-tui": "^0.70.2",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.3"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.70.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.2.tgz",
-      "integrity": "sha512-PtKC0NepnrYcqMx6MXkWTrBzC9tI62KeC6w940oT46lCbfvgmfqXciR15+9BZpxxc1H4jd3CMrKsmOPVeUqZ0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
-      }
-    },
     "node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1858,37 +3114,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1904,9 +3153,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2259,44 +3508,13 @@
         "win32"
       ]
     },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.17",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2304,85 +3522,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2390,43 +3536,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2434,201 +3550,25 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.32",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
-      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.17",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-middleware": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
-      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
-      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.17",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2636,36 +3576,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.12.13",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
-      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.17",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2673,61 +3590,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2737,200 +3602,30 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.49",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
-      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.54",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
-      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
-      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.25",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
-      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@tokenizer/inflate": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
-      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "token-types": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2957,12 +3652,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -2977,16 +3666,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -3203,6 +3882,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3215,6 +3895,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3226,12 +3907,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3240,18 +3915,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -3295,15 +3958,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -3341,15 +3995,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -3383,18 +4028,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -3405,79 +4038,11 @@
         "node": ">= 16"
       }
     },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3490,6 +4055,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3543,29 +4109,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3586,16 +4129,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -3646,58 +4181,6 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3706,15 +4189,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -3741,71 +4215,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3846,24 +4255,6 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "21.3.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
-      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.4",
-        "token-types": "^6.1.1",
-        "uint8array-extras": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -3931,9 +4322,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -3958,42 +4349,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -4007,50 +4362,10 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -4072,12 +4387,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
     },
     "node_modules/grammy": {
       "version": "1.41.1",
@@ -4118,30 +4427,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4177,26 +4466,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4206,19 +4475,11 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4351,17 +4612,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
-      "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -4374,15 +4624,6 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -4422,43 +4663,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4478,6 +4682,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4488,17 +4693,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -4517,15 +4711,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-domexception": {
@@ -4566,24 +4751,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/openai": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
@@ -4618,38 +4785,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4680,47 +4815,11 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
-    },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4730,22 +4829,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -4764,12 +4847,6 @@
       "engines": {
         "node": ">= 14.16"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4820,101 +4897,27 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -5137,60 +5140,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5212,12 +5161,14 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5271,6 +5222,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5280,6 +5232,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5292,6 +5245,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -5347,38 +5301,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5481,27 +5408,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5563,24 +5469,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/token-types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@borewit/text-codec": "^0.2.1",
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5620,9 +5508,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.33.tgz",
-      "integrity": "sha512-+/MWwlQ1q2GSVwoxi/+u5JsHkgLQKcCN2Nsjree9c+K7GJu40qbaHrFETmfV1i9Fs1TcOVfynW+jJvIWcXtvjw==",
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -5639,45 +5527,11 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -5936,23 +5790,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -5995,37 +5832,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6043,19 +5853,10 @@
         }
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -6067,59 +5868,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   },
   "dependencies": {
     "@grammyjs/auto-retry": "^2.0.2",
-    "@mariozechner/pi-coding-agent": "0.70.2",
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
     "grammy": "^1.35.0",
     "minimatch": "^10.2.4"
   },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,71 +1,75 @@
 import { readFile, unlink } from "node:fs/promises";
-
-import { InlineKeyboard, Bot, type Context } from "grammy";
+import type { ImageContent } from "@earendil-works/pi-ai";
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import { autoRetry } from "@grammyjs/auto-retry";
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
-import type { ImageContent } from "@mariozechner/pi-ai";
-
+import { Bot, type Context, InlineKeyboard } from "grammy";
+import {
+	COMMAND_MENU_CALLBACK_PREFIX,
+	isStaleCallbackQueryError,
+	logCallbackQueryError,
+} from "./bot/callback-query-logging.js";
+import { createBotChatState } from "./bot/chat-state.js";
+import { createChatTaskRunner } from "./bot/chat-task-runner.js";
+import {
+	createCommandPickerHandlers,
+	type PendingCommandPicker,
+} from "./bot/command-picker.js";
+import { createBasicCommandHandlers } from "./bot/commands/basic.js";
+import { createContextCommandHandlers } from "./bot/commands/context.js";
+import { createModelCommandHandlers } from "./bot/commands/model.js";
+import { createSessionCommandHandlers } from "./bot/commands/sessions.js";
+import { createTreeCommandHandlers } from "./bot/commands/tree.js";
+import { createExtensionDialogManager } from "./bot/extension-dialogs.js";
+import {
+	appendKeyboardItems,
+	KEYBOARD_PAGE_SIZE,
+	type KeyboardItem,
+	NOOP_PAGE_CALLBACK_DATA,
+	paginateKeyboard,
+} from "./bot/keyboard.js";
+import {
+	isMessageNotModifiedError,
+	renderFailedText,
+	renderPrefixedError,
+	renderSessionInfoHTML,
+	renderSessionInfoPlain,
+} from "./bot/message-rendering.js";
+import { createPromptHandler } from "./bot/prompt-handler.js";
+import { startPromptInboxPolling } from "./bot/prompt-inbox.js";
+import {
+	buildChatScopedCommandSignature,
+	buildChatScopedCommands,
+	getTelepiNativeCommandMenu,
+	normalizeSlashCommand,
+	rewriteSlashCommandForTelegram,
+	TELEPI_BOT_COMMANDS,
+	TELEPI_LOCAL_COMMAND_NAMES,
+	type TelepiNativeCommandMenu,
+} from "./bot/slash-command.js";
+import {
+	downloadTelegramFile,
+	getTelegramTarget,
+	safeEditMessage,
+	safeReply,
+	sendChatAction,
+	sendTextMessage,
+} from "./bot/telegram-transport.js";
+import {
+	type PendingTreeView,
+	registerTreeCallbacks,
+} from "./bot/tree-callbacks.js";
 import type { TelePiConfig } from "./config.js";
 import { formatError } from "./errors.js";
 import { escapeHTML } from "./format.js";
 import {
-  isMessageNotModifiedError,
-  renderFailedText,
-  renderPrefixedError,
-  renderSessionInfoHTML,
-  renderSessionInfoPlain,
-} from "./bot/message-rendering.js";
-import {
-  appendKeyboardItems,
-  paginateKeyboard,
-  type KeyboardItem,
-  KEYBOARD_PAGE_SIZE,
-  NOOP_PAGE_CALLBACK_DATA,
-} from "./bot/keyboard.js";
-import {
-  buildChatScopedCommands,
-  buildChatScopedCommandSignature,
-  getTelepiNativeCommandMenu,
-  normalizeSlashCommand,
-  rewriteSlashCommandForTelegram,
-  TELEPI_BOT_COMMANDS,
-  TELEPI_LOCAL_COMMAND_NAMES,
-  type TelepiNativeCommandMenu,
-} from "./bot/slash-command.js";
-import {
-  downloadTelegramFile,
-  getTelegramTarget,
-  safeEditMessage,
-  safeReply,
-  sendChatAction,
-  sendTextMessage,
-} from "./bot/telegram-transport.js";
-import { createExtensionDialogManager } from "./bot/extension-dialogs.js";
-import { createBotChatState } from "./bot/chat-state.js";
-import { createChatTaskRunner } from "./bot/chat-task-runner.js";
-import {
-  COMMAND_MENU_CALLBACK_PREFIX,
-  isStaleCallbackQueryError,
-  logCallbackQueryError,
-} from "./bot/callback-query-logging.js";
-import { createPromptHandler } from "./bot/prompt-handler.js";
-import { startPromptInboxPolling } from "./bot/prompt-inbox.js";
-import { createCommandPickerHandlers, type PendingCommandPicker } from "./bot/command-picker.js";
-import { createBasicCommandHandlers } from "./bot/commands/basic.js";
-import { createSessionCommandHandlers } from "./bot/commands/sessions.js";
-import { createContextCommandHandlers } from "./bot/commands/context.js";
-import { createModelCommandHandlers } from "./bot/commands/model.js";
-import { createTreeCommandHandlers } from "./bot/commands/tree.js";
-import { registerTreeCallbacks, type PendingTreeView } from "./bot/tree-callbacks.js";
-import {
-  type PiSessionContext,
-  type PiSessionInfo,
-  getPiSessionContextKey,
-  type PiSessionModelOption,
-  type PiSessionRegistry,
-  type PiSessionService,
+	getPiSessionContextKey,
+	type PiSessionContext,
+	type PiSessionInfo,
+	type PiSessionModelOption,
+	type PiSessionRegistry,
+	type PiSessionService,
 } from "./pi-session.js";
-import { truncateText, type TreeFilterMode } from "./tree.js";
+import { type TreeFilterMode, truncateText } from "./tree.js";
 import { getVoiceBackendStatus, transcribeAudio } from "./voice.js";
 
 const EDIT_DEBOUNCE_MS = 1500;
@@ -74,1242 +78,1504 @@ const EXTENSION_UI_TIMEOUT_MS = 60_000;
 const DEFAULT_IMAGE_PROMPT = "Please analyze this image.";
 
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png",
-  ".webp": "image/webp",
-  ".gif": "image/gif",
-  ".bmp": "image/bmp",
-  ".tiff": "image/tiff",
-  ".tif": "image/tiff",
-  ".heic": "image/heic",
-  ".heif": "image/heif",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png": "image/png",
+	".webp": "image/webp",
+	".gif": "image/gif",
+	".bmp": "image/bmp",
+	".tiff": "image/tiff",
+	".tif": "image/tiff",
+	".heic": "image/heic",
+	".heif": "image/heif",
 };
 
 type TelegramChatId = number | string;
 type ContextKey = string;
 
 function selectPhotoFileId(
-  photos: Array<{ file_id: string; file_size?: number }> | undefined,
+	photos: Array<{ file_id: string; file_size?: number }> | undefined,
 ): string | undefined {
-  if (!photos || photos.length === 0) {
-    return undefined;
-  }
+	if (!photos || photos.length === 0) {
+		return undefined;
+	}
 
-  let selected = photos[photos.length - 1];
-  for (const candidate of photos) {
-    if (candidate.file_size !== undefined && (selected.file_size === undefined || candidate.file_size > selected.file_size)) {
-      selected = candidate;
-    }
-  }
+	let selected = photos[photos.length - 1];
+	for (const candidate of photos) {
+		if (
+			candidate.file_size !== undefined &&
+			(selected.file_size === undefined ||
+				candidate.file_size > selected.file_size)
+		) {
+			selected = candidate;
+		}
+	}
 
-  return selected?.file_id;
+	return selected?.file_id;
 }
 
-function resolveImageMimeType(filePath: string, explicitMimeType?: string): string {
-  const normalizedMimeType = explicitMimeType?.trim().toLowerCase();
-  if (normalizedMimeType?.startsWith("image/")) {
-    return normalizedMimeType;
-  }
+function resolveImageMimeType(
+	filePath: string,
+	explicitMimeType?: string,
+): string {
+	const normalizedMimeType = explicitMimeType?.trim().toLowerCase();
+	if (normalizedMimeType?.startsWith("image/")) {
+		return normalizedMimeType;
+	}
 
-  const extensionIndex = filePath.lastIndexOf(".");
-  const extension = extensionIndex >= 0 ? filePath.slice(extensionIndex).toLowerCase() : "";
-  return IMAGE_MIME_BY_EXTENSION[extension] ?? "image/jpeg";
+	const extensionIndex = filePath.lastIndexOf(".");
+	const extension =
+		extensionIndex >= 0 ? filePath.slice(extensionIndex).toLowerCase() : "";
+	return IMAGE_MIME_BY_EXTENSION[extension] ?? "image/jpeg";
 }
 
-export function createBot(config: TelePiConfig, sessionRegistry: PiSessionRegistry): Bot<Context> {
-  const bot = new Bot<Context>(config.telegramBotToken);
-  bot.api.config.use(autoRetry({ maxRetryAttempts: 3, maxDelaySeconds: 10 }));
-
-  const chatState = createBotChatState();
-
-  const pendingSessionPicks = new Map<ContextKey, Array<{ path: string; cwd: string }>>();
-  const pendingSessionButtons = new Map<ContextKey, KeyboardItem[]>();
-  const pendingWorkspacePicks = new Map<ContextKey, string[]>();
-  const pendingWorkspaceButtons = new Map<ContextKey, KeyboardItem[]>();
-  const pendingModelPicks = new Map<ContextKey, PiSessionModelOption[]>();
-  const pendingModelButtons = new Map<ContextKey, KeyboardItem[]>();
-  const pendingModelExtraButtons = new Map<ContextKey, KeyboardItem[]>();
-  const pendingTreeNavs = new Map<ContextKey, string>();
-  const pendingTreeViews = new Map<ContextKey, PendingTreeView>();
-  const pendingBranchButtons = new Map<ContextKey, KeyboardItem[]>();
-  const pendingCommandPickers = new Map<ContextKey, PendingCommandPicker>();
-  const pendingCommandMenus = new Map<ContextKey, Map<string, { commandText: string }>>();
-  const surfacedStartupErrorSignatures = new Map<ContextKey, string>();
-  const chatScopedCommandSignatures = new Map<TelegramChatId, string>();
-  let nextCommandMenuToken = 0;
-
-  const getContextKey = (target: PiSessionContext): ContextKey => getPiSessionContextKey(target);
-  const getExistingSession = (target: PiSessionContext): PiSessionService | undefined => sessionRegistry.get(target);
-  const getOrCreateSession = async (target: PiSessionContext): Promise<PiSessionService> =>
-    sessionRegistry.getOrCreate(target);
-
-  const extensionDialogs = createExtensionDialogManager({
-    getContextKey,
-    sendTextMessage: (target, text, options) => sendTextMessage(bot.api, target, text, options),
-    editMessage: (target, messageId, text, options) => safeEditMessage(bot, target, messageId, text, options),
-    defaultTimeoutMs: EXTENSION_UI_TIMEOUT_MS,
-  });
-
-  const answerCallbackQuerySafely = async (
-    ctx: Context,
-    options?: Parameters<Context["answerCallbackQuery"]>[0],
-    logOptions?: { source?: string },
-  ): Promise<void> => {
-    const responseText = typeof options === "object" && options !== null && "text" in options
-      ? options.text
-      : undefined;
-
-    try {
-      await ctx.answerCallbackQuery(options);
-    } catch (error) {
-      logCallbackQueryError(ctx, error, {
-        phase: "answer",
-        source: logOptions?.source,
-        responseText,
-      });
-    }
-  };
-
-  const buildKeyboard = (
-    items: KeyboardItem[],
-    page: number,
-    prefix: string,
-    extraItems: KeyboardItem[] = [],
-  ): InlineKeyboard => {
-    const { keyboard } = paginateKeyboard(items, page, prefix);
-    return appendKeyboardItems(keyboard, extraItems);
-  };
-
-  const syncChatScopedCommands = async (
-    target: PiSessionContext,
-    slashCommands: SlashCommandInfo[],
-  ): Promise<void> => {
-    const commands = buildChatScopedCommands(slashCommands);
-    const signature = buildChatScopedCommandSignature(commands);
-    const previousSignature = chatScopedCommandSignatures.get(target.chatId);
-    if (signature === previousSignature) {
-      return;
-    }
-
-    // Telegram command scopes are chat-scoped, not topic-scoped, so messageThreadId
-    // is intentionally ignored here. In forum chats, the most recently synced topic wins.
-    await bot.api.setMyCommands(commands, {
-      scope: {
-        type: "chat",
-        chat_id: target.chatId,
-      },
-    });
-    chatScopedCommandSignatures.set(target.chatId, signature);
-  };
-
-  const refreshChatScopedCommands = async (
-    target: PiSessionContext,
-    piSession: PiSessionService,
-  ): Promise<void> => {
-    try {
-      const slashCommands = await piSession.listSlashCommands();
-      await syncChatScopedCommands(target, slashCommands);
-    } catch (error) {
-      console.error("Failed to sync chat-scoped Telegram commands", error);
-    }
-  };
-
-  const setPendingTreeView = (contextKey: ContextKey, mode: TreeFilterMode): void => {
-    pendingTreeViews.set(contextKey, { mode });
-  };
-
-  const clearPendingTreeView = (contextKey: ContextKey): void => {
-    pendingTreeViews.delete(contextKey);
-  };
-
-  const buildTreeKeyboard = (items: KeyboardItem[]): InlineKeyboard => {
-    const keyboard = new InlineKeyboard();
-    const navButtons = items.filter((button) => button.callbackData.startsWith("tree_nav_"));
-    const pageButtons = items.filter(
-      (button) => button.callbackData === NOOP_PAGE_CALLBACK_DATA || button.callbackData.startsWith("tree_page_"),
-    );
-    const filterButtons = items.filter((button) => button.callbackData.startsWith("tree_mode_"));
-
-    for (const button of navButtons) {
-      keyboard.text(button.label, button.callbackData).row();
-    }
-
-    if (pageButtons.length > 0) {
-      for (const button of pageButtons) {
-        keyboard.text(button.label, button.callbackData);
-      }
-      keyboard.row();
-    }
-
-    if (filterButtons.length > 0) {
-      for (const button of filterButtons) {
-        keyboard.text(button.label, button.callbackData);
-      }
-      keyboard.row();
-    }
-
-    return keyboard;
-  };
-
-  const createCommandMenuToken = (): string => {
-    nextCommandMenuToken += 1;
-    return nextCommandMenuToken.toString(36);
-  };
-
-  const openNativeCommandMenu = async (
-    ctx: Context,
-    target: PiSessionContext,
-    menu: TelepiNativeCommandMenu,
-  ): Promise<void> => {
-    const contextKey = getContextKey(target);
-    const keyboard = new InlineKeyboard();
-    const actions = new Map<string, { commandText: string }>();
-
-    menu.entries.forEach((entry, index) => {
-      const token = createCommandMenuToken();
-      actions.set(token, {
-        commandText: entry.commandText,
-      });
-      keyboard.text(entry.label, `${COMMAND_MENU_CALLBACK_PREFIX}${token}`);
-      if (index % 2 === 1 && index < menu.entries.length - 1) {
-        keyboard.row();
-      }
-    });
-
-    pendingCommandMenus.set(contextKey, actions);
-
-    await safeReply(
-      ctx,
-      `<b>${escapeHTML(menu.title)}</b>\nChoose a command to run:`,
-      {
-        fallbackText: `${menu.title}\nChoose a command to run:`,
-        replyMarkup: keyboard,
-      },
-      target,
-    );
-  };
-
-  const clearContextPickers = (contextKey: ContextKey): void => {
-    pendingSessionPicks.delete(contextKey);
-    pendingSessionButtons.delete(contextKey);
-    pendingWorkspacePicks.delete(contextKey);
-    pendingWorkspaceButtons.delete(contextKey);
-    pendingModelPicks.delete(contextKey);
-    pendingModelButtons.delete(contextKey);
-    pendingModelExtraButtons.delete(contextKey);
-    pendingTreeNavs.delete(contextKey);
-    pendingTreeViews.delete(contextKey);
-    pendingBranchButtons.delete(contextKey);
-    pendingCommandPickers.delete(contextKey);
-    pendingCommandMenus.delete(contextKey);
-    surfacedStartupErrorSignatures.delete(contextKey);
-  };
-
-  const clearContextPromptMemory = (target: PiSessionContext): void => {
-    chatState.clearPromptMemory(target);
-  };
-
-  const surfaceStartupErrorDiagnostics = async (
-    ctx: Context,
-    target: PiSessionContext,
-    info: PiSessionInfo,
-  ): Promise<void> => {
-    const contextKey = getContextKey(target);
-    const errors = info.diagnostics?.filter((diagnostic) => diagnostic.type === "error") ?? [];
-    if (errors.length === 0) {
-      surfacedStartupErrorSignatures.delete(contextKey);
-      return;
-    }
-
-    const signature = `${info.sessionId}:${errors.map((diagnostic) => diagnostic.message).join("\n")}`;
-    if (surfacedStartupErrorSignatures.get(contextKey) === signature) {
-      return;
-    }
-
-    surfacedStartupErrorSignatures.set(contextKey, signature);
-    const plainText = ["Session startup issues:", ...errors.map((diagnostic) => `- ${diagnostic.message}`)].join("\n");
-    const html = ["<b>Session startup issues:</b>", ...errors.map((diagnostic) => `• ${escapeHTML(diagnostic.message)}`)].join("\n");
-    await safeReply(ctx, html, { fallbackText: plainText }, target);
-  };
-
-  const isBusy = (target: PiSessionContext): boolean => {
-    const piSession = getExistingSession(target);
-    return chatState.isLocallyBusy(target) || piSession?.isStreaming() === true;
-  };
-
-  const sendBusyReply = async (ctx: Context): Promise<void> => {
-    const target = getTelegramTarget(ctx);
-    const pendingDialogKind = target ? extensionDialogs.getPendingKind(target) : undefined;
-    const message = pendingDialogKind === "input"
-      ? "Please answer the pending prompt above or use /abort."
-      : pendingDialogKind
-        ? "Please answer the pending dialog above."
-        : "Still working on previous message...";
-    await safeReply(ctx, escapeHTML(message), {
-      fallbackText: message,
-    }, target);
-  };
-
-  const ensureActiveSession = async (ctx: Context, target: PiSessionContext): Promise<PiSessionService | undefined> => {
-    const existing = getExistingSession(target);
-    const hadActiveSession = existing?.hasActiveSession() === true;
-    if (hadActiveSession) {
-      return existing;
-    }
-
-    try {
-      const piSession = existing ?? (await getOrCreateSession(target));
-      if (!piSession.hasActiveSession()) {
-        await piSession.newSession();
-      }
-      await surfaceStartupErrorDiagnostics(ctx, target, piSession.getInfo());
-      return piSession;
-    } catch (error) {
-      const failure = renderPrefixedError("Failed to create session", error);
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-      return undefined;
-    }
-  };
-
-  const handlePageCallback = (
-    pattern: RegExp,
-    prefix: string,
-    buttonsMap: Map<ContextKey, KeyboardItem[]>,
-    expiredMessage: string,
-    extraButtonsMap?: Map<ContextKey, KeyboardItem[]>,
-  ): void => {
-    bot.callbackQuery(pattern, async (ctx) => {
-      const target = getTelegramTarget(ctx);
-      const messageId = ctx.callbackQuery.message?.message_id;
-      const page = Number.parseInt(ctx.match?.[1] ?? "", 10);
-
-      if (!target || !messageId || Number.isNaN(page)) {
-        return;
-      }
-
-      const contextKey = getContextKey(target);
-      const buttons = buttonsMap.get(contextKey);
-      if (!buttons) {
-        await ctx.answerCallbackQuery({ text: expiredMessage });
-        return;
-      }
-
-      await ctx.answerCallbackQuery();
-
-      try {
-        const keyboard = buildKeyboard(buttons, page, prefix, extraButtonsMap?.get(contextKey) ?? []);
-        await bot.api.editMessageReplyMarkup(target.chatId, messageId, { reply_markup: keyboard });
-      } catch (error) {
-        if (!isMessageNotModifiedError(error)) {
-          console.error(`Failed to update ${prefix} keyboard page`, error);
-        }
-      }
-    });
-  };
-
-  bot.use(async (ctx, next) => {
-    const fromId = ctx.from?.id;
-    if (!fromId || !config.telegramAllowedUserIdSet.has(fromId)) {
-      if (ctx.callbackQuery) {
-        await ctx.answerCallbackQuery({ text: "Unauthorized" }).catch(() => {});
-      } else if (ctx.chat) {
-        await safeReply(ctx, escapeHTML("Unauthorized"), { fallbackText: "Unauthorized" });
-      }
-      return;
-    }
-
-    await next();
-  });
-
-  const chatTaskRunner = createChatTaskRunner({
-    beginProcessing: (target, promptText) => chatState.beginProcessing(target, promptText),
-    endProcessing: (target) => chatState.endProcessing(target),
-    onTaskError: (error, target, promptText) => {
-      console.error(
-        "Detached prompt task failed",
-        JSON.stringify({
-          contextKey: getPiSessionContextKey(target),
-          promptText,
-          error: formatError(error),
-        }),
-      );
-    },
-  });
-
-  const handleUserPrompt = createPromptHandler({
-    bot,
-    toolVerbosity: config.toolVerbosity,
-    editDebounceMs: EDIT_DEBOUNCE_MS,
-    typingIntervalMs: TYPING_INTERVAL_MS,
-    isBusy,
-    taskRunner: chatTaskRunner,
-    ensureActiveSession,
-    syncChatScopedCommands,
-    refreshChatScopedCommands,
-    extensionDialogs,
-    sendBusyReply,
-  });
-
-  if (config.promptInboxDir) {
-    const target: PiSessionContext = { chatId: config.telegramAllowedUserIds[0] };
-    const stopPromptInboxPolling = startPromptInboxPolling({
-      inboxDir: config.promptInboxDir,
-      intervalMs: config.promptInboxIntervalMs,
-      target,
-      isBusy,
-      handlePrompt: async (promptTarget, prompt) =>
-        await handleUserPrompt({ api: bot.api } as Context, promptTarget, prompt),
-      onError: (error) => {
-        console.error("Prompt inbox polling failed", error);
-      },
-    });
-    const stopBot = bot.stop.bind(bot);
-    bot.stop = (...args: Parameters<typeof bot.stop>): ReturnType<typeof bot.stop> => {
-      stopPromptInboxPolling();
-      return stopBot(...args);
-    };
-  }
-
-  const commandPickerHandlers = createCommandPickerHandlers({
-    bot,
-    pendingCommandPickers,
-    getTelegramTarget,
-    getContextKey,
-    getOrCreateSession,
-    syncChatScopedCommands,
-    isBusy,
-    handleUserPrompt,
-    runTelePiPickerCommand,
-    safeReply,
-    safeEditMessage: (target, messageId, text, options) => safeEditMessage(bot, target, messageId, text, options),
-    sendTextMessage: (ctx, target, text, options) => sendTextMessage(ctx.api, target, text, options),
-  });
-  const { openCommandPicker } = commandPickerHandlers;
-
-  const basicCommandHandlers = createBasicCommandHandlers({
-    sessionRegistry,
-    getExistingSession,
-    getOrCreateSession,
-    refreshChatScopedCommands,
-    openCommandPicker,
-    handleUserPrompt,
-    getLastPrompt: (target) => chatState.getLastPrompt(target),
-    extensionDialogs,
-    getVoiceBackendStatus,
-    safeReply,
-  });
-  const {
-    handleStartCommand,
-    handleHelpCommand,
-    handleCommandsCommand,
-    handleAbortCommand,
-    handleSessionCommand,
-    handleRetryCommand,
-  } = basicCommandHandlers;
-
-  const contextCommandHandlers = createContextCommandHandlers({
-    getExistingSession,
-    safeReply,
-  });
-  const { handleContextCommand } = contextCommandHandlers;
-
-  const sessionCommandHandlers = createSessionCommandHandlers({
-    getContextKey,
-    getOrCreateSession,
-    getExistingSession,
-    isBusy,
-    beginSwitching: (target) => chatState.beginSwitching(target),
-    endSwitching: (target) => chatState.endSwitching(target),
-    buildKeyboard,
-    clearContextPickers,
-    clearContextPromptMemory,
-    refreshChatScopedCommands,
-    syncChatScopedCommands,
-    setChatCommandSignature: (chatId, signature) => {
-      if (signature === undefined) {
-        chatScopedCommandSignatures.delete(chatId);
-      } else {
-        chatScopedCommandSignatures.set(chatId, signature);
-      }
-    },
-    removeSession: (target) => sessionRegistry.remove(target),
-    pendingSessionPicks,
-    pendingSessionButtons,
-    pendingWorkspacePicks,
-    pendingWorkspaceButtons,
-    safeReply,
-    surfaceStartupErrorDiagnostics,
-  });
-  const { handleSessionsCommand, handleNewCommand, handleHandbackCommand } = sessionCommandHandlers;
-
-  const modelCommandHandlers = createModelCommandHandlers({
-    getContextKey,
-    getExistingSession,
-    getOrCreateSession,
-    isBusy,
-    refreshChatScopedCommands,
-    pendingModelPicks,
-    pendingModelButtons,
-    pendingModelExtraButtons,
-    buildKeyboard,
-    safeReply,
-    safeEditMessage: (target, messageId, text, options) => safeEditMessage(bot, target, messageId, text, options),
-    surfaceStartupErrorDiagnostics,
-  });
-  const { renderModelPicker, handleModelCommand } = modelCommandHandlers;
-
-  const treeCommandHandlers = createTreeCommandHandlers({
-    getContextKey,
-    getExistingSession,
-    isBusy,
-    pendingTreeNavs,
-    pendingBranchButtons,
-    clearPendingTreeView,
-    setPendingTreeView,
-    buildTreeKeyboard,
-    buildKeyboard,
-    safeReply,
-  });
-  const { collectLabelsMap, handleTreeCommand, handleBranchCommand, handleLabelCommand } = treeCommandHandlers;
-
-  async function runTelePiPickerCommand(
-    ctx: Context,
-    target: PiSessionContext,
-    command: string,
-  ): Promise<void> {
-    switch (command) {
-      case "start":
-        await handleStartCommand(ctx, target);
-        return;
-      case "help":
-        await handleHelpCommand(ctx, target);
-        return;
-      case "abort":
-        await handleAbortCommand(ctx, target);
-        return;
-      case "session":
-        await handleSessionCommand(ctx, target);
-        return;
-      case "sessions":
-        await handleSessionsCommand(ctx, target, "/sessions");
-        return;
-      case "new":
-        await handleNewCommand(ctx, target);
-        return;
-      case "handback":
-        await handleHandbackCommand(ctx, target);
-        return;
-      case "context":
-        await handleContextCommand(ctx, target);
-        return;
-      case "model":
-        await handleModelCommand(ctx, target);
-        return;
-      case "tree":
-        await handleTreeCommand(ctx, target, "/tree");
-        return;
-      case "branch":
-        await safeReply(ctx, escapeHTML("Use /branch <entry-id> with an ID from /tree."), {
-          fallbackText: "Use /branch <entry-id> with an ID from /tree.",
-        }, target);
-        return;
-      case "label":
-        await handleLabelCommand(ctx, target, "/label");
-        return;
-      case "retry":
-        await handleRetryCommand(ctx, target);
-        return;
-      default:
-        await safeReply(ctx, escapeHTML(`Command not available from picker: /${command}`), {
-          fallbackText: `Command not available from picker: /${command}`,
-        }, target);
-        return;
-    }
-  }
-
-  bot.command("start", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleStartCommand(ctx, target);
-  });
-
-  bot.command("help", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleHelpCommand(ctx, target);
-  });
-
-  bot.command("commands", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleCommandsCommand(ctx, target);
-  });
-
-  bot.command("abort", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleAbortCommand(ctx, target);
-  });
-
-  bot.command("session", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleSessionCommand(ctx, target);
-  });
-
-  bot.command(["sessions", "switch"], async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleSessionsCommand(ctx, target);
-  });
-
-  bot.command("new", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleNewCommand(ctx, target);
-  });
-
-  bot.command("handback", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleHandbackCommand(ctx, target);
-  });
-
-  bot.command("context", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleContextCommand(ctx, target);
-  });
-
-  bot.command("model", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleModelCommand(ctx, target);
-  });
-
-  bot.command("tree", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleTreeCommand(ctx, target);
-  });
-
-  bot.command("branch", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleBranchCommand(ctx, target);
-  });
-
-  bot.command("label", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleLabelCommand(ctx, target);
-  });
-
-  bot.command("retry", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    await handleRetryCommand(ctx, target);
-  });
-
-  bot.callbackQuery("pi_abort", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    await ctx.answerCallbackQuery({ text: "Aborting..." });
-    if (!target) {
-      return;
-    }
-
-    await getExistingSession(target)?.abort();
-  });
-
-  bot.callbackQuery(NOOP_PAGE_CALLBACK_DATA, async (ctx) => {
-    await ctx.answerCallbackQuery();
-  });
-
-  bot.callbackQuery(/^ui_sel_([a-z0-9]+)_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const dialogId = ctx.match?.[1];
-    const optionIndex = Number.parseInt(ctx.match?.[2] ?? "", 10);
-    if (!target || !dialogId || Number.isNaN(optionIndex)) {
-      return;
-    }
-
-    const result = await extensionDialogs.resolveSelect(
-      target,
-      dialogId,
-      ctx.callbackQuery.message?.message_id,
-      optionIndex,
-    );
-    await answerCallbackQuerySafely(ctx, { text: result.callbackText }, { source: "extension.select" });
-    await result.afterAnswer?.();
-  });
-
-  bot.callbackQuery(/^ui_cfm_([a-z0-9]+)_(yes|no)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const dialogId = ctx.match?.[1];
-    const answer = ctx.match?.[2];
-    if (!target || !dialogId || !answer) {
-      return;
-    }
-
-    const result = await extensionDialogs.resolveConfirm(
-      target,
-      dialogId,
-      ctx.callbackQuery.message?.message_id,
-      answer === "yes",
-    );
-    await answerCallbackQuerySafely(ctx, { text: result.callbackText }, { source: "extension.confirm" });
-    await result.afterAnswer?.();
-  });
-
-  bot.callbackQuery(/^ui_x_([a-z0-9]+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const dialogId = ctx.match?.[1];
-    if (!target || !dialogId) {
-      return;
-    }
-
-    const result = await extensionDialogs.resolveCancel(
-      target,
-      dialogId,
-      ctx.callbackQuery.message?.message_id,
-    );
-    await answerCallbackQuerySafely(ctx, { text: result.callbackText }, { source: "extension.cancel" });
-    await result.afterAnswer?.();
-  });
-
-  bot.callbackQuery(/^cmdm_([a-z0-9]+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const token = ctx.match?.[1];
-    const logOptions = { source: "native.command-menu" };
-    if (!token) {
-      await answerCallbackQuerySafely(ctx, undefined, logOptions);
-      return;
-    }
-
-    if (!target) {
-      await answerCallbackQuerySafely(ctx, undefined, logOptions);
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const action = pendingCommandMenus.get(contextKey)?.get(token);
-    if (!action) {
-      await answerCallbackQuerySafely(ctx, { text: "Expired, run the slash command again" }, logOptions);
-      return;
-    }
-
-    if (isBusy(target)) {
-      await answerCallbackQuerySafely(ctx, { text: "Wait for the current prompt to finish" }, logOptions);
-      return;
-    }
-
-    await answerCallbackQuerySafely(ctx, { text: `Running ${action.commandText}` }, logOptions);
-    await handleUserPrompt(ctx, target, action.commandText);
-  });
-
-  handlePageCallback(/^switch_page_(\d+)$/, "switch", pendingSessionButtons, "Expired, run /sessions again");
-  handlePageCallback(/^newws_page_(\d+)$/, "newws", pendingWorkspaceButtons, "Expired, run /new again");
-  handlePageCallback(/^model_page_(\d+)$/, "model", pendingModelButtons, "Expired, run /model again", pendingModelExtraButtons);
-  handlePageCallback(/^branch_page_(\d+)$/, "branch", pendingBranchButtons, "Expired, run /branch again");
-
-  registerTreeCallbacks({
-    bot,
-    getTelegramTarget,
-    getContextKey,
-    getExistingSession,
-    isBusy,
-    beginSwitching: (target) => chatState.beginSwitching(target),
-    endSwitching: (target) => chatState.endSwitching(target),
-    pendingTreeViews,
-    pendingTreeNavs,
-    pendingBranchButtons,
-    setPendingTreeView,
-    clearPendingTreeView,
-    buildTreeKeyboard,
-    buildKeyboard,
-    collectLabelsMap,
-    safeReply,
-    safeEditMessage: (target, messageId, text, options) => safeEditMessage(bot, target, messageId, text, options),
-  });
-
-  bot.callbackQuery(/^switch_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
-
-    if (!target || Number.isNaN(index)) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const sessions = pendingSessionPicks.get(contextKey);
-    if (!sessions || !sessions[index]) {
-      await ctx.answerCallbackQuery({ text: "Session expired, run /sessions again" });
-      return;
-    }
-
-    if (isBusy(target)) {
-      await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
-      return;
-    }
-
-    const piSession = await getOrCreateSession(target);
-    await ctx.answerCallbackQuery({ text: "Switching..." });
-    pendingSessionPicks.delete(contextKey);
-    pendingSessionButtons.delete(contextKey);
-
-    chatState.beginSwitching(target);
-    try {
-      const resolvedSession = await piSession.resolveSessionReference(sessions[index].path);
-      const info = await piSession.switchSession(resolvedSession.path, resolvedSession.cwd);
-      if (info.cancelled) {
-        const cancelledText = "Session switch was cancelled.";
-        if (messageId) {
-          await safeEditMessage(bot, target, messageId, escapeHTML(cancelledText), {
-            fallbackText: cancelledText,
-          });
-          return;
-        }
-
-        await safeReply(ctx, escapeHTML(cancelledText), { fallbackText: cancelledText }, target);
-        return;
-      }
-
-      await refreshChatScopedCommands(target, piSession);
-      clearPendingTreeView(contextKey);
-      clearContextPromptMemory(target);
-      const workspaceNotePlain = resolvedSession.workspaceWarning
-        ? `\n\nWorkspace note: ${resolvedSession.workspaceWarning}`
-        : "";
-      const workspaceNoteHTML = resolvedSession.workspaceWarning
-        ? `\n\n<b>Workspace note:</b> ${escapeHTML(resolvedSession.workspaceWarning)}`
-        : "";
-      const plainText = `Switched!${workspaceNotePlain}\n\n${renderSessionInfoPlain(info)}`;
-      const html = `<b>Switched!</b>${workspaceNoteHTML}\n\n${renderSessionInfoHTML(info)}`;
-
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, html, { fallbackText: plainText });
-      } else {
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-      }
-
-      await surfaceStartupErrorDiagnostics(ctx, target, info);
-    } catch (error) {
-      const failure = renderFailedText(error);
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        });
-      } else {
-        await safeReply(ctx, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        }, target);
-      }
-    } finally {
-      chatState.endSwitching(target);
-    }
-  });
-
-  bot.callbackQuery(/^newws_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
-
-    if (!target || Number.isNaN(index)) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const workspaces = pendingWorkspacePicks.get(contextKey);
-    if (!workspaces || !workspaces[index]) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /new again" });
-      return;
-    }
-
-    if (isBusy(target)) {
-      await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
-      return;
-    }
-
-    const piSession = await getOrCreateSession(target);
-    await ctx.answerCallbackQuery({ text: "Creating session..." });
-    pendingWorkspacePicks.delete(contextKey);
-    pendingWorkspaceButtons.delete(contextKey);
-
-    chatState.beginSwitching(target);
-    try {
-      const { info, created } = await piSession.newSession(workspaces[index]);
-      if (!created) {
-        const html = escapeHTML("New session was cancelled.");
-        if (messageId) {
-          await safeEditMessage(bot, target, messageId, html, { fallbackText: "New session was cancelled." });
-        }
-        return;
-      }
-
-      await refreshChatScopedCommands(target, piSession);
-      clearPendingTreeView(contextKey);
-      clearContextPromptMemory(target);
-      const plainText = `New session created.\n\n${renderSessionInfoPlain(info)}`;
-      const html = `<b>New session created.</b>\n\n${renderSessionInfoHTML(info)}`;
-
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, html, { fallbackText: plainText });
-      } else {
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-      }
-
-      await surfaceStartupErrorDiagnostics(ctx, target, info);
-    } catch (error) {
-      const failure = renderFailedText(error);
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        });
-      } else {
-        await safeReply(ctx, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        }, target);
-      }
-    } finally {
-      chatState.endSwitching(target);
-    }
-  });
-
-  bot.callbackQuery("model_show_all", async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-
-    if (!target || !messageId) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const piSession = getExistingSession(target);
-    const models = pendingModelPicks.get(contextKey);
-    if (!models || models.length === 0 || !piSession) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /model again" });
-      return;
-    }
-
-    if (isBusy(target)) {
-      await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
-      return;
-    }
-
-    await ctx.answerCallbackQuery({ text: "Loading all models..." });
-    await renderModelPicker(ctx, target, piSession, { showAll: true, messageId });
-  });
-
-  bot.callbackQuery(/^model_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
-
-    if (!target || Number.isNaN(index)) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const piSession = getExistingSession(target);
-    const models = pendingModelPicks.get(contextKey);
-    if (!models || !models[index] || !piSession) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /model again" });
-      return;
-    }
-
-    if (isBusy(target)) {
-      await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
-      return;
-    }
-
-    await ctx.answerCallbackQuery({ text: "Switching model..." });
-    pendingModelPicks.delete(contextKey);
-    pendingModelButtons.delete(contextKey);
-    pendingModelExtraButtons.delete(contextKey);
-
-    chatState.beginSwitching(target);
-    try {
-      const modelName = await piSession.setModel(models[index].provider, models[index].id, models[index].thinkingLevel);
-      const html = `<b>Model switched to:</b> <code>${escapeHTML(modelName)}</code>`;
-      const plainText = `Model switched to: ${modelName}`;
-
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, html, { fallbackText: plainText });
-      } else {
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-      }
-    } catch (error) {
-      const failure = renderFailedText(error);
-      if (messageId) {
-        await safeEditMessage(bot, target, messageId, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        });
-        return;
-      }
-
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-    } finally {
-      chatState.endSwitching(target);
-    }
-  });
-
-  bot.on("message:text", async (ctx) => {
-    const userText = ctx.message.text.trim();
-    if (!userText) {
-      return;
-    }
-
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    const normalizedSlashCommand = normalizeSlashCommand(userText, bot.botInfo?.username);
-    if (normalizedSlashCommand && TELEPI_LOCAL_COMMAND_NAMES.has(normalizedSlashCommand.name)) {
-      return;
-    }
-    if (!normalizedSlashCommand && userText.startsWith("/")) {
-      return;
-    }
-
-    if (await extensionDialogs.consumeInput(target, userText)) {
-      return;
-    }
-
-    if (extensionDialogs.hasPending(target)) {
-      await safeReply(ctx, escapeHTML("Please answer the pending dialog above."), {
-        fallbackText: "Please answer the pending dialog above.",
-      }, target);
-      return;
-    }
-
-    if (normalizedSlashCommand) {
-      const piSession = await getOrCreateSession(target);
-      const slashCommands = await piSession.listSlashCommands();
-      void syncChatScopedCommands(target, slashCommands).catch((error) => {
-        console.error("Failed to sync chat-scoped Telegram commands", error);
-      });
-      const knownSlashCommands = new Set(slashCommands.map((command) => command.name));
-      if (!knownSlashCommands.has(normalizedSlashCommand.name)) {
-        await safeReply(ctx, escapeHTML("Unknown command. Use /commands to see available Pi slash commands."), {
-          fallbackText: "Unknown command. Use /commands to see available Pi slash commands.",
-        }, target);
-        return;
-      }
-
-      const nativeCommandMenu = getTelepiNativeCommandMenu(normalizedSlashCommand, slashCommands);
-      if (nativeCommandMenu) {
-        await openNativeCommandMenu(ctx, target, nativeCommandMenu);
-        return;
-      }
-
-      const commandText = rewriteSlashCommandForTelegram(normalizedSlashCommand, slashCommands);
-      await handleUserPrompt(ctx, target, commandText, slashCommands);
-      return;
-    }
-
-    await handleUserPrompt(ctx, target, userText);
-  });
-
-  bot.on(["message:photo", "message:document"], async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    if (isBusy(target)) {
-      await sendBusyReply(ctx);
-      return;
-    }
-
-    const photoFileId = selectPhotoFileId(ctx.message.photo as Array<{ file_id: string; file_size?: number }> | undefined);
-    const documentMimeType = ctx.message.document?.mime_type;
-    const isImageDocument = documentMimeType?.toLowerCase().startsWith("image/") ?? false;
-    const documentFileId = isImageDocument ? ctx.message.document?.file_id : undefined;
-    const fileId = photoFileId ?? documentFileId;
-    if (!fileId) {
-      return;
-    }
-
-    chatState.beginTranscribing(target);
-    let tempFilePath: string | undefined;
-    let promptText: string | undefined;
-    let images: ImageContent[] | undefined;
-
-    try {
-      await sendChatAction(ctx.api, target, "typing");
-      tempFilePath = await downloadTelegramFile(ctx.api, config.telegramBotToken, fileId, {
-        fileKind: "image file",
-        tempFilePrefix: "telepi-image",
-      });
-
-      const imageBytes = await readFile(tempFilePath);
-      const imageMimeType = resolveImageMimeType(tempFilePath, documentMimeType);
-      promptText = ctx.message.caption?.trim() || DEFAULT_IMAGE_PROMPT;
-      const preview = truncateText(promptText.replace(/\s+/g, " "), 240);
-      images = [{
-        type: "image",
-        data: imageBytes.toString("base64"),
-        mimeType: imageMimeType,
-      }];
-
-      await safeReply(
-        ctx,
-        `🖼️ ${escapeHTML(preview)}`,
-        { fallbackText: `🖼️ ${preview}` },
-        target,
-      );
-    } catch (error) {
-      const failure = renderPrefixedError("Image handling failed", error, true);
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-      return;
-    } finally {
-      chatState.endTranscribing(target);
-      if (tempFilePath) {
-        await unlink(tempFilePath).catch(() => {});
-      }
-    }
-
-    if (!promptText || !images) {
-      return;
-    }
-
-    await handleUserPrompt(ctx, target, promptText, undefined, images);
-  });
-
-  bot.on(["message:voice", "message:audio"], async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    if (!target) {
-      return;
-    }
-
-    const contextKey = getContextKey(target);
-    if (isBusy(target)) {
-      await sendBusyReply(ctx);
-      return;
-    }
-
-    const fileId = ctx.message.voice?.file_id ?? ctx.message.audio?.file_id;
-    if (!fileId) {
-      return;
-    }
-
-    chatState.beginTranscribing(target);
-    let tempFilePath: string | undefined;
-    let transcript: string | undefined;
-
-    try {
-      await sendChatAction(ctx.api, target, "typing");
-      tempFilePath = await downloadTelegramFile(ctx.api, config.telegramBotToken, fileId);
-
-      const result = await transcribeAudio(tempFilePath);
-      transcript = result.text.trim();
-      if (!transcript) {
-        await safeReply(ctx, escapeHTML("Transcription was empty. Please try again or send text instead."), {
-          fallbackText: "Transcription was empty. Please try again or send text instead.",
-        }, target);
-        return;
-      }
-
-      const preview = truncateText(transcript.replace(/\s+/g, " "), 240);
-      await safeReply(
-        ctx,
-        `🎤 ${escapeHTML(preview)} <i>(via ${escapeHTML(result.backend)})</i>`,
-        { fallbackText: `🎤 ${preview} (via ${result.backend})` },
-        target,
-      );
-    } catch (error) {
-      const failure = renderPrefixedError("Transcription failed", error, true);
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-      return;
-    } finally {
-      chatState.endTranscribing(target);
-      if (tempFilePath) {
-        await unlink(tempFilePath).catch(() => {});
-      }
-    }
-
-    if (!transcript) {
-      return;
-    }
-
-    await handleUserPrompt(ctx, target, transcript);
-  });
-
-  bot.catch((error) => {
-    if (error.ctx?.callbackQuery && isStaleCallbackQueryError(error.error)) {
-      logCallbackQueryError(error.ctx, error.error, { phase: "handler" });
-      return;
-    }
-
-    console.error("Telegram bot error:", formatError(error.error));
-  });
-
-  return bot;
+export function createBot(
+	config: TelePiConfig,
+	sessionRegistry: PiSessionRegistry,
+): Bot<Context> {
+	const bot = new Bot<Context>(config.telegramBotToken);
+	bot.api.config.use(autoRetry({ maxRetryAttempts: 3, maxDelaySeconds: 10 }));
+
+	const chatState = createBotChatState();
+
+	const pendingSessionPicks = new Map<
+		ContextKey,
+		Array<{ path: string; cwd: string }>
+	>();
+	const pendingSessionButtons = new Map<ContextKey, KeyboardItem[]>();
+	const pendingWorkspacePicks = new Map<ContextKey, string[]>();
+	const pendingWorkspaceButtons = new Map<ContextKey, KeyboardItem[]>();
+	const pendingModelPicks = new Map<ContextKey, PiSessionModelOption[]>();
+	const pendingModelButtons = new Map<ContextKey, KeyboardItem[]>();
+	const pendingModelExtraButtons = new Map<ContextKey, KeyboardItem[]>();
+	const pendingTreeNavs = new Map<ContextKey, string>();
+	const pendingTreeViews = new Map<ContextKey, PendingTreeView>();
+	const pendingBranchButtons = new Map<ContextKey, KeyboardItem[]>();
+	const pendingCommandPickers = new Map<ContextKey, PendingCommandPicker>();
+	const pendingCommandMenus = new Map<
+		ContextKey,
+		Map<string, { commandText: string }>
+	>();
+	const surfacedStartupErrorSignatures = new Map<ContextKey, string>();
+	const chatScopedCommandSignatures = new Map<TelegramChatId, string>();
+	let nextCommandMenuToken = 0;
+
+	const getContextKey = (target: PiSessionContext): ContextKey =>
+		getPiSessionContextKey(target);
+	const getExistingSession = (
+		target: PiSessionContext,
+	): PiSessionService | undefined => sessionRegistry.get(target);
+	const getOrCreateSession = async (
+		target: PiSessionContext,
+	): Promise<PiSessionService> => sessionRegistry.getOrCreate(target);
+
+	const extensionDialogs = createExtensionDialogManager({
+		getContextKey,
+		sendTextMessage: (target, text, options) =>
+			sendTextMessage(bot.api, target, text, options),
+		editMessage: (target, messageId, text, options) =>
+			safeEditMessage(bot, target, messageId, text, options),
+		defaultTimeoutMs: EXTENSION_UI_TIMEOUT_MS,
+	});
+
+	const answerCallbackQuerySafely = async (
+		ctx: Context,
+		options?: Parameters<Context["answerCallbackQuery"]>[0],
+		logOptions?: { source?: string },
+	): Promise<void> => {
+		const responseText =
+			typeof options === "object" && options !== null && "text" in options
+				? options.text
+				: undefined;
+
+		try {
+			await ctx.answerCallbackQuery(options);
+		} catch (error) {
+			logCallbackQueryError(ctx, error, {
+				phase: "answer",
+				source: logOptions?.source,
+				responseText,
+			});
+		}
+	};
+
+	const buildKeyboard = (
+		items: KeyboardItem[],
+		page: number,
+		prefix: string,
+		extraItems: KeyboardItem[] = [],
+	): InlineKeyboard => {
+		const { keyboard } = paginateKeyboard(items, page, prefix);
+		return appendKeyboardItems(keyboard, extraItems);
+	};
+
+	const syncChatScopedCommands = async (
+		target: PiSessionContext,
+		slashCommands: SlashCommandInfo[],
+	): Promise<void> => {
+		const commands = buildChatScopedCommands(slashCommands);
+		const signature = buildChatScopedCommandSignature(commands);
+		const previousSignature = chatScopedCommandSignatures.get(target.chatId);
+		if (signature === previousSignature) {
+			return;
+		}
+
+		// Telegram command scopes are chat-scoped, not topic-scoped, so messageThreadId
+		// is intentionally ignored here. In forum chats, the most recently synced topic wins.
+		await bot.api.setMyCommands(commands, {
+			scope: {
+				type: "chat",
+				chat_id: target.chatId,
+			},
+		});
+		chatScopedCommandSignatures.set(target.chatId, signature);
+	};
+
+	const refreshChatScopedCommands = async (
+		target: PiSessionContext,
+		piSession: PiSessionService,
+	): Promise<void> => {
+		try {
+			const slashCommands = await piSession.listSlashCommands();
+			await syncChatScopedCommands(target, slashCommands);
+		} catch (error) {
+			console.error("Failed to sync chat-scoped Telegram commands", error);
+		}
+	};
+
+	const setPendingTreeView = (
+		contextKey: ContextKey,
+		mode: TreeFilterMode,
+	): void => {
+		pendingTreeViews.set(contextKey, { mode });
+	};
+
+	const clearPendingTreeView = (contextKey: ContextKey): void => {
+		pendingTreeViews.delete(contextKey);
+	};
+
+	const buildTreeKeyboard = (items: KeyboardItem[]): InlineKeyboard => {
+		const keyboard = new InlineKeyboard();
+		const navButtons = items.filter((button) =>
+			button.callbackData.startsWith("tree_nav_"),
+		);
+		const pageButtons = items.filter(
+			(button) =>
+				button.callbackData === NOOP_PAGE_CALLBACK_DATA ||
+				button.callbackData.startsWith("tree_page_"),
+		);
+		const filterButtons = items.filter((button) =>
+			button.callbackData.startsWith("tree_mode_"),
+		);
+
+		for (const button of navButtons) {
+			keyboard.text(button.label, button.callbackData).row();
+		}
+
+		if (pageButtons.length > 0) {
+			for (const button of pageButtons) {
+				keyboard.text(button.label, button.callbackData);
+			}
+			keyboard.row();
+		}
+
+		if (filterButtons.length > 0) {
+			for (const button of filterButtons) {
+				keyboard.text(button.label, button.callbackData);
+			}
+			keyboard.row();
+		}
+
+		return keyboard;
+	};
+
+	const createCommandMenuToken = (): string => {
+		nextCommandMenuToken += 1;
+		return nextCommandMenuToken.toString(36);
+	};
+
+	const openNativeCommandMenu = async (
+		ctx: Context,
+		target: PiSessionContext,
+		menu: TelepiNativeCommandMenu,
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
+		const keyboard = new InlineKeyboard();
+		const actions = new Map<string, { commandText: string }>();
+
+		menu.entries.forEach((entry, index) => {
+			const token = createCommandMenuToken();
+			actions.set(token, {
+				commandText: entry.commandText,
+			});
+			keyboard.text(entry.label, `${COMMAND_MENU_CALLBACK_PREFIX}${token}`);
+			if (index % 2 === 1 && index < menu.entries.length - 1) {
+				keyboard.row();
+			}
+		});
+
+		pendingCommandMenus.set(contextKey, actions);
+
+		await safeReply(
+			ctx,
+			`<b>${escapeHTML(menu.title)}</b>\nChoose a command to run:`,
+			{
+				fallbackText: `${menu.title}\nChoose a command to run:`,
+				replyMarkup: keyboard,
+			},
+			target,
+		);
+	};
+
+	const clearContextPickers = (contextKey: ContextKey): void => {
+		pendingSessionPicks.delete(contextKey);
+		pendingSessionButtons.delete(contextKey);
+		pendingWorkspacePicks.delete(contextKey);
+		pendingWorkspaceButtons.delete(contextKey);
+		pendingModelPicks.delete(contextKey);
+		pendingModelButtons.delete(contextKey);
+		pendingModelExtraButtons.delete(contextKey);
+		pendingTreeNavs.delete(contextKey);
+		pendingTreeViews.delete(contextKey);
+		pendingBranchButtons.delete(contextKey);
+		pendingCommandPickers.delete(contextKey);
+		pendingCommandMenus.delete(contextKey);
+		surfacedStartupErrorSignatures.delete(contextKey);
+	};
+
+	const clearContextPromptMemory = (target: PiSessionContext): void => {
+		chatState.clearPromptMemory(target);
+	};
+
+	const surfaceStartupErrorDiagnostics = async (
+		ctx: Context,
+		target: PiSessionContext,
+		info: PiSessionInfo,
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
+		const errors =
+			info.diagnostics?.filter((diagnostic) => diagnostic.type === "error") ??
+			[];
+		if (errors.length === 0) {
+			surfacedStartupErrorSignatures.delete(contextKey);
+			return;
+		}
+
+		const signature = `${info.sessionId}:${errors.map((diagnostic) => diagnostic.message).join("\n")}`;
+		if (surfacedStartupErrorSignatures.get(contextKey) === signature) {
+			return;
+		}
+
+		surfacedStartupErrorSignatures.set(contextKey, signature);
+		const plainText = [
+			"Session startup issues:",
+			...errors.map((diagnostic) => `- ${diagnostic.message}`),
+		].join("\n");
+		const html = [
+			"<b>Session startup issues:</b>",
+			...errors.map((diagnostic) => `• ${escapeHTML(diagnostic.message)}`),
+		].join("\n");
+		await safeReply(ctx, html, { fallbackText: plainText }, target);
+	};
+
+	const isBusy = (target: PiSessionContext): boolean => {
+		const piSession = getExistingSession(target);
+		return chatState.isLocallyBusy(target) || piSession?.isStreaming() === true;
+	};
+
+	const sendBusyReply = async (ctx: Context): Promise<void> => {
+		const target = getTelegramTarget(ctx);
+		const pendingDialogKind = target
+			? extensionDialogs.getPendingKind(target)
+			: undefined;
+		const message =
+			pendingDialogKind === "input"
+				? "Please answer the pending prompt above or use /abort."
+				: pendingDialogKind
+					? "Please answer the pending dialog above."
+					: "Still working on previous message...";
+		await safeReply(
+			ctx,
+			escapeHTML(message),
+			{
+				fallbackText: message,
+			},
+			target,
+		);
+	};
+
+	const ensureActiveSession = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<PiSessionService | undefined> => {
+		const existing = getExistingSession(target);
+		const hadActiveSession = existing?.hasActiveSession() === true;
+		if (hadActiveSession) {
+			return existing;
+		}
+
+		try {
+			const piSession = existing ?? (await getOrCreateSession(target));
+			if (!piSession.hasActiveSession()) {
+				await piSession.newSession();
+			}
+			await surfaceStartupErrorDiagnostics(ctx, target, piSession.getInfo());
+			return piSession;
+		} catch (error) {
+			const failure = renderPrefixedError("Failed to create session", error);
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+			return undefined;
+		}
+	};
+
+	const handlePageCallback = (
+		pattern: RegExp,
+		prefix: string,
+		buttonsMap: Map<ContextKey, KeyboardItem[]>,
+		expiredMessage: string,
+		extraButtonsMap?: Map<ContextKey, KeyboardItem[]>,
+	): void => {
+		bot.callbackQuery(pattern, async (ctx) => {
+			const target = getTelegramTarget(ctx);
+			const messageId = ctx.callbackQuery.message?.message_id;
+			const page = Number.parseInt(ctx.match?.[1] ?? "", 10);
+
+			if (!target || !messageId || Number.isNaN(page)) {
+				return;
+			}
+
+			const contextKey = getContextKey(target);
+			const buttons = buttonsMap.get(contextKey);
+			if (!buttons) {
+				await ctx.answerCallbackQuery({ text: expiredMessage });
+				return;
+			}
+
+			await ctx.answerCallbackQuery();
+
+			try {
+				const keyboard = buildKeyboard(
+					buttons,
+					page,
+					prefix,
+					extraButtonsMap?.get(contextKey) ?? [],
+				);
+				await bot.api.editMessageReplyMarkup(target.chatId, messageId, {
+					reply_markup: keyboard,
+				});
+			} catch (error) {
+				if (!isMessageNotModifiedError(error)) {
+					console.error(`Failed to update ${prefix} keyboard page`, error);
+				}
+			}
+		});
+	};
+
+	bot.use(async (ctx, next) => {
+		const fromId = ctx.from?.id;
+		if (!fromId || !config.telegramAllowedUserIdSet.has(fromId)) {
+			if (ctx.callbackQuery) {
+				await ctx.answerCallbackQuery({ text: "Unauthorized" }).catch(() => {});
+			} else if (ctx.chat) {
+				await safeReply(ctx, escapeHTML("Unauthorized"), {
+					fallbackText: "Unauthorized",
+				});
+			}
+			return;
+		}
+
+		await next();
+	});
+
+	const chatTaskRunner = createChatTaskRunner({
+		beginProcessing: (target, promptText) =>
+			chatState.beginProcessing(target, promptText),
+		endProcessing: (target) => chatState.endProcessing(target),
+		onTaskError: (error, target, promptText) => {
+			console.error(
+				"Detached prompt task failed",
+				JSON.stringify({
+					contextKey: getPiSessionContextKey(target),
+					promptText,
+					error: formatError(error),
+				}),
+			);
+		},
+	});
+
+	const handleUserPrompt = createPromptHandler({
+		bot,
+		toolVerbosity: config.toolVerbosity,
+		editDebounceMs: EDIT_DEBOUNCE_MS,
+		typingIntervalMs: TYPING_INTERVAL_MS,
+		isBusy,
+		taskRunner: chatTaskRunner,
+		ensureActiveSession,
+		syncChatScopedCommands,
+		refreshChatScopedCommands,
+		extensionDialogs,
+		sendBusyReply,
+	});
+
+	if (config.promptInboxDir) {
+		const target: PiSessionContext = {
+			chatId: config.telegramAllowedUserIds[0],
+		};
+		const stopPromptInboxPolling = startPromptInboxPolling({
+			inboxDir: config.promptInboxDir,
+			intervalMs: config.promptInboxIntervalMs,
+			target,
+			isBusy,
+			handlePrompt: async (promptTarget, prompt) =>
+				await handleUserPrompt(
+					{ api: bot.api } as Context,
+					promptTarget,
+					prompt,
+				),
+			onError: (error) => {
+				console.error("Prompt inbox polling failed", error);
+			},
+		});
+		const stopBot = bot.stop.bind(bot);
+		bot.stop = (
+			...args: Parameters<typeof bot.stop>
+		): ReturnType<typeof bot.stop> => {
+			stopPromptInboxPolling();
+			return stopBot(...args);
+		};
+	}
+
+	const commandPickerHandlers = createCommandPickerHandlers({
+		bot,
+		pendingCommandPickers,
+		getTelegramTarget,
+		getContextKey,
+		getOrCreateSession,
+		syncChatScopedCommands,
+		isBusy,
+		handleUserPrompt,
+		runTelePiPickerCommand,
+		safeReply,
+		safeEditMessage: (target, messageId, text, options) =>
+			safeEditMessage(bot, target, messageId, text, options),
+		sendTextMessage: (ctx, target, text, options) =>
+			sendTextMessage(ctx.api, target, text, options),
+	});
+	const { openCommandPicker } = commandPickerHandlers;
+
+	const basicCommandHandlers = createBasicCommandHandlers({
+		sessionRegistry,
+		getExistingSession,
+		getOrCreateSession,
+		refreshChatScopedCommands,
+		openCommandPicker,
+		handleUserPrompt,
+		getLastPrompt: (target) => chatState.getLastPrompt(target),
+		extensionDialogs,
+		getVoiceBackendStatus,
+		safeReply,
+	});
+	const {
+		handleStartCommand,
+		handleHelpCommand,
+		handleCommandsCommand,
+		handleAbortCommand,
+		handleSessionCommand,
+		handleRetryCommand,
+	} = basicCommandHandlers;
+
+	const contextCommandHandlers = createContextCommandHandlers({
+		getExistingSession,
+		safeReply,
+	});
+	const { handleContextCommand } = contextCommandHandlers;
+
+	const sessionCommandHandlers = createSessionCommandHandlers({
+		getContextKey,
+		getOrCreateSession,
+		getExistingSession,
+		isBusy,
+		beginSwitching: (target) => chatState.beginSwitching(target),
+		endSwitching: (target) => chatState.endSwitching(target),
+		buildKeyboard,
+		clearContextPickers,
+		clearContextPromptMemory,
+		refreshChatScopedCommands,
+		syncChatScopedCommands,
+		setChatCommandSignature: (chatId, signature) => {
+			if (signature === undefined) {
+				chatScopedCommandSignatures.delete(chatId);
+			} else {
+				chatScopedCommandSignatures.set(chatId, signature);
+			}
+		},
+		removeSession: (target) => sessionRegistry.remove(target),
+		pendingSessionPicks,
+		pendingSessionButtons,
+		pendingWorkspacePicks,
+		pendingWorkspaceButtons,
+		safeReply,
+		surfaceStartupErrorDiagnostics,
+	});
+	const { handleSessionsCommand, handleNewCommand, handleHandbackCommand } =
+		sessionCommandHandlers;
+
+	const modelCommandHandlers = createModelCommandHandlers({
+		getContextKey,
+		getExistingSession,
+		getOrCreateSession,
+		isBusy,
+		refreshChatScopedCommands,
+		pendingModelPicks,
+		pendingModelButtons,
+		pendingModelExtraButtons,
+		buildKeyboard,
+		safeReply,
+		safeEditMessage: (target, messageId, text, options) =>
+			safeEditMessage(bot, target, messageId, text, options),
+		surfaceStartupErrorDiagnostics,
+	});
+	const { renderModelPicker, handleModelCommand } = modelCommandHandlers;
+
+	const treeCommandHandlers = createTreeCommandHandlers({
+		getContextKey,
+		getExistingSession,
+		isBusy,
+		pendingTreeNavs,
+		pendingBranchButtons,
+		clearPendingTreeView,
+		setPendingTreeView,
+		buildTreeKeyboard,
+		buildKeyboard,
+		safeReply,
+	});
+	const {
+		collectLabelsMap,
+		handleTreeCommand,
+		handleBranchCommand,
+		handleLabelCommand,
+	} = treeCommandHandlers;
+
+	async function runTelePiPickerCommand(
+		ctx: Context,
+		target: PiSessionContext,
+		command: string,
+	): Promise<void> {
+		switch (command) {
+			case "start":
+				await handleStartCommand(ctx, target);
+				return;
+			case "help":
+				await handleHelpCommand(ctx, target);
+				return;
+			case "abort":
+				await handleAbortCommand(ctx, target);
+				return;
+			case "session":
+				await handleSessionCommand(ctx, target);
+				return;
+			case "sessions":
+				await handleSessionsCommand(ctx, target, "/sessions");
+				return;
+			case "new":
+				await handleNewCommand(ctx, target);
+				return;
+			case "handback":
+				await handleHandbackCommand(ctx, target);
+				return;
+			case "context":
+				await handleContextCommand(ctx, target);
+				return;
+			case "model":
+				await handleModelCommand(ctx, target);
+				return;
+			case "tree":
+				await handleTreeCommand(ctx, target, "/tree");
+				return;
+			case "branch":
+				await safeReply(
+					ctx,
+					escapeHTML("Use /branch <entry-id> with an ID from /tree."),
+					{
+						fallbackText: "Use /branch <entry-id> with an ID from /tree.",
+					},
+					target,
+				);
+				return;
+			case "label":
+				await handleLabelCommand(ctx, target, "/label");
+				return;
+			case "retry":
+				await handleRetryCommand(ctx, target);
+				return;
+			default:
+				await safeReply(
+					ctx,
+					escapeHTML(`Command not available from picker: /${command}`),
+					{
+						fallbackText: `Command not available from picker: /${command}`,
+					},
+					target,
+				);
+				return;
+		}
+	}
+
+	bot.command("start", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleStartCommand(ctx, target);
+	});
+
+	bot.command("help", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleHelpCommand(ctx, target);
+	});
+
+	bot.command("commands", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleCommandsCommand(ctx, target);
+	});
+
+	bot.command("abort", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleAbortCommand(ctx, target);
+	});
+
+	bot.command("session", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleSessionCommand(ctx, target);
+	});
+
+	bot.command(["sessions", "switch"], async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleSessionsCommand(ctx, target);
+	});
+
+	bot.command("new", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleNewCommand(ctx, target);
+	});
+
+	bot.command("handback", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleHandbackCommand(ctx, target);
+	});
+
+	bot.command("context", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleContextCommand(ctx, target);
+	});
+
+	bot.command("model", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleModelCommand(ctx, target);
+	});
+
+	bot.command("tree", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleTreeCommand(ctx, target);
+	});
+
+	bot.command("branch", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleBranchCommand(ctx, target);
+	});
+
+	bot.command("label", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleLabelCommand(ctx, target);
+	});
+
+	bot.command("retry", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		await handleRetryCommand(ctx, target);
+	});
+
+	bot.callbackQuery("pi_abort", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		await ctx.answerCallbackQuery({ text: "Aborting..." });
+		if (!target) {
+			return;
+		}
+
+		await getExistingSession(target)?.abort();
+	});
+
+	bot.callbackQuery(NOOP_PAGE_CALLBACK_DATA, async (ctx) => {
+		await ctx.answerCallbackQuery();
+	});
+
+	bot.callbackQuery(/^ui_sel_([a-z0-9]+)_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const dialogId = ctx.match?.[1];
+		const optionIndex = Number.parseInt(ctx.match?.[2] ?? "", 10);
+		if (!target || !dialogId || Number.isNaN(optionIndex)) {
+			return;
+		}
+
+		const result = await extensionDialogs.resolveSelect(
+			target,
+			dialogId,
+			ctx.callbackQuery.message?.message_id,
+			optionIndex,
+		);
+		await answerCallbackQuerySafely(
+			ctx,
+			{ text: result.callbackText },
+			{ source: "extension.select" },
+		);
+		await result.afterAnswer?.();
+	});
+
+	bot.callbackQuery(/^ui_cfm_([a-z0-9]+)_(yes|no)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const dialogId = ctx.match?.[1];
+		const answer = ctx.match?.[2];
+		if (!target || !dialogId || !answer) {
+			return;
+		}
+
+		const result = await extensionDialogs.resolveConfirm(
+			target,
+			dialogId,
+			ctx.callbackQuery.message?.message_id,
+			answer === "yes",
+		);
+		await answerCallbackQuerySafely(
+			ctx,
+			{ text: result.callbackText },
+			{ source: "extension.confirm" },
+		);
+		await result.afterAnswer?.();
+	});
+
+	bot.callbackQuery(/^ui_x_([a-z0-9]+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const dialogId = ctx.match?.[1];
+		if (!target || !dialogId) {
+			return;
+		}
+
+		const result = await extensionDialogs.resolveCancel(
+			target,
+			dialogId,
+			ctx.callbackQuery.message?.message_id,
+		);
+		await answerCallbackQuerySafely(
+			ctx,
+			{ text: result.callbackText },
+			{ source: "extension.cancel" },
+		);
+		await result.afterAnswer?.();
+	});
+
+	bot.callbackQuery(/^cmdm_([a-z0-9]+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const token = ctx.match?.[1];
+		const logOptions = { source: "native.command-menu" };
+		if (!token) {
+			await answerCallbackQuerySafely(ctx, undefined, logOptions);
+			return;
+		}
+
+		if (!target) {
+			await answerCallbackQuerySafely(ctx, undefined, logOptions);
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const action = pendingCommandMenus.get(contextKey)?.get(token);
+		if (!action) {
+			await answerCallbackQuerySafely(
+				ctx,
+				{ text: "Expired, run the slash command again" },
+				logOptions,
+			);
+			return;
+		}
+
+		if (isBusy(target)) {
+			await answerCallbackQuerySafely(
+				ctx,
+				{ text: "Wait for the current prompt to finish" },
+				logOptions,
+			);
+			return;
+		}
+
+		await answerCallbackQuerySafely(
+			ctx,
+			{ text: `Running ${action.commandText}` },
+			logOptions,
+		);
+		await handleUserPrompt(ctx, target, action.commandText);
+	});
+
+	handlePageCallback(
+		/^switch_page_(\d+)$/,
+		"switch",
+		pendingSessionButtons,
+		"Expired, run /sessions again",
+	);
+	handlePageCallback(
+		/^newws_page_(\d+)$/,
+		"newws",
+		pendingWorkspaceButtons,
+		"Expired, run /new again",
+	);
+	handlePageCallback(
+		/^model_page_(\d+)$/,
+		"model",
+		pendingModelButtons,
+		"Expired, run /model again",
+		pendingModelExtraButtons,
+	);
+	handlePageCallback(
+		/^branch_page_(\d+)$/,
+		"branch",
+		pendingBranchButtons,
+		"Expired, run /branch again",
+	);
+
+	registerTreeCallbacks({
+		bot,
+		getTelegramTarget,
+		getContextKey,
+		getExistingSession,
+		isBusy,
+		beginSwitching: (target) => chatState.beginSwitching(target),
+		endSwitching: (target) => chatState.endSwitching(target),
+		pendingTreeViews,
+		pendingTreeNavs,
+		pendingBranchButtons,
+		setPendingTreeView,
+		clearPendingTreeView,
+		buildTreeKeyboard,
+		buildKeyboard,
+		collectLabelsMap,
+		safeReply,
+		safeEditMessage: (target, messageId, text, options) =>
+			safeEditMessage(bot, target, messageId, text, options),
+	});
+
+	bot.callbackQuery(/^switch_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
+
+		if (!target || Number.isNaN(index)) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const sessions = pendingSessionPicks.get(contextKey);
+		if (!sessions || !sessions[index]) {
+			await ctx.answerCallbackQuery({
+				text: "Session expired, run /sessions again",
+			});
+			return;
+		}
+
+		if (isBusy(target)) {
+			await ctx.answerCallbackQuery({
+				text: "Wait for the current prompt to finish",
+			});
+			return;
+		}
+
+		const piSession = await getOrCreateSession(target);
+		await ctx.answerCallbackQuery({ text: "Switching..." });
+		pendingSessionPicks.delete(contextKey);
+		pendingSessionButtons.delete(contextKey);
+
+		chatState.beginSwitching(target);
+		try {
+			const resolvedSession = await piSession.resolveSessionReference(
+				sessions[index].path,
+			);
+			const info = await piSession.switchSession(
+				resolvedSession.path,
+				resolvedSession.cwd,
+			);
+			if (info.cancelled) {
+				const cancelledText = "Session switch was cancelled.";
+				if (messageId) {
+					await safeEditMessage(
+						bot,
+						target,
+						messageId,
+						escapeHTML(cancelledText),
+						{
+							fallbackText: cancelledText,
+						},
+					);
+					return;
+				}
+
+				await safeReply(
+					ctx,
+					escapeHTML(cancelledText),
+					{ fallbackText: cancelledText },
+					target,
+				);
+				return;
+			}
+
+			await refreshChatScopedCommands(target, piSession);
+			clearPendingTreeView(contextKey);
+			clearContextPromptMemory(target);
+			const workspaceNotePlain = resolvedSession.workspaceWarning
+				? `\n\nWorkspace note: ${resolvedSession.workspaceWarning}`
+				: "";
+			const workspaceNoteHTML = resolvedSession.workspaceWarning
+				? `\n\n<b>Workspace note:</b> ${escapeHTML(resolvedSession.workspaceWarning)}`
+				: "";
+			const plainText = `Switched!${workspaceNotePlain}\n\n${renderSessionInfoPlain(info)}`;
+			const html = `<b>Switched!</b>${workspaceNoteHTML}\n\n${renderSessionInfoHTML(info)}`;
+
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, html, {
+					fallbackText: plainText,
+				});
+			} else {
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+			}
+
+			await surfaceStartupErrorDiagnostics(ctx, target, info);
+		} catch (error) {
+			const failure = renderFailedText(error);
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, failure.text, {
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				});
+			} else {
+				await safeReply(
+					ctx,
+					failure.text,
+					{
+						fallbackText: failure.fallbackText,
+						parseMode: failure.parseMode,
+					},
+					target,
+				);
+			}
+		} finally {
+			chatState.endSwitching(target);
+		}
+	});
+
+	bot.callbackQuery(/^newws_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
+
+		if (!target || Number.isNaN(index)) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const workspaces = pendingWorkspacePicks.get(contextKey);
+		if (!workspaces || !workspaces[index]) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /new again" });
+			return;
+		}
+
+		if (isBusy(target)) {
+			await ctx.answerCallbackQuery({
+				text: "Wait for the current prompt to finish",
+			});
+			return;
+		}
+
+		const piSession = await getOrCreateSession(target);
+		await ctx.answerCallbackQuery({ text: "Creating session..." });
+		pendingWorkspacePicks.delete(contextKey);
+		pendingWorkspaceButtons.delete(contextKey);
+
+		chatState.beginSwitching(target);
+		try {
+			const { info, created } = await piSession.newSession(workspaces[index]);
+			if (!created) {
+				const html = escapeHTML("New session was cancelled.");
+				if (messageId) {
+					await safeEditMessage(bot, target, messageId, html, {
+						fallbackText: "New session was cancelled.",
+					});
+				}
+				return;
+			}
+
+			await refreshChatScopedCommands(target, piSession);
+			clearPendingTreeView(contextKey);
+			clearContextPromptMemory(target);
+			const plainText = `New session created.\n\n${renderSessionInfoPlain(info)}`;
+			const html = `<b>New session created.</b>\n\n${renderSessionInfoHTML(info)}`;
+
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, html, {
+					fallbackText: plainText,
+				});
+			} else {
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+			}
+
+			await surfaceStartupErrorDiagnostics(ctx, target, info);
+		} catch (error) {
+			const failure = renderFailedText(error);
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, failure.text, {
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				});
+			} else {
+				await safeReply(
+					ctx,
+					failure.text,
+					{
+						fallbackText: failure.fallbackText,
+						parseMode: failure.parseMode,
+					},
+					target,
+				);
+			}
+		} finally {
+			chatState.endSwitching(target);
+		}
+	});
+
+	bot.callbackQuery("model_show_all", async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+
+		if (!target || !messageId) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const piSession = getExistingSession(target);
+		const models = pendingModelPicks.get(contextKey);
+		if (!models || models.length === 0 || !piSession) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /model again" });
+			return;
+		}
+
+		if (isBusy(target)) {
+			await ctx.answerCallbackQuery({
+				text: "Wait for the current prompt to finish",
+			});
+			return;
+		}
+
+		await ctx.answerCallbackQuery({ text: "Loading all models..." });
+		await renderModelPicker(ctx, target, piSession, {
+			showAll: true,
+			messageId,
+		});
+	});
+
+	bot.callbackQuery(/^model_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
+
+		if (!target || Number.isNaN(index)) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const piSession = getExistingSession(target);
+		const models = pendingModelPicks.get(contextKey);
+		if (!models || !models[index] || !piSession) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /model again" });
+			return;
+		}
+
+		if (isBusy(target)) {
+			await ctx.answerCallbackQuery({
+				text: "Wait for the current prompt to finish",
+			});
+			return;
+		}
+
+		await ctx.answerCallbackQuery({ text: "Switching model..." });
+		pendingModelPicks.delete(contextKey);
+		pendingModelButtons.delete(contextKey);
+		pendingModelExtraButtons.delete(contextKey);
+
+		chatState.beginSwitching(target);
+		try {
+			const modelName = await piSession.setModel(
+				models[index].provider,
+				models[index].id,
+				models[index].thinkingLevel,
+			);
+			const html = `<b>Model switched to:</b> <code>${escapeHTML(modelName)}</code>`;
+			const plainText = `Model switched to: ${modelName}`;
+
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, html, {
+					fallbackText: plainText,
+				});
+			} else {
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+			}
+		} catch (error) {
+			const failure = renderFailedText(error);
+			if (messageId) {
+				await safeEditMessage(bot, target, messageId, failure.text, {
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				});
+				return;
+			}
+
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+		} finally {
+			chatState.endSwitching(target);
+		}
+	});
+
+	bot.on("message:text", async (ctx) => {
+		const userText = ctx.message.text.trim();
+		if (!userText) {
+			return;
+		}
+
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		const normalizedSlashCommand = normalizeSlashCommand(
+			userText,
+			bot.botInfo?.username,
+		);
+		if (
+			normalizedSlashCommand &&
+			TELEPI_LOCAL_COMMAND_NAMES.has(normalizedSlashCommand.name)
+		) {
+			return;
+		}
+		if (!normalizedSlashCommand && userText.startsWith("/")) {
+			return;
+		}
+
+		if (await extensionDialogs.consumeInput(target, userText)) {
+			return;
+		}
+
+		if (extensionDialogs.hasPending(target)) {
+			await safeReply(
+				ctx,
+				escapeHTML("Please answer the pending dialog above."),
+				{
+					fallbackText: "Please answer the pending dialog above.",
+				},
+				target,
+			);
+			return;
+		}
+
+		if (normalizedSlashCommand) {
+			const piSession = await getOrCreateSession(target);
+			const slashCommands = await piSession.listSlashCommands();
+			void syncChatScopedCommands(target, slashCommands).catch((error) => {
+				console.error("Failed to sync chat-scoped Telegram commands", error);
+			});
+			const knownSlashCommands = new Set(
+				slashCommands.map((command) => command.name),
+			);
+			if (!knownSlashCommands.has(normalizedSlashCommand.name)) {
+				await safeReply(
+					ctx,
+					escapeHTML(
+						"Unknown command. Use /commands to see available Pi slash commands.",
+					),
+					{
+						fallbackText:
+							"Unknown command. Use /commands to see available Pi slash commands.",
+					},
+					target,
+				);
+				return;
+			}
+
+			const nativeCommandMenu = getTelepiNativeCommandMenu(
+				normalizedSlashCommand,
+				slashCommands,
+			);
+			if (nativeCommandMenu) {
+				await openNativeCommandMenu(ctx, target, nativeCommandMenu);
+				return;
+			}
+
+			const commandText = rewriteSlashCommandForTelegram(
+				normalizedSlashCommand,
+				slashCommands,
+			);
+			await handleUserPrompt(ctx, target, commandText, slashCommands);
+			return;
+		}
+
+		await handleUserPrompt(ctx, target, userText);
+	});
+
+	bot.on(["message:photo", "message:document"], async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		if (isBusy(target)) {
+			await sendBusyReply(ctx);
+			return;
+		}
+
+		const photoFileId = selectPhotoFileId(
+			ctx.message.photo as
+				| Array<{ file_id: string; file_size?: number }>
+				| undefined,
+		);
+		const documentMimeType = ctx.message.document?.mime_type;
+		const isImageDocument =
+			documentMimeType?.toLowerCase().startsWith("image/") ?? false;
+		const documentFileId = isImageDocument
+			? ctx.message.document?.file_id
+			: undefined;
+		const fileId = photoFileId ?? documentFileId;
+		if (!fileId) {
+			return;
+		}
+
+		chatState.beginTranscribing(target);
+		let tempFilePath: string | undefined;
+		let promptText: string | undefined;
+		let images: ImageContent[] | undefined;
+
+		try {
+			await sendChatAction(ctx.api, target, "typing");
+			tempFilePath = await downloadTelegramFile(
+				ctx.api,
+				config.telegramBotToken,
+				fileId,
+				{
+					fileKind: "image file",
+					tempFilePrefix: "telepi-image",
+				},
+			);
+
+			const imageBytes = await readFile(tempFilePath);
+			const imageMimeType = resolveImageMimeType(
+				tempFilePath,
+				documentMimeType,
+			);
+			promptText = ctx.message.caption?.trim() || DEFAULT_IMAGE_PROMPT;
+			const preview = truncateText(promptText.replace(/\s+/g, " "), 240);
+			images = [
+				{
+					type: "image",
+					data: imageBytes.toString("base64"),
+					mimeType: imageMimeType,
+				},
+			];
+
+			await safeReply(
+				ctx,
+				`🖼️ ${escapeHTML(preview)}`,
+				{ fallbackText: `🖼️ ${preview}` },
+				target,
+			);
+		} catch (error) {
+			const failure = renderPrefixedError("Image handling failed", error, true);
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+			return;
+		} finally {
+			chatState.endTranscribing(target);
+			if (tempFilePath) {
+				await unlink(tempFilePath).catch(() => {});
+			}
+		}
+
+		if (!promptText || !images) {
+			return;
+		}
+
+		await handleUserPrompt(ctx, target, promptText, undefined, images);
+	});
+
+	bot.on(["message:voice", "message:audio"], async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		if (!target) {
+			return;
+		}
+
+		const contextKey = getContextKey(target);
+		if (isBusy(target)) {
+			await sendBusyReply(ctx);
+			return;
+		}
+
+		const fileId = ctx.message.voice?.file_id ?? ctx.message.audio?.file_id;
+		if (!fileId) {
+			return;
+		}
+
+		chatState.beginTranscribing(target);
+		let tempFilePath: string | undefined;
+		let transcript: string | undefined;
+
+		try {
+			await sendChatAction(ctx.api, target, "typing");
+			tempFilePath = await downloadTelegramFile(
+				ctx.api,
+				config.telegramBotToken,
+				fileId,
+			);
+
+			const result = await transcribeAudio(tempFilePath);
+			transcript = result.text.trim();
+			if (!transcript) {
+				await safeReply(
+					ctx,
+					escapeHTML(
+						"Transcription was empty. Please try again or send text instead.",
+					),
+					{
+						fallbackText:
+							"Transcription was empty. Please try again or send text instead.",
+					},
+					target,
+				);
+				return;
+			}
+
+			const preview = truncateText(transcript.replace(/\s+/g, " "), 240);
+			await safeReply(
+				ctx,
+				`🎤 ${escapeHTML(preview)} <i>(via ${escapeHTML(result.backend)})</i>`,
+				{ fallbackText: `🎤 ${preview} (via ${result.backend})` },
+				target,
+			);
+		} catch (error) {
+			const failure = renderPrefixedError("Transcription failed", error, true);
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+			return;
+		} finally {
+			chatState.endTranscribing(target);
+			if (tempFilePath) {
+				await unlink(tempFilePath).catch(() => {});
+			}
+		}
+
+		if (!transcript) {
+			return;
+		}
+
+		await handleUserPrompt(ctx, target, transcript);
+	});
+
+	bot.catch((error) => {
+		if (error.ctx?.callbackQuery && isStaleCallbackQueryError(error.error)) {
+			logCallbackQueryError(error.ctx, error.error, { phase: "handler" });
+			return;
+		}
+
+		console.error("Telegram bot error:", formatError(error.error));
+	});
+
+	return bot;
 }
 
 export async function registerCommands(bot: Bot<Context>): Promise<void> {
-  await bot.api.setMyCommands([...TELEPI_BOT_COMMANDS]);
+	await bot.api.setMyCommands([...TELEPI_BOT_COMMANDS]);
 }

--- a/src/bot/command-picker.ts
+++ b/src/bot/command-picker.ts
@@ -1,320 +1,388 @@
-import { InlineKeyboard, type Bot, type Context } from "grammy";
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
+import { type Bot, type Context, InlineKeyboard } from "grammy";
 
 import { escapeHTML } from "../format.js";
 import type { PiSessionContext, PiSessionService } from "../pi-session.js";
-import { renderPrefixedError, trimLine, type RenderedText } from "./message-rendering.js";
 import { KEYBOARD_PAGE_SIZE, NOOP_PAGE_CALLBACK_DATA } from "./keyboard.js";
 import {
-  buildCommandPickerEntries,
-  filterCommandPickerEntries,
-  getCommandPickerCounts,
-  getCommandPickerFilterName,
-  type CommandPickerEntry,
-  type CommandPickerFilter,
+	type RenderedText,
+	renderPrefixedError,
+	trimLine,
+} from "./message-rendering.js";
+import {
+	buildCommandPickerEntries,
+	type CommandPickerEntry,
+	type CommandPickerFilter,
+	filterCommandPickerEntries,
+	getCommandPickerCounts,
+	getCommandPickerFilterName,
 } from "./slash-command.js";
 import type { TextOptions } from "./telegram-transport.js";
 
 export type PendingCommandPicker = {
-  messageId: number;
-  entries: CommandPickerEntry[];
-  filter: CommandPickerFilter;
-  page: number;
+	messageId: number;
+	entries: CommandPickerEntry[];
+	filter: CommandPickerFilter;
+	page: number;
 };
 
-export function renderCommandPickerState(picker: PendingCommandPicker): RenderedText & {
-  replyMarkup: InlineKeyboard;
-  page: number;
-  filteredEntries: CommandPickerEntry[];
+export function renderCommandPickerState(
+	picker: PendingCommandPicker,
+): RenderedText & {
+	replyMarkup: InlineKeyboard;
+	page: number;
+	filteredEntries: CommandPickerEntry[];
 } {
-  const filteredEntries = filterCommandPickerEntries(picker.entries, picker.filter);
-  const totalPages = Math.max(1, Math.ceil(filteredEntries.length / KEYBOARD_PAGE_SIZE));
-  const page = Math.max(0, Math.min(picker.page, totalPages - 1));
-  const pageEntries = filteredEntries.slice(page * KEYBOARD_PAGE_SIZE, (page + 1) * KEYBOARD_PAGE_SIZE);
-  const counts = getCommandPickerCounts(picker.entries);
+	const filteredEntries = filterCommandPickerEntries(
+		picker.entries,
+		picker.filter,
+	);
+	const totalPages = Math.max(
+		1,
+		Math.ceil(filteredEntries.length / KEYBOARD_PAGE_SIZE),
+	);
+	const page = Math.max(0, Math.min(picker.page, totalPages - 1));
+	const pageEntries = filteredEntries.slice(
+		page * KEYBOARD_PAGE_SIZE,
+		(page + 1) * KEYBOARD_PAGE_SIZE,
+	);
+	const counts = getCommandPickerCounts(picker.entries);
 
-  const keyboard = new InlineKeyboard();
-  for (const entry of pageEntries) {
-    keyboard.text(trimLine(entry.label, 48), `cmd_pick_${entry.id}`).row();
-  }
+	const keyboard = new InlineKeyboard();
+	for (const entry of pageEntries) {
+		keyboard.text(trimLine(entry.label, 48), `cmd_pick_${entry.id}`).row();
+	}
 
-  if (totalPages > 1) {
-    if (page > 0) {
-      keyboard.text("◀️ Prev", `cmd_page_${page - 1}`);
-    }
-    keyboard.text(`${page + 1}/${totalPages}`, NOOP_PAGE_CALLBACK_DATA);
-    if (page < totalPages - 1) {
-      keyboard.text("Next ▶️", `cmd_page_${page + 1}`);
-    }
-    keyboard.row();
-  }
+	if (totalPages > 1) {
+		if (page > 0) {
+			keyboard.text("◀️ Prev", `cmd_page_${page - 1}`);
+		}
+		keyboard.text(`${page + 1}/${totalPages}`, NOOP_PAGE_CALLBACK_DATA);
+		if (page < totalPages - 1) {
+			keyboard.text("Next ▶️", `cmd_page_${page + 1}`);
+		}
+		keyboard.row();
+	}
 
-  const filterButtons: Array<{ filter: CommandPickerFilter; icon: string }> = [
-    { filter: "all", icon: "🧭" },
-    { filter: "telepi", icon: "📱" },
-    { filter: "pi", icon: "⚡" },
-  ];
-  for (const button of filterButtons) {
-    const active = picker.filter === button.filter;
-    const label = `${active ? "✅ " : ""}${button.icon} ${getCommandPickerFilterName(button.filter)} ${counts[button.filter]}`;
-    keyboard.text(label, `cmd_filter_${button.filter}`);
-  }
-  keyboard.row();
+	const filterButtons: Array<{ filter: CommandPickerFilter; icon: string }> = [
+		{ filter: "all", icon: "🧭" },
+		{ filter: "telepi", icon: "📱" },
+		{ filter: "pi", icon: "⚡" },
+	];
+	for (const button of filterButtons) {
+		const active = picker.filter === button.filter;
+		const label = `${active ? "✅ " : ""}${button.icon} ${getCommandPickerFilterName(button.filter)} ${counts[button.filter]}`;
+		keyboard.text(label, `cmd_filter_${button.filter}`);
+	}
+	keyboard.row();
 
-  const summary = filteredEntries.length === 0
-    ? `No ${getCommandPickerFilterName(picker.filter)} commands available.`
-    : `Showing ${page * KEYBOARD_PAGE_SIZE + 1}-${page * KEYBOARD_PAGE_SIZE + pageEntries.length} of ${filteredEntries.length} ${getCommandPickerFilterName(picker.filter)} commands.`;
+	const summary =
+		filteredEntries.length === 0
+			? `No ${getCommandPickerFilterName(picker.filter)} commands available.`
+			: `Showing ${page * KEYBOARD_PAGE_SIZE + 1}-${page * KEYBOARD_PAGE_SIZE + pageEntries.length} of ${filteredEntries.length} ${getCommandPickerFilterName(picker.filter)} commands.`;
 
-  const plainLines = [
-    "Command picker",
-    `Filter: ${getCommandPickerFilterName(picker.filter)}`,
-    `Page: ${page + 1}/${totalPages}`,
-    summary,
-    "",
-    ...(pageEntries.length > 0
-      ? pageEntries.map((entry) => {
-        const detail = entry.kind === "pi" ? `${entry.description} [${entry.source}]` : entry.description;
-        return `${entry.label.replace(/^[^/]+\s*/, "")} — ${detail}`;
-      })
-      : [picker.filter === "pi" ? "No Pi commands found in this session." : "No commands found for this filter."]),
-    "",
-    "Tap a button below to run a command.",
-  ];
+	const plainLines = [
+		"Command picker",
+		`Filter: ${getCommandPickerFilterName(picker.filter)}`,
+		`Page: ${page + 1}/${totalPages}`,
+		summary,
+		"",
+		...(pageEntries.length > 0
+			? pageEntries.map((entry) => {
+					const detail =
+						entry.kind === "pi"
+							? `${entry.description} [${entry.source}]`
+							: entry.description;
+					return `${entry.label.replace(/^[^/]+\s*/, "")} — ${detail}`;
+				})
+			: [
+					picker.filter === "pi"
+						? "No Pi commands found in this session."
+						: "No commands found for this filter.",
+				]),
+		"",
+		"Tap a button below to run a command.",
+	];
 
-  const htmlLines = [
-    "<b>Command picker</b>",
-    `<i>Filter:</i> <b>${escapeHTML(getCommandPickerFilterName(picker.filter))}</b>`,
-    `<i>Page:</i> ${page + 1}/${totalPages}`,
-    `<i>${escapeHTML(summary)}</i>`,
-    "",
-    ...(pageEntries.length > 0
-      ? pageEntries.map((entry) => entry.kind === "pi"
-        ? `${escapeHTML(entry.label)} — ${escapeHTML(entry.description)} <i>(${escapeHTML(entry.source)})</i>`
-        : `${escapeHTML(entry.label)} — ${escapeHTML(entry.description)}`)
-      : [picker.filter === "pi" ? "<i>No Pi commands found in this session.</i>" : "<i>No commands found for this filter.</i>"]),
-    "",
-    "Tap a button below to run a command.",
-  ];
+	const htmlLines = [
+		"<b>Command picker</b>",
+		`<i>Filter:</i> <b>${escapeHTML(getCommandPickerFilterName(picker.filter))}</b>`,
+		`<i>Page:</i> ${page + 1}/${totalPages}`,
+		`<i>${escapeHTML(summary)}</i>`,
+		"",
+		...(pageEntries.length > 0
+			? pageEntries.map((entry) =>
+					entry.kind === "pi"
+						? `${escapeHTML(entry.label)} — ${escapeHTML(entry.description)} <i>(${escapeHTML(entry.source)})</i>`
+						: `${escapeHTML(entry.label)} — ${escapeHTML(entry.description)}`,
+				)
+			: [
+					picker.filter === "pi"
+						? "<i>No Pi commands found in this session.</i>"
+						: "<i>No commands found for this filter.</i>",
+				]),
+		"",
+		"Tap a button below to run a command.",
+	];
 
-  return {
-    text: htmlLines.join("\n"),
-    fallbackText: plainLines.join("\n"),
-    parseMode: "HTML",
-    replyMarkup: keyboard,
-    page,
-    filteredEntries,
-  };
+	return {
+		text: htmlLines.join("\n"),
+		fallbackText: plainLines.join("\n"),
+		parseMode: "HTML",
+		replyMarkup: keyboard,
+		page,
+		filteredEntries,
+	};
 }
 
 export function createCommandPickerHandlers(deps: {
-  bot: Bot<Context>;
-  pendingCommandPickers: Map<string, PendingCommandPicker>;
-  getTelegramTarget: (ctx: Context) => PiSessionContext | undefined;
-  getContextKey: (target: PiSessionContext) => string;
-  getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
-  syncChatScopedCommands: (target: PiSessionContext, slashCommands: SlashCommandInfo[]) => Promise<void>;
-  isBusy: (target: PiSessionContext) => boolean;
-  handleUserPrompt: (
-    ctx: Context,
-    target: PiSessionContext,
-    userText: string,
-    preloadedSlashCommands?: SlashCommandInfo[],
-  ) => Promise<boolean>;
-  runTelePiPickerCommand: (ctx: Context, target: PiSessionContext, command: string) => Promise<void>;
-  safeReply: (ctx: Context, text: string, options?: TextOptions, target?: PiSessionContext) => Promise<void>;
-  safeEditMessage: (target: PiSessionContext, messageId: number, text: string, options?: TextOptions) => Promise<void>;
-  sendTextMessage: (ctx: Context, target: PiSessionContext, text: string, options?: TextOptions) => Promise<{ message_id: number }>;
+	bot: Bot<Context>;
+	pendingCommandPickers: Map<string, PendingCommandPicker>;
+	getTelegramTarget: (ctx: Context) => PiSessionContext | undefined;
+	getContextKey: (target: PiSessionContext) => string;
+	getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
+	syncChatScopedCommands: (
+		target: PiSessionContext,
+		slashCommands: SlashCommandInfo[],
+	) => Promise<void>;
+	isBusy: (target: PiSessionContext) => boolean;
+	handleUserPrompt: (
+		ctx: Context,
+		target: PiSessionContext,
+		userText: string,
+		preloadedSlashCommands?: SlashCommandInfo[],
+	) => Promise<boolean>;
+	runTelePiPickerCommand: (
+		ctx: Context,
+		target: PiSessionContext,
+		command: string,
+	) => Promise<void>;
+	safeReply: (
+		ctx: Context,
+		text: string,
+		options?: TextOptions,
+		target?: PiSessionContext,
+	) => Promise<void>;
+	safeEditMessage: (
+		target: PiSessionContext,
+		messageId: number,
+		text: string,
+		options?: TextOptions,
+	) => Promise<void>;
+	sendTextMessage: (
+		ctx: Context,
+		target: PiSessionContext,
+		text: string,
+		options?: TextOptions,
+	) => Promise<{ message_id: number }>;
 }) {
-  const {
-    bot,
-    pendingCommandPickers,
-    getTelegramTarget,
-    getContextKey,
-    getOrCreateSession,
-    syncChatScopedCommands,
-    isBusy,
-    handleUserPrompt,
-    runTelePiPickerCommand,
-    safeReply,
-    safeEditMessage,
-    sendTextMessage,
-  } = deps;
+	const {
+		bot,
+		pendingCommandPickers,
+		getTelegramTarget,
+		getContextKey,
+		getOrCreateSession,
+		syncChatScopedCommands,
+		isBusy,
+		handleUserPrompt,
+		runTelePiPickerCommand,
+		safeReply,
+		safeEditMessage,
+		sendTextMessage,
+	} = deps;
 
-  const getPendingCommandPicker = (
-    target: PiSessionContext,
-    messageId?: number,
-  ): { contextKey: string; picker: PendingCommandPicker } | undefined => {
-    if (!messageId) {
-      return undefined;
-    }
+	const getPendingCommandPicker = (
+		target: PiSessionContext,
+		messageId?: number,
+	): { contextKey: string; picker: PendingCommandPicker } | undefined => {
+		if (!messageId) {
+			return undefined;
+		}
 
-    const contextKey = getContextKey(target);
-    const picker = pendingCommandPickers.get(contextKey);
-    if (!picker || picker.messageId !== messageId) {
-      return undefined;
-    }
+		const contextKey = getContextKey(target);
+		const picker = pendingCommandPickers.get(contextKey);
+		if (!picker || picker.messageId !== messageId) {
+			return undefined;
+		}
 
-    return { contextKey, picker };
-  };
+		return { contextKey, picker };
+	};
 
-  const openCommandPicker = async (
-    ctx: Context,
-    target: PiSessionContext,
-    options?: { messageId?: number; filter?: CommandPickerFilter; page?: number },
-  ): Promise<void> => {
-    const contextKey = getContextKey(target);
-    const piSession = await getOrCreateSession(target);
+	const openCommandPicker = async (
+		ctx: Context,
+		target: PiSessionContext,
+		options?: {
+			messageId?: number;
+			filter?: CommandPickerFilter;
+			page?: number;
+		},
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
+		const piSession = await getOrCreateSession(target);
 
-    let slashCommands: SlashCommandInfo[];
-    try {
-      slashCommands = await piSession.listSlashCommands();
-    } catch (error) {
-      const failure = renderPrefixedError("Failed to load commands", error);
-      if (options?.messageId) {
-        await safeEditMessage(target, options.messageId, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        });
-      } else {
-        await safeReply(ctx, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        }, target);
-      }
-      return;
-    }
+		let slashCommands: SlashCommandInfo[];
+		try {
+			slashCommands = await piSession.listSlashCommands();
+		} catch (error) {
+			const failure = renderPrefixedError("Failed to load commands", error);
+			if (options?.messageId) {
+				await safeEditMessage(target, options.messageId, failure.text, {
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				});
+			} else {
+				await safeReply(
+					ctx,
+					failure.text,
+					{
+						fallbackText: failure.fallbackText,
+						parseMode: failure.parseMode,
+					},
+					target,
+				);
+			}
+			return;
+		}
 
-    try {
-      await syncChatScopedCommands(target, slashCommands);
-    } catch (error) {
-      console.error("Failed to sync chat-scoped Telegram commands", error);
-    }
+		try {
+			await syncChatScopedCommands(target, slashCommands);
+		} catch (error) {
+			console.error("Failed to sync chat-scoped Telegram commands", error);
+		}
 
-    const picker: PendingCommandPicker = {
-      messageId: options?.messageId ?? 0,
-      entries: buildCommandPickerEntries(slashCommands),
-      filter: options?.filter ?? "all",
-      page: options?.page ?? 0,
-    };
-    const rendered = renderCommandPickerState(picker);
-    picker.page = rendered.page;
+		const picker: PendingCommandPicker = {
+			messageId: options?.messageId ?? 0,
+			entries: buildCommandPickerEntries(slashCommands),
+			filter: options?.filter ?? "all",
+			page: options?.page ?? 0,
+		};
+		const rendered = renderCommandPickerState(picker);
+		picker.page = rendered.page;
 
-    if (options?.messageId) {
-      await safeEditMessage(target, options.messageId, rendered.text, {
-        fallbackText: rendered.fallbackText,
-        parseMode: rendered.parseMode,
-        replyMarkup: rendered.replyMarkup,
-      });
-      picker.messageId = options.messageId;
-      pendingCommandPickers.set(contextKey, picker);
-      return;
-    }
+		if (options?.messageId) {
+			await safeEditMessage(target, options.messageId, rendered.text, {
+				fallbackText: rendered.fallbackText,
+				parseMode: rendered.parseMode,
+				replyMarkup: rendered.replyMarkup,
+			});
+			picker.messageId = options.messageId;
+			pendingCommandPickers.set(contextKey, picker);
+			return;
+		}
 
-    const message = await sendTextMessage(ctx, target, rendered.text, {
-      fallbackText: rendered.fallbackText,
-      parseMode: rendered.parseMode,
-      replyMarkup: rendered.replyMarkup,
-    });
-    picker.messageId = message.message_id;
-    pendingCommandPickers.set(contextKey, picker);
-  };
+		const message = await sendTextMessage(ctx, target, rendered.text, {
+			fallbackText: rendered.fallbackText,
+			parseMode: rendered.parseMode,
+			replyMarkup: rendered.replyMarkup,
+		});
+		picker.messageId = message.message_id;
+		pendingCommandPickers.set(contextKey, picker);
+	};
 
-  bot.callbackQuery(/^cmd_page_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const page = Number.parseInt(ctx.match?.[1] ?? "", 10);
+	bot.callbackQuery(/^cmd_page_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const page = Number.parseInt(ctx.match?.[1] ?? "", 10);
 
-    if (!target || !messageId || Number.isNaN(page)) {
-      return;
-    }
+		if (!target || !messageId || Number.isNaN(page)) {
+			return;
+		}
 
-    const activePicker = getPendingCommandPicker(target, messageId);
-    if (!activePicker) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
-      return;
-    }
+		const activePicker = getPendingCommandPicker(target, messageId);
+		if (!activePicker) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
+			return;
+		}
 
-    activePicker.picker.page = page;
-    const rendered = renderCommandPickerState(activePicker.picker);
-    activePicker.picker.page = rendered.page;
-    pendingCommandPickers.set(activePicker.contextKey, activePicker.picker);
+		activePicker.picker.page = page;
+		const rendered = renderCommandPickerState(activePicker.picker);
+		activePicker.picker.page = rendered.page;
+		pendingCommandPickers.set(activePicker.contextKey, activePicker.picker);
 
-    await ctx.answerCallbackQuery();
-    await safeEditMessage(target, messageId, rendered.text, {
-      fallbackText: rendered.fallbackText,
-      parseMode: rendered.parseMode,
-      replyMarkup: rendered.replyMarkup,
-    });
-  });
+		await ctx.answerCallbackQuery();
+		await safeEditMessage(target, messageId, rendered.text, {
+			fallbackText: rendered.fallbackText,
+			parseMode: rendered.parseMode,
+			replyMarkup: rendered.replyMarkup,
+		});
+	});
 
-  bot.callbackQuery(/^cmd_filter_(all|telepi|pi)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const filter = ctx.match?.[1] as CommandPickerFilter | undefined;
+	bot.callbackQuery(/^cmd_filter_(all|telepi|pi)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const filter = ctx.match?.[1] as CommandPickerFilter | undefined;
 
-    if (!target || !messageId || !filter) {
-      return;
-    }
+		if (!target || !messageId || !filter) {
+			return;
+		}
 
-    const activePicker = getPendingCommandPicker(target, messageId);
-    if (!activePicker) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
-      return;
-    }
+		const activePicker = getPendingCommandPicker(target, messageId);
+		if (!activePicker) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
+			return;
+		}
 
-    activePicker.picker.filter = filter;
-    activePicker.picker.page = 0;
-    const rendered = renderCommandPickerState(activePicker.picker);
-    activePicker.picker.page = rendered.page;
-    pendingCommandPickers.set(activePicker.contextKey, activePicker.picker);
+		activePicker.picker.filter = filter;
+		activePicker.picker.page = 0;
+		const rendered = renderCommandPickerState(activePicker.picker);
+		activePicker.picker.page = rendered.page;
+		pendingCommandPickers.set(activePicker.contextKey, activePicker.picker);
 
-    await ctx.answerCallbackQuery({ text: `Showing ${getCommandPickerFilterName(filter)} commands` });
-    await safeEditMessage(target, messageId, rendered.text, {
-      fallbackText: rendered.fallbackText,
-      parseMode: rendered.parseMode,
-      replyMarkup: rendered.replyMarkup,
-    });
-  });
+		await ctx.answerCallbackQuery({
+			text: `Showing ${getCommandPickerFilterName(filter)} commands`,
+		});
+		await safeEditMessage(target, messageId, rendered.text, {
+			fallbackText: rendered.fallbackText,
+			parseMode: rendered.parseMode,
+			replyMarkup: rendered.replyMarkup,
+		});
+	});
 
-  bot.callbackQuery(/^cmd_pick_(\d+)$/, async (ctx) => {
-    const target = getTelegramTarget(ctx);
-    const messageId = ctx.callbackQuery.message?.message_id;
-    const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
+	bot.callbackQuery(/^cmd_pick_(\d+)$/, async (ctx) => {
+		const target = getTelegramTarget(ctx);
+		const messageId = ctx.callbackQuery.message?.message_id;
+		const index = Number.parseInt(ctx.match?.[1] ?? "", 10);
 
-    if (!target || !messageId || Number.isNaN(index)) {
-      return;
-    }
+		if (!target || !messageId || Number.isNaN(index)) {
+			return;
+		}
 
-    const activePicker = getPendingCommandPicker(target, messageId);
-    if (!activePicker) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
-      return;
-    }
+		const activePicker = getPendingCommandPicker(target, messageId);
+		if (!activePicker) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
+			return;
+		}
 
-    const entry = activePicker.picker.entries.find((item) => item.id === index);
-    if (!entry) {
-      await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
-      return;
-    }
+		const entry = activePicker.picker.entries.find((item) => item.id === index);
+		if (!entry) {
+			await ctx.answerCallbackQuery({ text: "Expired, run /commands again" });
+			return;
+		}
 
-    if (entry.kind === "pi") {
-      if (isBusy(target)) {
-        await ctx.answerCallbackQuery({ text: "Wait for the current prompt to finish" });
-        return;
-      }
+		if (entry.kind === "pi") {
+			if (isBusy(target)) {
+				await ctx.answerCallbackQuery({
+					text: "Wait for the current prompt to finish",
+				});
+				return;
+			}
 
-      pendingCommandPickers.delete(activePicker.contextKey);
-      await ctx.answerCallbackQuery({ text: `Running ${trimLine(entry.commandText, 32)}` });
-      await handleUserPrompt(ctx, target, entry.commandText);
-      return;
-    }
+			pendingCommandPickers.delete(activePicker.contextKey);
+			await ctx.answerCallbackQuery({
+				text: `Running ${trimLine(entry.commandText, 32)}`,
+			});
+			await handleUserPrompt(ctx, target, entry.commandText);
+			return;
+		}
 
-    pendingCommandPickers.delete(activePicker.contextKey);
-    await ctx.answerCallbackQuery({ text: `Opening ${trimLine(entry.commandText, 32)}` });
-    await runTelePiPickerCommand(ctx, target, entry.command);
-  });
+		pendingCommandPickers.delete(activePicker.contextKey);
+		await ctx.answerCallbackQuery({
+			text: `Opening ${trimLine(entry.commandText, 32)}`,
+		});
+		await runTelePiPickerCommand(ctx, target, entry.command);
+	});
 
-  return {
-    openCommandPicker,
-  };
+	return {
+		openCommandPicker,
+	};
 }

--- a/src/bot/commands/basic.ts
+++ b/src/bot/commands/basic.ts
@@ -1,140 +1,224 @@
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { Context } from "grammy";
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
 
 import { escapeHTML } from "../../format.js";
-import type { PiSessionContext, PiSessionRegistry, PiSessionService } from "../../pi-session.js";
-import { renderFailedText, renderHelpHTML, renderHelpPlain, renderPrefixedError, renderSessionInfoHTML, renderSessionInfoPlain, renderVoiceSupportHTML, renderVoiceSupportPlain } from "../message-rendering.js";
+import type {
+	PiSessionContext,
+	PiSessionRegistry,
+	PiSessionService,
+} from "../../pi-session.js";
+import {
+	renderFailedText,
+	renderHelpHTML,
+	renderHelpPlain,
+	renderPrefixedError,
+	renderSessionInfoHTML,
+	renderSessionInfoPlain,
+	renderVoiceSupportHTML,
+	renderVoiceSupportPlain,
+} from "../message-rendering.js";
 import type { TextOptions } from "../telegram-transport.js";
 
 export function createBasicCommandHandlers(deps: {
-  sessionRegistry: PiSessionRegistry;
-  getExistingSession: (target: PiSessionContext) => PiSessionService | undefined;
-  getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
-  refreshChatScopedCommands: (target: PiSessionContext, piSession: PiSessionService) => Promise<void>;
-  openCommandPicker: (ctx: Context, target: PiSessionContext) => Promise<void>;
-  handleUserPrompt: (
-    ctx: Context,
-    target: PiSessionContext,
-    userText: string,
-    preloadedSlashCommands?: SlashCommandInfo[],
-  ) => Promise<boolean>;
-  getLastPrompt: (target: PiSessionContext) => string | undefined;
-  extensionDialogs: { cancelPending: (target: PiSessionContext) => Promise<boolean> };
-  getVoiceBackendStatus: () => Promise<{ backends: string[]; warning?: string }>;
-  safeReply: (ctx: Context, text: string, options?: TextOptions, target?: PiSessionContext) => Promise<void>;
+	sessionRegistry: PiSessionRegistry;
+	getExistingSession: (
+		target: PiSessionContext,
+	) => PiSessionService | undefined;
+	getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
+	refreshChatScopedCommands: (
+		target: PiSessionContext,
+		piSession: PiSessionService,
+	) => Promise<void>;
+	openCommandPicker: (ctx: Context, target: PiSessionContext) => Promise<void>;
+	handleUserPrompt: (
+		ctx: Context,
+		target: PiSessionContext,
+		userText: string,
+		preloadedSlashCommands?: SlashCommandInfo[],
+	) => Promise<boolean>;
+	getLastPrompt: (target: PiSessionContext) => string | undefined;
+	extensionDialogs: {
+		cancelPending: (target: PiSessionContext) => Promise<boolean>;
+	};
+	getVoiceBackendStatus: () => Promise<{
+		backends: string[];
+		warning?: string;
+	}>;
+	safeReply: (
+		ctx: Context,
+		text: string,
+		options?: TextOptions,
+		target?: PiSessionContext,
+	) => Promise<void>;
 }) {
-  const {
-    sessionRegistry,
-    getExistingSession,
-    getOrCreateSession,
-    refreshChatScopedCommands,
-    openCommandPicker,
-    handleUserPrompt,
-    getLastPrompt,
-    extensionDialogs,
-    getVoiceBackendStatus,
-    safeReply,
-  } = deps;
+	const {
+		sessionRegistry,
+		getExistingSession,
+		getOrCreateSession,
+		refreshChatScopedCommands,
+		openCommandPicker,
+		handleUserPrompt,
+		getLastPrompt,
+		extensionDialogs,
+		getVoiceBackendStatus,
+		safeReply,
+	} = deps;
 
-  const handleStartCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const piSession = await getOrCreateSession(target);
-    await refreshChatScopedCommands(target, piSession);
-    const info = piSession.getInfo();
-    let voiceStatus: { backends: string[]; warning?: string } = { backends: [] };
-    try {
-      voiceStatus = (await getVoiceBackendStatus()) ?? { backends: [] };
-    } catch {
-      // Keep /start working even if backend probing fails.
-    }
-    const voiceInfoPlain = renderVoiceSupportPlain(voiceStatus.backends, voiceStatus.warning);
-    const voiceInfoHTML = renderVoiceSupportHTML(voiceStatus.backends, voiceStatus.warning);
-    const plainText = [
-      "TelePi is ready.",
-      "",
-      "Each Telegram chat/topic gets its own Pi session.",
-      "Send any text message to continue the current Pi session from Telegram.",
-      "Send a voice message or audio file to transcribe it into a Pi prompt.",
-      "Use /help to see all commands. Use /retry to resend the last prompt in this chat/topic.",
-      voiceInfoPlain,
-      "",
-      renderSessionInfoPlain(info),
-    ].join("\n");
-    const html = [
-      "<b>TelePi is ready.</b>",
-      "",
-      "Each Telegram chat/topic gets its own Pi session.",
-      "Send any text message to continue the current Pi session from Telegram.",
-      "Send a voice message or audio file to transcribe it into a Pi prompt.",
-      "Use <code>/help</code> to see all commands. Use <code>/retry</code> to resend the last prompt in this chat/topic.",
-      voiceInfoHTML,
-      "",
-      renderSessionInfoHTML(info),
-    ].join("\n");
+	const handleStartCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const piSession = await getOrCreateSession(target);
+		await refreshChatScopedCommands(target, piSession);
+		const info = piSession.getInfo();
+		let voiceStatus: { backends: string[]; warning?: string } = {
+			backends: [],
+		};
+		try {
+			voiceStatus = (await getVoiceBackendStatus()) ?? { backends: [] };
+		} catch {
+			// Keep /start working even if backend probing fails.
+		}
+		const voiceInfoPlain = renderVoiceSupportPlain(
+			voiceStatus.backends,
+			voiceStatus.warning,
+		);
+		const voiceInfoHTML = renderVoiceSupportHTML(
+			voiceStatus.backends,
+			voiceStatus.warning,
+		);
+		const plainText = [
+			"TelePi is ready.",
+			"",
+			"Each Telegram chat/topic gets its own Pi session.",
+			"Send any text message to continue the current Pi session from Telegram.",
+			"Send a voice message or audio file to transcribe it into a Pi prompt.",
+			"Use /help to see all commands. Use /retry to resend the last prompt in this chat/topic.",
+			voiceInfoPlain,
+			"",
+			renderSessionInfoPlain(info),
+		].join("\n");
+		const html = [
+			"<b>TelePi is ready.</b>",
+			"",
+			"Each Telegram chat/topic gets its own Pi session.",
+			"Send any text message to continue the current Pi session from Telegram.",
+			"Send a voice message or audio file to transcribe it into a Pi prompt.",
+			"Use <code>/help</code> to see all commands. Use <code>/retry</code> to resend the last prompt in this chat/topic.",
+			voiceInfoHTML,
+			"",
+			renderSessionInfoHTML(info),
+		].join("\n");
 
-    await safeReply(ctx, html, { fallbackText: plainText }, target);
-  };
+		await safeReply(ctx, html, { fallbackText: plainText }, target);
+	};
 
-  const handleHelpCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const info = sessionRegistry.getInfo(target);
-    await safeReply(ctx, renderHelpHTML(info), {
-      fallbackText: renderHelpPlain(info),
-    }, target);
-  };
+	const handleHelpCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const info = sessionRegistry.getInfo(target);
+		await safeReply(
+			ctx,
+			renderHelpHTML(info),
+			{
+				fallbackText: renderHelpPlain(info),
+			},
+			target,
+		);
+	};
 
-  const handleCommandsCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    await openCommandPicker(ctx, target);
-  };
+	const handleCommandsCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		await openCommandPicker(ctx, target);
+	};
 
-  const handleAbortCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    await extensionDialogs.cancelPending(target);
+	const handleAbortCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		await extensionDialogs.cancelPending(target);
 
-    const piSession = getExistingSession(target);
-    if (!piSession?.hasActiveSession()) {
-      await safeReply(ctx, escapeHTML("No active session to abort."), {
-        fallbackText: "No active session to abort.",
-      }, target);
-      return;
-    }
+		const piSession = getExistingSession(target);
+		if (!piSession?.hasActiveSession()) {
+			await safeReply(
+				ctx,
+				escapeHTML("No active session to abort."),
+				{
+					fallbackText: "No active session to abort.",
+				},
+				target,
+			);
+			return;
+		}
 
-    try {
-      await piSession.abort();
-      await safeReply(ctx, escapeHTML("Aborted current operation"), {
-        fallbackText: "Aborted current operation",
-      }, target);
-    } catch (error) {
-      const failure = renderFailedText(error);
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-    }
-  };
+		try {
+			await piSession.abort();
+			await safeReply(
+				ctx,
+				escapeHTML("Aborted current operation"),
+				{
+					fallbackText: "Aborted current operation",
+				},
+				target,
+			);
+		} catch (error) {
+			const failure = renderFailedText(error);
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+		}
+	};
 
-  const handleSessionCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const info = sessionRegistry.getInfo(target);
-    await safeReply(ctx, renderSessionInfoHTML(info), {
-      fallbackText: renderSessionInfoPlain(info),
-    }, target);
-  };
+	const handleSessionCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const info = sessionRegistry.getInfo(target);
+		await safeReply(
+			ctx,
+			renderSessionInfoHTML(info),
+			{
+				fallbackText: renderSessionInfoPlain(info),
+			},
+			target,
+		);
+	};
 
-  const handleRetryCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const lastPrompt = getLastPrompt(target);
-    if (!lastPrompt) {
-      await safeReply(ctx, escapeHTML("Nothing to retry yet in this chat/topic."), {
-        fallbackText: "Nothing to retry yet in this chat/topic.",
-      }, target);
-      return;
-    }
+	const handleRetryCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const lastPrompt = getLastPrompt(target);
+		if (!lastPrompt) {
+			await safeReply(
+				ctx,
+				escapeHTML("Nothing to retry yet in this chat/topic."),
+				{
+					fallbackText: "Nothing to retry yet in this chat/topic.",
+				},
+				target,
+			);
+			return;
+		}
 
-    await handleUserPrompt(ctx, target, lastPrompt);
-  };
+		await handleUserPrompt(ctx, target, lastPrompt);
+	};
 
-  return {
-    handleStartCommand,
-    handleHelpCommand,
-    handleCommandsCommand,
-    handleAbortCommand,
-    handleSessionCommand,
-    handleRetryCommand,
-  };
+	return {
+		handleStartCommand,
+		handleHelpCommand,
+		handleCommandsCommand,
+		handleAbortCommand,
+		handleSessionCommand,
+		handleRetryCommand,
+	};
 }

--- a/src/bot/commands/sessions.ts
+++ b/src/bot/commands/sessions.ts
@@ -1,295 +1,421 @@
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import type { Context } from "grammy";
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
 
 import { escapeHTML } from "../../format.js";
-import type { PiSessionContext, PiSessionInfo, PiSessionService } from "../../pi-session.js";
+import type {
+	PiSessionContext,
+	PiSessionInfo,
+	PiSessionService,
+} from "../../pi-session.js";
 import type { KeyboardItem } from "../keyboard.js";
-import { getWorkspaceShortName, renderFailedText, renderPrefixedError, renderSessionInfoHTML, renderSessionInfoPlain, trimLine } from "../message-rendering.js";
+import {
+	getWorkspaceShortName,
+	renderFailedText,
+	renderPrefixedError,
+	renderSessionInfoHTML,
+	renderSessionInfoPlain,
+	trimLine,
+} from "../message-rendering.js";
 import type { TextOptions } from "../telegram-transport.js";
 
 export function createSessionCommandHandlers(deps: {
-  getContextKey: (target: PiSessionContext) => string;
-  getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
-  getExistingSession: (target: PiSessionContext) => PiSessionService | undefined;
-  isBusy: (target: PiSessionContext) => boolean;
-  beginSwitching: (target: PiSessionContext) => void;
-  endSwitching: (target: PiSessionContext) => void;
-  buildKeyboard: (items: KeyboardItem[], page: number, prefix: string, extraItems?: KeyboardItem[]) => any;
-  clearContextPickers: (contextKey: string) => void;
-  clearContextPromptMemory: (target: PiSessionContext) => void;
-  refreshChatScopedCommands: (target: PiSessionContext, piSession: PiSessionService) => Promise<void>;
-  syncChatScopedCommands: (target: PiSessionContext, slashCommands: SlashCommandInfo[]) => Promise<void>;
-  setChatCommandSignature: (chatId: number | string, signature?: string) => void;
-  removeSession: (target: PiSessionContext) => void;
-  pendingSessionPicks: Map<string, Array<{ path: string; cwd: string }>>;
-  pendingSessionButtons: Map<string, KeyboardItem[]>;
-  pendingWorkspacePicks: Map<string, string[]>;
-  pendingWorkspaceButtons: Map<string, KeyboardItem[]>;
-  safeReply: (ctx: Context, text: string, options?: TextOptions, target?: PiSessionContext) => Promise<void>;
-  surfaceStartupErrorDiagnostics: (ctx: Context, target: PiSessionContext, info: PiSessionInfo) => Promise<void>;
+	getContextKey: (target: PiSessionContext) => string;
+	getOrCreateSession: (target: PiSessionContext) => Promise<PiSessionService>;
+	getExistingSession: (
+		target: PiSessionContext,
+	) => PiSessionService | undefined;
+	isBusy: (target: PiSessionContext) => boolean;
+	beginSwitching: (target: PiSessionContext) => void;
+	endSwitching: (target: PiSessionContext) => void;
+	buildKeyboard: (
+		items: KeyboardItem[],
+		page: number,
+		prefix: string,
+		extraItems?: KeyboardItem[],
+	) => any;
+	clearContextPickers: (contextKey: string) => void;
+	clearContextPromptMemory: (target: PiSessionContext) => void;
+	refreshChatScopedCommands: (
+		target: PiSessionContext,
+		piSession: PiSessionService,
+	) => Promise<void>;
+	syncChatScopedCommands: (
+		target: PiSessionContext,
+		slashCommands: SlashCommandInfo[],
+	) => Promise<void>;
+	setChatCommandSignature: (
+		chatId: number | string,
+		signature?: string,
+	) => void;
+	removeSession: (target: PiSessionContext) => void;
+	pendingSessionPicks: Map<string, Array<{ path: string; cwd: string }>>;
+	pendingSessionButtons: Map<string, KeyboardItem[]>;
+	pendingWorkspacePicks: Map<string, string[]>;
+	pendingWorkspaceButtons: Map<string, KeyboardItem[]>;
+	safeReply: (
+		ctx: Context,
+		text: string,
+		options?: TextOptions,
+		target?: PiSessionContext,
+	) => Promise<void>;
+	surfaceStartupErrorDiagnostics: (
+		ctx: Context,
+		target: PiSessionContext,
+		info: PiSessionInfo,
+	) => Promise<void>;
 }) {
-  const {
-    getContextKey,
-    getOrCreateSession,
-    getExistingSession,
-    isBusy,
-    beginSwitching,
-    endSwitching,
-    buildKeyboard,
-    clearContextPickers,
-    clearContextPromptMemory,
-    refreshChatScopedCommands,
-    syncChatScopedCommands,
-    setChatCommandSignature,
-    removeSession,
-    pendingSessionPicks,
-    pendingSessionButtons,
-    pendingWorkspacePicks,
-    pendingWorkspaceButtons,
-    safeReply,
-    surfaceStartupErrorDiagnostics,
-  } = deps;
+	const {
+		getContextKey,
+		getOrCreateSession,
+		getExistingSession,
+		isBusy,
+		beginSwitching,
+		endSwitching,
+		buildKeyboard,
+		clearContextPickers,
+		clearContextPromptMemory,
+		refreshChatScopedCommands,
+		syncChatScopedCommands,
+		setChatCommandSignature,
+		removeSession,
+		pendingSessionPicks,
+		pendingSessionButtons,
+		pendingWorkspacePicks,
+		pendingWorkspaceButtons,
+		safeReply,
+		surfaceStartupErrorDiagnostics,
+	} = deps;
 
-  const handleSessionsCommand = async (
-    ctx: Context,
-    target: PiSessionContext,
-    commandText?: string,
-  ): Promise<void> => {
-    const contextKey = getContextKey(target);
+	const handleSessionsCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+		commandText?: string,
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
 
-    if (isBusy(target)) {
-      await safeReply(ctx, escapeHTML("Cannot switch sessions while a prompt is running."), {
-        fallbackText: "Cannot switch sessions while a prompt is running.",
-      }, target);
-      return;
-    }
+		if (isBusy(target)) {
+			await safeReply(
+				ctx,
+				escapeHTML("Cannot switch sessions while a prompt is running."),
+				{
+					fallbackText: "Cannot switch sessions while a prompt is running.",
+				},
+				target,
+			);
+			return;
+		}
 
-    const piSession = await getOrCreateSession(target);
-    const rawText = commandText ?? ctx.message?.text ?? "";
-    const sessionReference = rawText.replace(/^\/(?:sessions|switch)(?:@\w+)?\s*/, "").trim();
-    if (sessionReference) {
-      beginSwitching(target);
-      try {
-        const resolvedSession = await piSession.resolveSessionReference(sessionReference);
-        const info = await piSession.switchSession(resolvedSession.path, resolvedSession.cwd);
-        if (info.cancelled) {
-          await safeReply(ctx, escapeHTML("Session switch was cancelled."), {
-            fallbackText: "Session switch was cancelled.",
-          }, target);
-          return;
-        }
+		const piSession = await getOrCreateSession(target);
+		const rawText = commandText ?? ctx.message?.text ?? "";
+		const sessionReference = rawText
+			.replace(/^\/(?:sessions|switch)(?:@\w+)?\s*/, "")
+			.trim();
+		if (sessionReference) {
+			beginSwitching(target);
+			try {
+				const resolvedSession =
+					await piSession.resolveSessionReference(sessionReference);
+				const info = await piSession.switchSession(
+					resolvedSession.path,
+					resolvedSession.cwd,
+				);
+				if (info.cancelled) {
+					await safeReply(
+						ctx,
+						escapeHTML("Session switch was cancelled."),
+						{
+							fallbackText: "Session switch was cancelled.",
+						},
+						target,
+					);
+					return;
+				}
 
-        await refreshChatScopedCommands(target, piSession);
-        clearContextPickers(contextKey);
-        clearContextPromptMemory(target);
-        const workspaceNotePlain = resolvedSession.workspaceWarning
-          ? `\n\nWorkspace note: ${resolvedSession.workspaceWarning}`
-          : "";
-        const workspaceNoteHTML = resolvedSession.workspaceWarning
-          ? `\n\n<b>Workspace note:</b> ${escapeHTML(resolvedSession.workspaceWarning)}`
-          : "";
-        const plainText = `Switched session.${workspaceNotePlain}\n\n${renderSessionInfoPlain(info)}`;
-        const html = `<b>Switched session.</b>${workspaceNoteHTML}\n\n${renderSessionInfoHTML(info)}`;
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-        await surfaceStartupErrorDiagnostics(ctx, target, info);
-      } catch (error) {
-        const failure = renderFailedText(error);
-        await safeReply(ctx, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        }, target);
-      } finally {
-        endSwitching(target);
-      }
-      return;
-    }
+				await refreshChatScopedCommands(target, piSession);
+				clearContextPickers(contextKey);
+				clearContextPromptMemory(target);
+				const workspaceNotePlain = resolvedSession.workspaceWarning
+					? `\n\nWorkspace note: ${resolvedSession.workspaceWarning}`
+					: "";
+				const workspaceNoteHTML = resolvedSession.workspaceWarning
+					? `\n\n<b>Workspace note:</b> ${escapeHTML(resolvedSession.workspaceWarning)}`
+					: "";
+				const plainText = `Switched session.${workspaceNotePlain}\n\n${renderSessionInfoPlain(info)}`;
+				const html = `<b>Switched session.</b>${workspaceNoteHTML}\n\n${renderSessionInfoHTML(info)}`;
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+				await surfaceStartupErrorDiagnostics(ctx, target, info);
+			} catch (error) {
+				const failure = renderFailedText(error);
+				await safeReply(
+					ctx,
+					failure.text,
+					{
+						fallbackText: failure.fallbackText,
+						parseMode: failure.parseMode,
+					},
+					target,
+				);
+			} finally {
+				endSwitching(target);
+			}
+			return;
+		}
 
-    const allSessions = await piSession.listAllSessions();
-    if (allSessions.length === 0) {
-      await safeReply(ctx, escapeHTML("No saved sessions found."), {
-        fallbackText: "No saved sessions found.",
-      }, target);
-      return;
-    }
+		const allSessions = await piSession.listAllSessions();
+		if (allSessions.length === 0) {
+			await safeReply(
+				ctx,
+				escapeHTML("No saved sessions found."),
+				{
+					fallbackText: "No saved sessions found.",
+				},
+				target,
+			);
+			return;
+		}
 
-    const orderedPicks: Array<{ path: string; cwd: string }> = [];
-    const sessionButtons: KeyboardItem[] = allSessions.map((session, idx) => {
-      const shortWorkspace = getWorkspaceShortName(session.cwd || "Unknown");
-      const label = trimLine(session.name || session.firstMessage, 35) || `Session ${idx + 1}`;
-      orderedPicks.push({ path: session.path, cwd: session.cwd });
-      return {
-        label: `📁 ${shortWorkspace.slice(0, 8)} · ${label.slice(0, 30)}`,
-        callbackData: `switch_${idx}`,
-      };
-    });
+		const orderedPicks: Array<{ path: string; cwd: string }> = [];
+		const sessionButtons: KeyboardItem[] = allSessions.map((session, idx) => {
+			const shortWorkspace = getWorkspaceShortName(session.cwd || "Unknown");
+			const label =
+				trimLine(session.name || session.firstMessage, 35) ||
+				`Session ${idx + 1}`;
+			orderedPicks.push({ path: session.path, cwd: session.cwd });
+			return {
+				label: `📁 ${shortWorkspace.slice(0, 8)} · ${label.slice(0, 30)}`,
+				callbackData: `switch_${idx}`,
+			};
+		});
 
-    pendingSessionPicks.set(contextKey, orderedPicks);
-    pendingSessionButtons.set(contextKey, sessionButtons);
+		pendingSessionPicks.set(contextKey, orderedPicks);
+		pendingSessionButtons.set(contextKey, sessionButtons);
 
-    const keyboard = buildKeyboard(sessionButtons, 0, "switch");
-    const plainText = `Select a session to switch (${allSessions.length} found).`;
-    const html = `<b>Select a session to switch</b> <i>(${allSessions.length} found)</i>`;
+		const keyboard = buildKeyboard(sessionButtons, 0, "switch");
+		const plainText = `Select a session to switch (${allSessions.length} found).`;
+		const html = `<b>Select a session to switch</b> <i>(${allSessions.length} found)</i>`;
 
-    await safeReply(ctx, html, {
-      fallbackText: plainText,
-      replyMarkup: keyboard,
-    }, target);
-  };
+		await safeReply(
+			ctx,
+			html,
+			{
+				fallbackText: plainText,
+				replyMarkup: keyboard,
+			},
+			target,
+		);
+	};
 
-  const handleNewCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const contextKey = getContextKey(target);
+	const handleNewCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
 
-    if (isBusy(target)) {
-      await safeReply(ctx, escapeHTML("Cannot create new session while a prompt is running."), {
-        fallbackText: "Cannot create new session while a prompt is running.",
-      }, target);
-      return;
-    }
+		if (isBusy(target)) {
+			await safeReply(
+				ctx,
+				escapeHTML("Cannot create new session while a prompt is running."),
+				{
+					fallbackText: "Cannot create new session while a prompt is running.",
+				},
+				target,
+			);
+			return;
+		}
 
-    const piSession = await getOrCreateSession(target);
-    const workspaces = await piSession.listWorkspaces();
+		const piSession = await getOrCreateSession(target);
+		const workspaces = await piSession.listWorkspaces();
 
-    if (workspaces.length <= 1) {
-      try {
-        const { info, created } = await piSession.newSession();
-        if (!created) {
-          await safeReply(ctx, escapeHTML("New session was cancelled."), {
-            fallbackText: "New session was cancelled.",
-          }, target);
-          return;
-        }
+		if (workspaces.length <= 1) {
+			try {
+				const { info, created } = await piSession.newSession();
+				if (!created) {
+					await safeReply(
+						ctx,
+						escapeHTML("New session was cancelled."),
+						{
+							fallbackText: "New session was cancelled.",
+						},
+						target,
+					);
+					return;
+				}
 
-        await refreshChatScopedCommands(target, piSession);
-        clearContextPickers(contextKey);
-        clearContextPromptMemory(target);
-        const plainText = `New session created.\n\n${renderSessionInfoPlain(info)}`;
-        const html = `<b>New session created.</b>\n\n${renderSessionInfoHTML(info)}`;
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-        await surfaceStartupErrorDiagnostics(ctx, target, info);
-      } catch (error) {
-        const failure = renderFailedText(error);
-        await safeReply(ctx, failure.text, {
-          fallbackText: failure.fallbackText,
-          parseMode: failure.parseMode,
-        }, target);
-      }
-      return;
-    }
+				await refreshChatScopedCommands(target, piSession);
+				clearContextPickers(contextKey);
+				clearContextPromptMemory(target);
+				const plainText = `New session created.\n\n${renderSessionInfoPlain(info)}`;
+				const html = `<b>New session created.</b>\n\n${renderSessionInfoHTML(info)}`;
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+				await surfaceStartupErrorDiagnostics(ctx, target, info);
+			} catch (error) {
+				const failure = renderFailedText(error);
+				await safeReply(
+					ctx,
+					failure.text,
+					{
+						fallbackText: failure.fallbackText,
+						parseMode: failure.parseMode,
+					},
+					target,
+				);
+			}
+			return;
+		}
 
-    pendingWorkspacePicks.set(contextKey, workspaces);
-    const currentWorkspace = piSession.getCurrentWorkspace();
-    const workspaceButtons = workspaces.map((workspace, index) => {
-      const shortName = getWorkspaceShortName(workspace);
-      const prefix = workspace === currentWorkspace ? "📂 " : "📁 ";
-      return {
-        label: `${prefix}${shortName}`,
-        callbackData: `newws_${index}`,
-      };
-    });
-    pendingWorkspaceButtons.set(contextKey, workspaceButtons);
+		pendingWorkspacePicks.set(contextKey, workspaces);
+		const currentWorkspace = piSession.getCurrentWorkspace();
+		const workspaceButtons = workspaces.map((workspace, index) => {
+			const shortName = getWorkspaceShortName(workspace);
+			const prefix = workspace === currentWorkspace ? "📂 " : "📁 ";
+			return {
+				label: `${prefix}${shortName}`,
+				callbackData: `newws_${index}`,
+			};
+		});
+		pendingWorkspaceButtons.set(contextKey, workspaceButtons);
 
-    await safeReply(ctx, "<b>Select workspace for new session:</b>", {
-      fallbackText: "Select workspace for new session:",
-      replyMarkup: buildKeyboard(workspaceButtons, 0, "newws"),
-    }, target);
-  };
+		await safeReply(
+			ctx,
+			"<b>Select workspace for new session:</b>",
+			{
+				fallbackText: "Select workspace for new session:",
+				replyMarkup: buildKeyboard(workspaceButtons, 0, "newws"),
+			},
+			target,
+		);
+	};
 
-  const handleHandbackCommand = async (ctx: Context, target: PiSessionContext): Promise<void> => {
-    const contextKey = getContextKey(target);
-    const piSession = getExistingSession(target);
+	const handleHandbackCommand = async (
+		ctx: Context,
+		target: PiSessionContext,
+	): Promise<void> => {
+		const contextKey = getContextKey(target);
+		const piSession = getExistingSession(target);
 
-    if (isBusy(target)) {
-      await safeReply(ctx, escapeHTML("Cannot hand back while a prompt is running. Use /abort first."), {
-        fallbackText: "Cannot hand back while a prompt is running. Use /abort first.",
-      }, target);
-      return;
-    }
+		if (isBusy(target)) {
+			await safeReply(
+				ctx,
+				escapeHTML(
+					"Cannot hand back while a prompt is running. Use /abort first.",
+				),
+				{
+					fallbackText:
+						"Cannot hand back while a prompt is running. Use /abort first.",
+				},
+				target,
+			);
+			return;
+		}
 
-    if (!piSession?.hasActiveSession()) {
-      await safeReply(ctx, escapeHTML("No active session to hand back."), {
-        fallbackText: "No active session to hand back.",
-      }, target);
-      return;
-    }
+		if (!piSession?.hasActiveSession()) {
+			await safeReply(
+				ctx,
+				escapeHTML("No active session to hand back."),
+				{
+					fallbackText: "No active session to hand back.",
+				},
+				target,
+			);
+			return;
+		}
 
-    try {
-      const { sessionFile, workspace } = await piSession.handback();
-      clearContextPickers(contextKey);
-      clearContextPromptMemory(target);
-      removeSession(target);
-      setChatCommandSignature(target.chatId, undefined);
-      try {
-        await syncChatScopedCommands(target, []);
-      } catch (error) {
-        console.error("Failed to reset chat-scoped Telegram commands", error);
-      }
+		try {
+			const { sessionFile, workspace } = await piSession.handback();
+			clearContextPickers(contextKey);
+			clearContextPromptMemory(target);
+			removeSession(target);
+			setChatCommandSignature(target.chatId, undefined);
+			try {
+				await syncChatScopedCommands(target, []);
+			} catch (error) {
+				console.error("Failed to reset chat-scoped Telegram commands", error);
+			}
 
-      if (!sessionFile) {
-        await safeReply(ctx, escapeHTML("Session was in-memory. No file to resume.\nUse /new to start a fresh session."), {
-          fallbackText: "Session was in-memory. No file to resume.\nUse /new to start a fresh session.",
-        }, target);
-        return;
-      }
+			if (!sessionFile) {
+				await safeReply(
+					ctx,
+					escapeHTML(
+						"Session was in-memory. No file to resume.\nUse /new to start a fresh session.",
+					),
+					{
+						fallbackText:
+							"Session was in-memory. No file to resume.\nUse /new to start a fresh session.",
+					},
+					target,
+				);
+				return;
+			}
 
-      const shellEscape = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'";
-      const piCommand = `cd ${shellEscape(workspace)} && pi --session ${shellEscape(sessionFile)}`;
-      const piContinueCommand = `cd ${shellEscape(workspace)} && pi -c`;
+			const shellEscape = (s: string): string =>
+				"'" + s.replace(/'/g, "'\\''") + "'";
+			const piCommand = `cd ${shellEscape(workspace)} && pi --session ${shellEscape(sessionFile)}`;
+			const piContinueCommand = `cd ${shellEscape(workspace)} && pi -c`;
 
-      let copiedToClipboard = false;
-      try {
-        const { copyToClipboard: copyToClipboardUtil } = await import("../../install/clipboard.js");
-        copiedToClipboard = await copyToClipboardUtil(piCommand);
-      } catch {
-        // Ignore clipboard failures.
-      }
+			let copiedToClipboard = false;
+			try {
+				const { copyToClipboard: copyToClipboardUtil } = await import(
+					"../../install/clipboard.js"
+				);
+				copiedToClipboard = await copyToClipboardUtil(piCommand);
+			} catch {
+				// Ignore clipboard failures.
+			}
 
-      const plainText = [
-        "🔄 Session handed back to Pi CLI.",
-        "",
-        "Run this in your terminal:",
-        piCommand,
-        "",
-        "Or simply:",
-        piContinueCommand,
-        "(to continue the most recent session)",
-        copiedToClipboard ? "" : undefined,
-        copiedToClipboard ? "📋 Command copied to clipboard!" : undefined,
-        "",
-        "Send any message here to start a new TelePi session.",
-      ]
-        .filter((line): line is string => line !== undefined)
-        .join("\n");
+			const plainText = [
+				"🔄 Session handed back to Pi CLI.",
+				"",
+				"Run this in your terminal:",
+				piCommand,
+				"",
+				"Or simply:",
+				piContinueCommand,
+				"(to continue the most recent session)",
+				copiedToClipboard ? "" : undefined,
+				copiedToClipboard ? "📋 Command copied to clipboard!" : undefined,
+				"",
+				"Send any message here to start a new TelePi session.",
+			]
+				.filter((line): line is string => line !== undefined)
+				.join("\n");
 
-      const html = [
-        "<b>🔄 Session handed back to Pi CLI.</b>",
-        "",
-        "Run this in your terminal:",
-        `<pre>${escapeHTML(piCommand)}</pre>`,
-        "",
-        "Or simply:",
-        `<pre>${escapeHTML(piContinueCommand)}</pre>`,
-        "<i>(to continue the most recent session)</i>",
-        copiedToClipboard ? "" : undefined,
-        copiedToClipboard ? "📋 <i>Command copied to clipboard!</i>" : undefined,
-        "",
-        "Send any message here to start a new TelePi session.",
-      ]
-        .filter((line): line is string => line !== undefined)
-        .join("\n");
+			const html = [
+				"<b>🔄 Session handed back to Pi CLI.</b>",
+				"",
+				"Run this in your terminal:",
+				`<pre>${escapeHTML(piCommand)}</pre>`,
+				"",
+				"Or simply:",
+				`<pre>${escapeHTML(piContinueCommand)}</pre>`,
+				"<i>(to continue the most recent session)</i>",
+				copiedToClipboard ? "" : undefined,
+				copiedToClipboard
+					? "📋 <i>Command copied to clipboard!</i>"
+					: undefined,
+				"",
+				"Send any message here to start a new TelePi session.",
+			]
+				.filter((line): line is string => line !== undefined)
+				.join("\n");
 
-      await safeReply(ctx, html, { fallbackText: plainText }, target);
-    } catch (error) {
-      const failure = renderFailedText(error);
-      await safeReply(ctx, failure.text, {
-        fallbackText: failure.fallbackText,
-        parseMode: failure.parseMode,
-      }, target);
-    }
-  };
+			await safeReply(ctx, html, { fallbackText: plainText }, target);
+		} catch (error) {
+			const failure = renderFailedText(error);
+			await safeReply(
+				ctx,
+				failure.text,
+				{
+					fallbackText: failure.fallbackText,
+					parseMode: failure.parseMode,
+				},
+				target,
+			);
+		}
+	};
 
-  return {
-    handleSessionsCommand,
-    handleNewCommand,
-    handleHandbackCommand,
-  };
+	return {
+		handleSessionsCommand,
+		handleNewCommand,
+		handleHandbackCommand,
+	};
 }

--- a/src/bot/prompt-handler.ts
+++ b/src/bot/prompt-handler.ts
@@ -1,533 +1,606 @@
-import { InlineKeyboard, type Bot, type Context } from "grammy";
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
-import type { ImageContent } from "@mariozechner/pi-ai";
-
+import type { ImageContent } from "@earendil-works/pi-ai";
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
+import { type Bot, type Context, InlineKeyboard } from "grammy";
+import type { ToolVerbosity } from "../config.js";
 import { formatError } from "../errors.js";
+import type { PiSessionContext, PiSessionService } from "../pi-session.js";
+import { createTelegramUIContext } from "../telegram-ui-context.js";
+import type { ChatTaskRunner } from "./chat-task-runner.js";
+import type { ExtensionDialogManager } from "./extension-dialogs.js";
 import {
-  appendWithCap,
-  buildStreamingPreview,
-  formatToolSummaryLine,
-  isMessageNotModifiedError,
-  renderExtensionError,
-  renderExtensionNotice,
-  renderPromptFailure,
-  renderToolEndMessage,
-  renderToolStartMessage,
-  renderMarkdownChunkWithinLimit,
-  splitMarkdownForTelegram,
-  TOOL_OUTPUT_PREVIEW_LIMIT,
-  type RenderedChunk,
-  type RenderedText,
+	appendWithCap,
+	buildStreamingPreview,
+	formatToolSummaryLine,
+	isMessageNotModifiedError,
+	type RenderedChunk,
+	type RenderedText,
+	renderExtensionError,
+	renderExtensionNotice,
+	renderMarkdownChunkWithinLimit,
+	renderPromptFailure,
+	renderToolEndMessage,
+	renderToolStartMessage,
+	splitMarkdownForTelegram,
+	TOOL_OUTPUT_PREVIEW_LIMIT,
 } from "./message-rendering.js";
 import {
-  safeEditMessage,
-  safeReply,
-  sendChatAction,
-  sendTextMessage,
+	safeEditMessage,
+	safeReply,
+	sendChatAction,
+	sendTextMessage,
 } from "./telegram-transport.js";
-import { createTelegramUIContext } from "../telegram-ui-context.js";
-import type { ToolVerbosity } from "../config.js";
-import type { ExtensionDialogManager } from "./extension-dialogs.js";
-import type { ChatTaskRunner } from "./chat-task-runner.js";
-import type { PiSessionContext, PiSessionService } from "../pi-session.js";
 
 export type HandleUserPrompt = (
-  ctx: Context,
-  target: PiSessionContext,
-  userText: string,
-  preloadedSlashCommands?: SlashCommandInfo[],
-  images?: ImageContent[],
+	ctx: Context,
+	target: PiSessionContext,
+	userText: string,
+	preloadedSlashCommands?: SlashCommandInfo[],
+	images?: ImageContent[],
 ) => Promise<boolean>;
 
 interface CreatePromptHandlerOptions {
-  bot: Bot<Context>;
-  toolVerbosity: ToolVerbosity;
-  editDebounceMs: number;
-  typingIntervalMs: number;
-  isBusy: (target: PiSessionContext) => boolean;
-  taskRunner: ChatTaskRunner;
-  ensureActiveSession: (ctx: Context, target: PiSessionContext) => Promise<PiSessionService | undefined>;
-  syncChatScopedCommands: (target: PiSessionContext, slashCommands: SlashCommandInfo[]) => Promise<void>;
-  refreshChatScopedCommands: (target: PiSessionContext, piSession: PiSessionService) => Promise<void>;
-  extensionDialogs: Pick<ExtensionDialogManager, "openSelect" | "openConfirm" | "openInput">;
-  sendBusyReply: (ctx: Context) => Promise<void>;
+	bot: Bot<Context>;
+	toolVerbosity: ToolVerbosity;
+	editDebounceMs: number;
+	typingIntervalMs: number;
+	isBusy: (target: PiSessionContext) => boolean;
+	taskRunner: ChatTaskRunner;
+	ensureActiveSession: (
+		ctx: Context,
+		target: PiSessionContext,
+	) => Promise<PiSessionService | undefined>;
+	syncChatScopedCommands: (
+		target: PiSessionContext,
+		slashCommands: SlashCommandInfo[],
+	) => Promise<void>;
+	refreshChatScopedCommands: (
+		target: PiSessionContext,
+		piSession: PiSessionService,
+	) => Promise<void>;
+	extensionDialogs: Pick<
+		ExtensionDialogManager,
+		"openSelect" | "openConfirm" | "openInput"
+	>;
+	sendBusyReply: (ctx: Context) => Promise<void>;
 }
 
-type PromptFlowDeps = Omit<CreatePromptHandlerOptions, "isBusy" | "taskRunner" | "sendBusyReply">;
+type PromptFlowDeps = Omit<
+	CreatePromptHandlerOptions,
+	"isBusy" | "taskRunner" | "sendBusyReply"
+>;
 
 type ToolState = {
-  toolName: string;
-  partialResult: string;
-  messageId?: number;
-  finalStatus?: RenderedText;
+	toolName: string;
+	partialResult: string;
+	messageId?: number;
+	finalStatus?: RenderedText;
 };
 
 async function runPromptFlow(
-  deps: PromptFlowDeps,
-  ctx: Context,
-  target: PiSessionContext,
-  userText: string,
-  preloadedSlashCommands?: SlashCommandInfo[],
-  images?: ImageContent[],
+	deps: PromptFlowDeps,
+	ctx: Context,
+	target: PiSessionContext,
+	userText: string,
+	preloadedSlashCommands?: SlashCommandInfo[],
+	images?: ImageContent[],
 ): Promise<void> {
-  const {
-    bot,
-    toolVerbosity,
-    editDebounceMs,
-    typingIntervalMs,
-    ensureActiveSession,
-    syncChatScopedCommands,
-    refreshChatScopedCommands,
-    extensionDialogs,
-  } = deps;
+	const {
+		bot,
+		toolVerbosity,
+		editDebounceMs,
+		typingIntervalMs,
+		ensureActiveSession,
+		syncChatScopedCommands,
+		refreshChatScopedCommands,
+		extensionDialogs,
+	} = deps;
 
-  const piSession = await ensureActiveSession(ctx, target);
-  if (!piSession) {
-    return;
-  }
+	const piSession = await ensureActiveSession(ctx, target);
+	if (!piSession) {
+		return;
+	}
 
-  const slashCommands = preloadedSlashCommands;
-  if (slashCommands) {
-    void syncChatScopedCommands(target, slashCommands).catch((error) => {
-      console.error("Failed to sync chat-scoped Telegram commands", error);
-    });
-  } else {
-    void refreshChatScopedCommands(target, piSession);
-  }
+	const slashCommands = preloadedSlashCommands;
+	if (slashCommands) {
+		void syncChatScopedCommands(target, slashCommands).catch((error) => {
+			console.error("Failed to sync chat-scoped Telegram commands", error);
+		});
+	} else {
+		void refreshChatScopedCommands(target, piSession);
+	}
 
-  const abortKeyboard = new InlineKeyboard().text("⏹ Abort", "pi_abort");
-  const toolStates = new Map<string, ToolState>();
-  const toolCounts = new Map<string, number>();
-  let accumulatedText = "";
-  let responseMessageId: number | undefined;
-  let responseMessagePromise: Promise<void> | undefined;
-  let lastRenderedText = "";
-  let lastEditAt = 0;
-  let flushTimer: NodeJS.Timeout | undefined;
-  let isFlushing = false;
-  let flushPending = false;
-  let finalized = false;
+	const abortKeyboard = new InlineKeyboard().text("⏹ Abort", "pi_abort");
+	const toolStates = new Map<string, ToolState>();
+	const toolCounts = new Map<string, number>();
+	let accumulatedText = "";
+	let responseMessageId: number | undefined;
+	let responseMessagePromise: Promise<void> | undefined;
+	let lastRenderedText = "";
+	let lastEditAt = 0;
+	let flushTimer: NodeJS.Timeout | undefined;
+	let isFlushing = false;
+	let flushPending = false;
+	let finalized = false;
 
-  const typingInterval = setInterval(() => {
-    void sendChatAction(bot.api, target, "typing").catch(() => {});
-  }, typingIntervalMs);
-  void sendChatAction(bot.api, target, "typing").catch(() => {});
+	const typingInterval = setInterval(() => {
+		void sendChatAction(bot.api, target, "typing").catch(() => {});
+	}, typingIntervalMs);
+	void sendChatAction(bot.api, target, "typing").catch(() => {});
 
-  const stopTyping = (): void => {
-    clearInterval(typingInterval);
-  };
+	const stopTyping = (): void => {
+		clearInterval(typingInterval);
+	};
 
-  const clearFlushTimer = (): void => {
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = undefined;
-    }
-  };
+	const clearFlushTimer = (): void => {
+		if (flushTimer) {
+			clearTimeout(flushTimer);
+			flushTimer = undefined;
+		}
+	};
 
-  const renderPreview = (): RenderedChunk => {
-    const previewText = buildStreamingPreview(accumulatedText);
-    return renderMarkdownChunkWithinLimit(previewText);
-  };
+	const renderPreview = (): RenderedChunk => {
+		const previewText = buildStreamingPreview(accumulatedText);
+		return renderMarkdownChunkWithinLimit(previewText);
+	};
 
-  const buildFinalResponseText = (text: string): string => {
-    if (toolVerbosity !== "summary") {
-      return text.trim();
-    }
+	const buildFinalResponseText = (text: string): string => {
+		if (toolVerbosity !== "summary") {
+			return text.trim();
+		}
 
-    const summaryLine = formatToolSummaryLine(toolCounts);
-    const trimmedText = text.trim();
-    if (!summaryLine) {
-      return trimmedText;
-    }
+		const summaryLine = formatToolSummaryLine(toolCounts);
+		const trimmedText = text.trim();
+		if (!summaryLine) {
+			return trimmedText;
+		}
 
-    return trimmedText ? `${trimmedText}\n\n${summaryLine}` : summaryLine;
-  };
+		return trimmedText ? `${trimmedText}\n\n${summaryLine}` : summaryLine;
+	};
 
-  const ensureResponseMessage = async (): Promise<void> => {
-    if (responseMessageId) {
-      return;
-    }
-    if (responseMessagePromise) {
-      await responseMessagePromise;
-      return;
-    }
+	const ensureResponseMessage = async (): Promise<void> => {
+		if (responseMessageId) {
+			return;
+		}
+		if (responseMessagePromise) {
+			await responseMessagePromise;
+			return;
+		}
 
-    responseMessagePromise = (async () => {
-      stopTyping();
-      const preview = renderPreview();
-      const message = await sendTextMessage(bot.api, target, preview.text, {
-        parseMode: preview.parseMode,
-        fallbackText: preview.fallbackText,
-        replyMarkup: abortKeyboard,
-      });
-      responseMessageId = message.message_id;
-      lastRenderedText = preview.text;
-      lastEditAt = Date.now();
-    })();
+		responseMessagePromise = (async () => {
+			stopTyping();
+			const preview = renderPreview();
+			const message = await sendTextMessage(bot.api, target, preview.text, {
+				parseMode: preview.parseMode,
+				fallbackText: preview.fallbackText,
+				replyMarkup: abortKeyboard,
+			});
+			responseMessageId = message.message_id;
+			lastRenderedText = preview.text;
+			lastEditAt = Date.now();
+		})();
 
-    try {
-      await responseMessagePromise;
-    } finally {
-      responseMessagePromise = undefined;
-    }
-  };
+		try {
+			await responseMessagePromise;
+		} finally {
+			responseMessagePromise = undefined;
+		}
+	};
 
-  const flushResponse = async (force = false): Promise<void> => {
-    if (!accumulatedText) {
-      return;
-    }
-    if (!responseMessageId) {
-      await ensureResponseMessage();
-      return;
-    }
-    if (isFlushing) {
-      flushPending = true;
-      return;
-    }
+	const flushResponse = async (force = false): Promise<void> => {
+		if (!accumulatedText) {
+			return;
+		}
+		if (!responseMessageId) {
+			await ensureResponseMessage();
+			return;
+		}
+		if (isFlushing) {
+			flushPending = true;
+			return;
+		}
 
-    const now = Date.now();
-    if (!force && now - lastEditAt < editDebounceMs) {
-      return;
-    }
+		const now = Date.now();
+		if (!force && now - lastEditAt < editDebounceMs) {
+			return;
+		}
 
-    const nextText = renderPreview();
-    if (nextText.text === lastRenderedText) {
-      return;
-    }
+		const nextText = renderPreview();
+		if (nextText.text === lastRenderedText) {
+			return;
+		}
 
-    isFlushing = true;
-    try {
-      await safeEditMessage(bot, target, responseMessageId, nextText.text, {
-        parseMode: nextText.parseMode,
-        fallbackText: nextText.fallbackText,
-        replyMarkup: abortKeyboard,
-      });
-      lastRenderedText = nextText.text;
-      lastEditAt = Date.now();
-    } finally {
-      isFlushing = false;
-      if (flushPending) {
-        flushPending = false;
-        scheduleFlush();
-      }
-    }
-  };
+		isFlushing = true;
+		try {
+			await safeEditMessage(bot, target, responseMessageId, nextText.text, {
+				parseMode: nextText.parseMode,
+				fallbackText: nextText.fallbackText,
+				replyMarkup: abortKeyboard,
+			});
+			lastRenderedText = nextText.text;
+			lastEditAt = Date.now();
+		} finally {
+			isFlushing = false;
+			if (flushPending) {
+				flushPending = false;
+				scheduleFlush();
+			}
+		}
+	};
 
-  const scheduleFlush = (): void => {
-    if (flushTimer || finalized) {
-      return;
-    }
+	const scheduleFlush = (): void => {
+		if (flushTimer || finalized) {
+			return;
+		}
 
-    const delay = Math.max(0, editDebounceMs - (Date.now() - lastEditAt));
-    flushTimer = setTimeout(() => {
-      flushTimer = undefined;
-      void flushResponse().catch((error) => {
-        console.error("Failed to update Telegram response message", error);
-      });
-    }, delay);
-  };
+		const delay = Math.max(0, editDebounceMs - (Date.now() - lastEditAt));
+		flushTimer = setTimeout(() => {
+			flushTimer = undefined;
+			void flushResponse().catch((error) => {
+				console.error("Failed to update Telegram response message", error);
+			});
+		}, delay);
+	};
 
-  const removeAbortKeyboard = async (): Promise<void> => {
-    if (!responseMessageId) {
-      return;
-    }
+	const removeAbortKeyboard = async (): Promise<void> => {
+		if (!responseMessageId) {
+			return;
+		}
 
-    try {
-      await bot.api.editMessageReplyMarkup(target.chatId, responseMessageId, {
-        reply_markup: new InlineKeyboard(),
-      });
-    } catch (error) {
-      if (!isMessageNotModifiedError(error)) {
-        console.error("Failed to clear Abort button", error);
-      }
-    }
-  };
+		try {
+			await bot.api.editMessageReplyMarkup(target.chatId, responseMessageId, {
+				reply_markup: new InlineKeyboard(),
+			});
+		} catch (error) {
+			if (!isMessageNotModifiedError(error)) {
+				console.error("Failed to clear Abort button", error);
+			}
+		}
+	};
 
-  const deliverRenderedChunks = async (chunks: RenderedChunk[]): Promise<void> => {
-    if (chunks.length === 0) {
-      return;
-    }
+	const deliverRenderedChunks = async (
+		chunks: RenderedChunk[],
+	): Promise<void> => {
+		if (chunks.length === 0) {
+			return;
+		}
 
-    const [firstChunk, ...remainingChunks] = chunks;
-    if (responseMessageId) {
-      await safeEditMessage(bot, target, responseMessageId, firstChunk.text, {
-        parseMode: firstChunk.parseMode,
-        fallbackText: firstChunk.fallbackText,
-      });
-      await removeAbortKeyboard();
-    } else {
-      const message = await sendTextMessage(bot.api, target, firstChunk.text, {
-        parseMode: firstChunk.parseMode,
-        fallbackText: firstChunk.fallbackText,
-      });
-      responseMessageId = message.message_id;
-    }
+		const [firstChunk, ...remainingChunks] = chunks;
+		if (responseMessageId) {
+			await safeEditMessage(bot, target, responseMessageId, firstChunk.text, {
+				parseMode: firstChunk.parseMode,
+				fallbackText: firstChunk.fallbackText,
+			});
+			await removeAbortKeyboard();
+		} else {
+			const message = await sendTextMessage(bot.api, target, firstChunk.text, {
+				parseMode: firstChunk.parseMode,
+				fallbackText: firstChunk.fallbackText,
+			});
+			responseMessageId = message.message_id;
+		}
 
-    for (const chunk of remainingChunks) {
-      await sendTextMessage(bot.api, target, chunk.text, {
-        parseMode: chunk.parseMode,
-        fallbackText: chunk.fallbackText,
-      });
-    }
-  };
+		for (const chunk of remainingChunks) {
+			await sendTextMessage(bot.api, target, chunk.text, {
+				parseMode: chunk.parseMode,
+				fallbackText: chunk.fallbackText,
+			});
+		}
+	};
 
-  const finalizeResponse = async (): Promise<void> => {
-    if (finalized) {
-      return;
-    }
-    finalized = true;
+	const finalizeResponse = async (): Promise<void> => {
+		if (finalized) {
+			return;
+		}
+		finalized = true;
 
-    stopTyping();
-    clearFlushTimer();
-    if (responseMessagePromise) {
-      try {
-        await responseMessagePromise;
-      } catch {
-        // If the initial send failed, we will fall back to sending the final response below.
-      }
-    }
+		stopTyping();
+		clearFlushTimer();
+		if (responseMessagePromise) {
+			try {
+				await responseMessagePromise;
+			} catch {
+				// If the initial send failed, we will fall back to sending the final response below.
+			}
+		}
 
-    const finalText = buildFinalResponseText(accumulatedText);
-    if (!finalText) {
-      const html = "<b>✅ Done</b>";
-      const plainText = "✅ Done";
+		const finalText = buildFinalResponseText(accumulatedText);
+		if (!finalText) {
+			const html = "<b>✅ Done</b>";
+			const plainText = "✅ Done";
 
-      if (responseMessageId) {
-        await safeEditMessage(bot, target, responseMessageId, html, { fallbackText: plainText });
-        await removeAbortKeyboard();
-      } else {
-        await safeReply(ctx, html, { fallbackText: plainText }, target);
-      }
-      return;
-    }
+			if (responseMessageId) {
+				await safeEditMessage(bot, target, responseMessageId, html, {
+					fallbackText: plainText,
+				});
+				await removeAbortKeyboard();
+			} else {
+				await safeReply(ctx, html, { fallbackText: plainText }, target);
+			}
+			return;
+		}
 
-    await deliverRenderedChunks(splitMarkdownForTelegram(finalText));
-  };
+		await deliverRenderedChunks(splitMarkdownForTelegram(finalText));
+	};
 
-  await piSession.bindExtensions({
-    commandContextActions: {
-      waitForIdle: async () => {
-        await piSession.getSession().agent.waitForIdle();
-      },
-      newSession: async (options) => {
-        const result = await piSession.newSession(options);
-        return { cancelled: !result.created };
-      },
-      fork: async (entryId, forkOptions) => piSession.fork(entryId, forkOptions),
-      navigateTree: async (targetId, navOptions) => {
-        const result = await piSession.navigateTree(targetId, navOptions);
-        return { cancelled: result.cancelled };
-      },
-      switchSession: async (sessionPath, switchOptions) => {
-        const result = await piSession.switchSession(sessionPath, switchOptions);
-        return { cancelled: result.cancelled };
-      },
-      reload: async () => {
-        await piSession.reload();
-      },
-    },
-    uiContext: createTelegramUIContext({
-      notify: (message, type) => {
-        const rendered = renderExtensionNotice(message, type);
-        void sendTextMessage(bot.api, target, rendered.text, {
-          parseMode: rendered.parseMode,
-          fallbackText: rendered.fallbackText,
-        }).catch((error) => {
-          console.error("Failed to send extension notification", error);
-        });
-      },
-      select: (title, choices, dialogOptions) => extensionDialogs.openSelect(target, title, choices, dialogOptions),
-      confirm: (title, message, dialogOptions) => extensionDialogs.openConfirm(target, title, message, dialogOptions),
-      input: (title, placeholder, dialogOptions) => extensionDialogs.openInput(target, title, placeholder, dialogOptions),
-    }),
-    onError: (error) => {
-      const rendered = renderExtensionError(error.extensionPath, error.event, error.error);
-      void sendTextMessage(bot.api, target, rendered.text, {
-        parseMode: rendered.parseMode,
-        fallbackText: rendered.fallbackText,
-      }).catch((sendError) => {
-        console.error("Failed to send extension error", sendError);
-      });
-    },
-  });
+	await piSession.bindExtensions({
+		commandContextActions: {
+			waitForIdle: async () => {
+				await piSession.getSession().agent.waitForIdle();
+			},
+			newSession: async (options) => {
+				const result = await piSession.newSession(options);
+				return { cancelled: !result.created };
+			},
+			fork: async (entryId, forkOptions) =>
+				piSession.fork(entryId, forkOptions),
+			navigateTree: async (targetId, navOptions) => {
+				const result = await piSession.navigateTree(targetId, navOptions);
+				return { cancelled: result.cancelled };
+			},
+			switchSession: async (sessionPath, switchOptions) => {
+				const result = await piSession.switchSession(
+					sessionPath,
+					switchOptions,
+				);
+				return { cancelled: result.cancelled };
+			},
+			reload: async () => {
+				await piSession.reload();
+			},
+		},
+		uiContext: createTelegramUIContext({
+			notify: (message, type) => {
+				const rendered = renderExtensionNotice(message, type);
+				void sendTextMessage(bot.api, target, rendered.text, {
+					parseMode: rendered.parseMode,
+					fallbackText: rendered.fallbackText,
+				}).catch((error) => {
+					console.error("Failed to send extension notification", error);
+				});
+			},
+			select: (title, choices, dialogOptions) =>
+				extensionDialogs.openSelect(target, title, choices, dialogOptions),
+			confirm: (title, message, dialogOptions) =>
+				extensionDialogs.openConfirm(target, title, message, dialogOptions),
+			input: (title, placeholder, dialogOptions) =>
+				extensionDialogs.openInput(target, title, placeholder, dialogOptions),
+		}),
+		onError: (error) => {
+			const rendered = renderExtensionError(
+				error.extensionPath,
+				error.event,
+				error.error,
+			);
+			void sendTextMessage(bot.api, target, rendered.text, {
+				parseMode: rendered.parseMode,
+				fallbackText: rendered.fallbackText,
+			}).catch((sendError) => {
+				console.error("Failed to send extension error", sendError);
+			});
+		},
+	});
 
-  const unsubscribe = piSession.subscribe({
-    onTextDelta: (delta) => {
-      accumulatedText += delta;
-      if (!responseMessageId) {
-        void ensureResponseMessage()
-          .then(() => {
-            scheduleFlush();
-          })
-          .catch((error) => {
-            console.error("Failed to send initial Telegram response message", error);
-          });
-        return;
-      }
+	const unsubscribe = piSession.subscribe({
+		onTextDelta: (delta) => {
+			accumulatedText += delta;
+			if (!responseMessageId) {
+				void ensureResponseMessage()
+					.then(() => {
+						scheduleFlush();
+					})
+					.catch((error) => {
+						console.error(
+							"Failed to send initial Telegram response message",
+							error,
+						);
+					});
+				return;
+			}
 
-      scheduleFlush();
-    },
-    onToolStart: (toolName, toolCallId) => {
-      if (toolVerbosity === "summary") {
-        toolCounts.set(toolName, (toolCounts.get(toolName) ?? 0) + 1);
-        return;
-      }
+			scheduleFlush();
+		},
+		onToolStart: (toolName, toolCallId) => {
+			if (toolVerbosity === "summary") {
+				toolCounts.set(toolName, (toolCounts.get(toolName) ?? 0) + 1);
+				return;
+			}
 
-      if (toolVerbosity === "none") {
-        return;
-      }
+			if (toolVerbosity === "none") {
+				return;
+			}
 
-      toolStates.set(toolCallId, { toolName, partialResult: "" });
-      if (toolVerbosity !== "all") {
-        return;
-      }
+			toolStates.set(toolCallId, { toolName, partialResult: "" });
+			if (toolVerbosity !== "all") {
+				return;
+			}
 
-      const messageText = renderToolStartMessage(toolName);
+			const messageText = renderToolStartMessage(toolName);
 
-      void (async () => {
-        const message = await sendTextMessage(bot.api, target, messageText.text, {
-          parseMode: messageText.parseMode,
-          fallbackText: messageText.fallbackText,
-        });
-        const state = toolStates.get(toolCallId);
-        if (!state) {
-          return;
-        }
+			void (async () => {
+				const message = await sendTextMessage(
+					bot.api,
+					target,
+					messageText.text,
+					{
+						parseMode: messageText.parseMode,
+						fallbackText: messageText.fallbackText,
+					},
+				);
+				const state = toolStates.get(toolCallId);
+				if (!state) {
+					return;
+				}
 
-        state.messageId = message.message_id;
-        if (state.finalStatus) {
-          await safeEditMessage(bot, target, state.messageId, state.finalStatus.text, {
-            parseMode: state.finalStatus.parseMode,
-            fallbackText: state.finalStatus.fallbackText,
-          });
-        }
-      })().catch((error) => {
-        console.error(`Failed to send tool start message for ${toolName}`, error);
-      });
-    },
-    onToolUpdate: (toolCallId, partialResult) => {
-      if (toolVerbosity === "none" || toolVerbosity === "summary") {
-        return;
-      }
+				state.messageId = message.message_id;
+				if (state.finalStatus) {
+					await safeEditMessage(
+						bot,
+						target,
+						state.messageId,
+						state.finalStatus.text,
+						{
+							parseMode: state.finalStatus.parseMode,
+							fallbackText: state.finalStatus.fallbackText,
+						},
+					);
+				}
+			})().catch((error) => {
+				console.error(
+					`Failed to send tool start message for ${toolName}`,
+					error,
+				);
+			});
+		},
+		onToolUpdate: (toolCallId, partialResult) => {
+			if (toolVerbosity === "none" || toolVerbosity === "summary") {
+				return;
+			}
 
-      const state = toolStates.get(toolCallId);
-      if (!state || !partialResult) {
-        return;
-      }
+			const state = toolStates.get(toolCallId);
+			if (!state || !partialResult) {
+				return;
+			}
 
-      state.partialResult = appendWithCap(state.partialResult, partialResult, TOOL_OUTPUT_PREVIEW_LIMIT);
-    },
-    onToolEnd: (toolCallId, isError) => {
-      if (toolVerbosity === "none" || toolVerbosity === "summary") {
-        return;
-      }
+			state.partialResult = appendWithCap(
+				state.partialResult,
+				partialResult,
+				TOOL_OUTPUT_PREVIEW_LIMIT,
+			);
+		},
+		onToolEnd: (toolCallId, isError) => {
+			if (toolVerbosity === "none" || toolVerbosity === "summary") {
+				return;
+			}
 
-      const state = toolStates.get(toolCallId);
-      if (!state) {
-        return;
-      }
+			const state = toolStates.get(toolCallId);
+			if (!state) {
+				return;
+			}
 
-      state.finalStatus = renderToolEndMessage(state.toolName, state.partialResult, isError);
-      if (toolVerbosity === "errors-only") {
-        if (!isError) {
-          return;
-        }
+			state.finalStatus = renderToolEndMessage(
+				state.toolName,
+				state.partialResult,
+				isError,
+			);
+			if (toolVerbosity === "errors-only") {
+				if (!isError) {
+					return;
+				}
 
-        void sendTextMessage(bot.api, target, state.finalStatus.text, {
-          parseMode: state.finalStatus.parseMode,
-          fallbackText: state.finalStatus.fallbackText,
-        }).catch((error) => {
-          console.error(`Failed to send tool error message for ${state.toolName}`, error);
-        });
-        return;
-      }
+				void sendTextMessage(bot.api, target, state.finalStatus.text, {
+					parseMode: state.finalStatus.parseMode,
+					fallbackText: state.finalStatus.fallbackText,
+				}).catch((error) => {
+					console.error(
+						`Failed to send tool error message for ${state.toolName}`,
+						error,
+					);
+				});
+				return;
+			}
 
-      if (!state.messageId) {
-        return;
-      }
+			if (!state.messageId) {
+				return;
+			}
 
-      void safeEditMessage(bot, target, state.messageId, state.finalStatus.text, {
-        parseMode: state.finalStatus.parseMode,
-        fallbackText: state.finalStatus.fallbackText,
-      }).catch((error) => {
-        console.error(`Failed to update tool message for ${state.toolName}`, error);
-      });
-    },
-    onAgentEnd: () => {
-      void finalizeResponse().catch((error) => {
-        console.error("Failed to finalize Telegram response message", error);
-      });
-    },
-  });
+			void safeEditMessage(
+				bot,
+				target,
+				state.messageId,
+				state.finalStatus.text,
+				{
+					parseMode: state.finalStatus.parseMode,
+					fallbackText: state.finalStatus.fallbackText,
+				},
+			).catch((error) => {
+				console.error(
+					`Failed to update tool message for ${state.toolName}`,
+					error,
+				);
+			});
+		},
+		onAgentEnd: () => {
+			void finalizeResponse().catch((error) => {
+				console.error("Failed to finalize Telegram response message", error);
+			});
+		},
+	});
 
-  try {
-    if (images && images.length > 0) {
-      await piSession.prompt(userText, images);
-    } else {
-      await piSession.prompt(userText);
-    }
-    await finalizeResponse();
-  } catch (error) {
-    stopTyping();
-    clearFlushTimer();
-    if (responseMessagePromise) {
-      try {
-        await responseMessagePromise;
-      } catch {
-        // Ignore; we will send an error message below.
-      }
-    }
+	try {
+		if (images && images.length > 0) {
+			await piSession.prompt(userText, images);
+		} else {
+			await piSession.prompt(userText);
+		}
+		await finalizeResponse();
+	} catch (error) {
+		stopTyping();
+		clearFlushTimer();
+		if (responseMessagePromise) {
+			try {
+				await responseMessagePromise;
+			} catch {
+				// Ignore; we will send an error message below.
+			}
+		}
 
-    if (finalized) {
-      console.error("Pi prompt error after finalization:", formatError(error));
-    } else {
-      finalized = true;
+		if (finalized) {
+			console.error("Pi prompt error after finalization:", formatError(error));
+		} else {
+			finalized = true;
 
-      const combinedText = buildFinalResponseText(renderPromptFailure(accumulatedText, error));
-      const chunks = splitMarkdownForTelegram(combinedText);
-      try {
-        await deliverRenderedChunks(chunks);
-      } catch (telegramError) {
-        console.error("Failed to send error message to Telegram:", telegramError);
-      }
-    }
-  } finally {
-    stopTyping();
-    clearFlushTimer();
-    unsubscribe();
-  }
+			const combinedText = buildFinalResponseText(
+				renderPromptFailure(accumulatedText, error),
+			);
+			const chunks = splitMarkdownForTelegram(combinedText);
+			try {
+				await deliverRenderedChunks(chunks);
+			} catch (telegramError) {
+				console.error(
+					"Failed to send error message to Telegram:",
+					telegramError,
+				);
+			}
+		}
+	} finally {
+		stopTyping();
+		clearFlushTimer();
+		unsubscribe();
+	}
 }
 
-export function createPromptHandler(options: CreatePromptHandlerOptions): HandleUserPrompt {
-  const {
-    isBusy,
-    taskRunner,
-    sendBusyReply,
-    ...promptFlowDeps
-  } = options;
+export function createPromptHandler(
+	options: CreatePromptHandlerOptions,
+): HandleUserPrompt {
+	const { isBusy, taskRunner, sendBusyReply, ...promptFlowDeps } = options;
 
-  return async (
-    ctx: Context,
-    target: PiSessionContext,
-    userText: string,
-    preloadedSlashCommands?: SlashCommandInfo[],
-    images?: ImageContent[],
-  ): Promise<boolean> => {
-    if (isBusy(target)) {
-      await sendBusyReply(ctx);
-      return false;
-    }
+	return async (
+		ctx: Context,
+		target: PiSessionContext,
+		userText: string,
+		preloadedSlashCommands?: SlashCommandInfo[],
+		images?: ImageContent[],
+	): Promise<boolean> => {
+		if (isBusy(target)) {
+			await sendBusyReply(ctx);
+			return false;
+		}
 
-    const result = taskRunner.tryStartPrompt(
-      target,
-      userText,
-      () => runPromptFlow(promptFlowDeps, ctx, target, userText, preloadedSlashCommands, images),
-    );
-    if (result === "busy") {
-      await sendBusyReply(ctx);
-      return false;
-    }
+		const result = taskRunner.tryStartPrompt(target, userText, () =>
+			runPromptFlow(
+				promptFlowDeps,
+				ctx,
+				target,
+				userText,
+				preloadedSlashCommands,
+				images,
+			),
+		);
+		if (result === "busy") {
+			await sendBusyReply(ctx);
+			return false;
+		}
 
-    return true;
-  };
+		return true;
+	};
 }

--- a/src/bot/slash-command.ts
+++ b/src/bot/slash-command.ts
@@ -1,342 +1,411 @@
 import { readFileSync } from "node:fs";
 
 import {
-  parseFrontmatter,
-  type SlashCommandInfo,
-} from "@mariozechner/pi-coding-agent";
+	parseFrontmatter,
+	type SlashCommandInfo,
+} from "@earendil-works/pi-coding-agent";
 
 import { trimLine } from "./message-rendering.js";
 
 export const TELEPI_BOT_COMMANDS = [
-  { command: "start", description: "Welcome and session info" },
-  { command: "help", description: "Show commands and usage tips" },
-  { command: "commands", description: "Browse TelePi and Pi commands" },
-  { command: "new", description: "Start a new session" },
-  { command: "retry", description: "Retry the last prompt in this chat/topic" },
-  { command: "handback", description: "Hand session back to Pi CLI" },
-  { command: "abort", description: "Cancel current operation" },
-  { command: "session", description: "Current session details" },
-  { command: "sessions", description: "List and switch sessions (or /sessions <path|id>)" },
-  { command: "context", description: "Show context usage and session stats" },
-  { command: "model", description: "Switch AI model" },
-  { command: "tree", description: "View and navigate the session tree" },
-  { command: "branch", description: "Navigate to a tree entry (/branch <id>)" },
-  { command: "label", description: "Label an entry (/label [name] or /label <id> <name>)" },
+	{ command: "start", description: "Welcome and session info" },
+	{ command: "help", description: "Show commands and usage tips" },
+	{ command: "commands", description: "Browse TelePi and Pi commands" },
+	{ command: "new", description: "Start a new session" },
+	{ command: "retry", description: "Retry the last prompt in this chat/topic" },
+	{ command: "handback", description: "Hand session back to Pi CLI" },
+	{ command: "abort", description: "Cancel current operation" },
+	{ command: "session", description: "Current session details" },
+	{
+		command: "sessions",
+		description: "List and switch sessions (or /sessions <path|id>)",
+	},
+	{ command: "context", description: "Show context usage and session stats" },
+	{ command: "model", description: "Switch AI model" },
+	{ command: "tree", description: "View and navigate the session tree" },
+	{ command: "branch", description: "Navigate to a tree entry (/branch <id>)" },
+	{
+		command: "label",
+		description: "Label an entry (/label [name] or /label <id> <name>)",
+	},
 ] as const;
 
 export const TELEPI_LOCAL_COMMAND_NAMES = new Set<string>([
-  ...TELEPI_BOT_COMMANDS.map((command) => command.command),
-  "switch",
+	...TELEPI_BOT_COMMANDS.map((command) => command.command),
+	"switch",
 ]);
 
 export type NormalizedSlashCommand = {
-  name: string;
-  text: string;
+	name: string;
+	text: string;
 };
 
 export type CommandPickerFilter = "all" | "telepi" | "pi";
 
 export type CommandPickerEntry =
-  | {
-      id: number;
-      kind: "telepi";
-      command: string;
-      description: string;
-      label: string;
-      commandText: string;
-    }
-  | {
-      id: number;
-      kind: "pi";
-      name: string;
-      description: string;
-      label: string;
-      commandText: string;
-      source: string;
-    };
+	| {
+			id: number;
+			kind: "telepi";
+			command: string;
+			description: string;
+			label: string;
+			commandText: string;
+	  }
+	| {
+			id: number;
+			kind: "pi";
+			name: string;
+			description: string;
+			label: string;
+			commandText: string;
+			source: string;
+	  };
 
 export type TelepiNativeCommandMenuEntry = {
-  id: string;
-  label: string;
-  commandText: string;
+	id: string;
+	label: string;
+	commandText: string;
 };
 
 export type TelepiNativeCommandMenu = {
-  name: string;
-  bareCommandText: string;
-  title: string;
-  entries: TelepiNativeCommandMenuEntry[];
+	name: string;
+	bareCommandText: string;
+	title: string;
+	entries: TelepiNativeCommandMenuEntry[];
 };
 
-export function normalizeSlashCommand(text: string, botUsername?: string): NormalizedSlashCommand | undefined {
-  const trimmed = text.trim();
-  if (!trimmed.startsWith("/")) {
-    return undefined;
-  }
+export function normalizeSlashCommand(
+	text: string,
+	botUsername?: string,
+): NormalizedSlashCommand | undefined {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("/")) {
+		return undefined;
+	}
 
-  const spaceIndex = trimmed.indexOf(" ");
-  const rawCommand = (spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex)).slice(1);
-  const args = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1).trim();
-  const atIndex = rawCommand.indexOf("@");
-  const rawName = atIndex === -1 ? rawCommand : rawCommand.slice(0, atIndex);
-  const addressedBot = atIndex === -1 ? undefined : rawCommand.slice(atIndex + 1);
+	const spaceIndex = trimmed.indexOf(" ");
+	const rawCommand = (
+		spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex)
+	).slice(1);
+	const args = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1).trim();
+	const atIndex = rawCommand.indexOf("@");
+	const rawName = atIndex === -1 ? rawCommand : rawCommand.slice(0, atIndex);
+	const addressedBot =
+		atIndex === -1 ? undefined : rawCommand.slice(atIndex + 1);
 
-  if (!rawName) {
-    return undefined;
-  }
+	if (!rawName) {
+		return undefined;
+	}
 
-  if (addressedBot && botUsername && addressedBot.toLowerCase() !== botUsername.toLowerCase()) {
-    return undefined;
-  }
+	if (
+		addressedBot &&
+		botUsername &&
+		addressedBot.toLowerCase() !== botUsername.toLowerCase()
+	) {
+		return undefined;
+	}
 
-  return {
-    name: rawName,
-    text: args ? `/${rawName} ${args}` : `/${rawName}`,
-  };
+	return {
+		name: rawName,
+		text: args ? `/${rawName} ${args}` : `/${rawName}`,
+	};
 }
 
 type SlashCommandInfoWithArgumentHint = SlashCommandInfo & {
-  argumentHint?: string;
+	argumentHint?: string;
 };
 
 function normalizeArgumentHint(argumentHint: unknown): string | undefined {
-  if (typeof argumentHint !== "string") {
-    return undefined;
-  }
+	if (typeof argumentHint !== "string") {
+		return undefined;
+	}
 
-  const trimmed = argumentHint.trim();
-  return trimmed ? trimmed : undefined;
+	const trimmed = argumentHint.trim();
+	return trimmed ? trimmed : undefined;
 }
 
 function readPromptArgumentHint(sourcePath: string): string | undefined {
-  try {
-    const { frontmatter } = parseFrontmatter<Record<string, unknown>>(readFileSync(sourcePath, "utf8"));
-    return normalizeArgumentHint(frontmatter["argument-hint"]);
-  } catch {
-    return undefined;
-  }
+	try {
+		const { frontmatter } = parseFrontmatter<Record<string, unknown>>(
+			readFileSync(sourcePath, "utf8"),
+		);
+		return normalizeArgumentHint(frontmatter["argument-hint"]);
+	} catch {
+		return undefined;
+	}
 }
 
-function createSlashCommandArgumentHintResolver(): (command: SlashCommandInfo) => string | undefined {
-  const hintBySourcePath = new Map<string, string | undefined>();
+function createSlashCommandArgumentHintResolver(): (
+	command: SlashCommandInfo,
+) => string | undefined {
+	const hintBySourcePath = new Map<string, string | undefined>();
 
-  return (command: SlashCommandInfo): string | undefined => {
-    const commandWithMetadata = command as SlashCommandInfoWithArgumentHint;
-    const directHint = normalizeArgumentHint(commandWithMetadata.argumentHint);
-    if (directHint) {
-      return directHint;
-    }
+	return (command: SlashCommandInfo): string | undefined => {
+		const commandWithMetadata = command as SlashCommandInfoWithArgumentHint;
+		const directHint = normalizeArgumentHint(commandWithMetadata.argumentHint);
+		if (directHint) {
+			return directHint;
+		}
 
-    if (command.source !== "prompt") {
-      return undefined;
-    }
+		if (command.source !== "prompt") {
+			return undefined;
+		}
 
-    const sourcePath = typeof command.sourceInfo?.path === "string" ? command.sourceInfo.path.trim() : "";
-    if (!sourcePath) {
-      return undefined;
-    }
+		const sourcePath =
+			typeof command.sourceInfo?.path === "string"
+				? command.sourceInfo.path.trim()
+				: "";
+		if (!sourcePath) {
+			return undefined;
+		}
 
-    if (hintBySourcePath.has(sourcePath)) {
-      return hintBySourcePath.get(sourcePath);
-    }
+		if (hintBySourcePath.has(sourcePath)) {
+			return hintBySourcePath.get(sourcePath);
+		}
 
-    const argumentHint = readPromptArgumentHint(sourcePath);
-    hintBySourcePath.set(sourcePath, argumentHint);
-    return argumentHint;
-  };
+		const argumentHint = readPromptArgumentHint(sourcePath);
+		hintBySourcePath.set(sourcePath, argumentHint);
+		return argumentHint;
+	};
 }
 
 function getPiSlashCommandDisplayText(
-  command: SlashCommandInfo,
-  getSlashCommandArgumentHint: (command: SlashCommandInfo) => string | undefined,
+	command: SlashCommandInfo,
+	getSlashCommandArgumentHint: (
+		command: SlashCommandInfo,
+	) => string | undefined,
 ): string {
-  const argumentHint = getSlashCommandArgumentHint(command);
-  return argumentHint ? `/${command.name} ${argumentHint}` : `/${command.name}`;
+	const argumentHint = getSlashCommandArgumentHint(command);
+	return argumentHint ? `/${command.name} ${argumentHint}` : `/${command.name}`;
 }
 
 function getPiSlashCommandLabel(
-  command: SlashCommandInfo,
-  getSlashCommandArgumentHint: (command: SlashCommandInfo) => string | undefined,
+	command: SlashCommandInfo,
+	getSlashCommandArgumentHint: (
+		command: SlashCommandInfo,
+	) => string | undefined,
 ): string {
-  const displayText = getPiSlashCommandDisplayText(command, getSlashCommandArgumentHint);
+	const displayText = getPiSlashCommandDisplayText(
+		command,
+		getSlashCommandArgumentHint,
+	);
 
-  switch (command.source) {
-    case "prompt":
-      return `📝 ${displayText}`;
-    case "skill":
-      return `🧰 ${displayText}`;
-    case "extension":
-      return `🧩 ${displayText}`;
-    default:
-      return `⚡ ${displayText}`;
-  }
+	switch (command.source) {
+		case "prompt":
+			return `📝 ${displayText}`;
+		case "skill":
+			return `🧰 ${displayText}`;
+		case "extension":
+			return `🧩 ${displayText}`;
+		default:
+			return `⚡ ${displayText}`;
+	}
 }
 
 function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
+	return typeof value === "string" && value.trim().length > 0;
 }
 
-function normalizeTelepiNativeCommandMenuEntry(entry: unknown): TelepiNativeCommandMenuEntry | undefined {
-  if (!entry || typeof entry !== "object") {
-    return undefined;
-  }
+function normalizeTelepiNativeCommandMenuEntry(
+	entry: unknown,
+): TelepiNativeCommandMenuEntry | undefined {
+	if (!entry || typeof entry !== "object") {
+		return undefined;
+	}
 
-  const candidate = entry as Partial<TelepiNativeCommandMenuEntry>;
-  if (!isNonEmptyString(candidate.id) || !isNonEmptyString(candidate.label) || !isNonEmptyString(candidate.commandText)) {
-    return undefined;
-  }
+	const candidate = entry as Partial<TelepiNativeCommandMenuEntry>;
+	if (
+		!isNonEmptyString(candidate.id) ||
+		!isNonEmptyString(candidate.label) ||
+		!isNonEmptyString(candidate.commandText)
+	) {
+		return undefined;
+	}
 
-  return {
-    id: candidate.id.trim(),
-    label: candidate.label.trim(),
-    commandText: candidate.commandText.trim(),
-  };
+	return {
+		id: candidate.id.trim(),
+		label: candidate.label.trim(),
+		commandText: candidate.commandText.trim(),
+	};
 }
 
-function getTelepiNativeCommandMenuEntries(command: SlashCommandInfo): TelepiNativeCommandMenuEntry[] | undefined {
-  const bareIntegration = (command as { integrations?: { telepi?: { bare?: { kind?: string; entries?: unknown[] } } } }).integrations?.telepi?.bare;
-  if (!bareIntegration || bareIntegration.kind !== "native-menu" || !Array.isArray(bareIntegration.entries)) {
-    return undefined;
-  }
+function getTelepiNativeCommandMenuEntries(
+	command: SlashCommandInfo,
+): TelepiNativeCommandMenuEntry[] | undefined {
+	const bareIntegration = (
+		command as {
+			integrations?: {
+				telepi?: { bare?: { kind?: string; entries?: unknown[] } };
+			};
+		}
+	).integrations?.telepi?.bare;
+	if (
+		!bareIntegration ||
+		bareIntegration.kind !== "native-menu" ||
+		!Array.isArray(bareIntegration.entries)
+	) {
+		return undefined;
+	}
 
-  const entries = bareIntegration.entries
-    .map((entry: unknown) => normalizeTelepiNativeCommandMenuEntry(entry))
-    .filter((entry): entry is TelepiNativeCommandMenuEntry => entry !== undefined);
+	const entries = bareIntegration.entries
+		.map((entry: unknown) => normalizeTelepiNativeCommandMenuEntry(entry))
+		.filter(
+			(entry): entry is TelepiNativeCommandMenuEntry => entry !== undefined,
+		);
 
-  return entries.length === bareIntegration.entries.length && entries.length > 0 ? entries : undefined;
+	return entries.length === bareIntegration.entries.length && entries.length > 0
+		? entries
+		: undefined;
 }
 
 function getOnlyMatchingCommand(
-  slashCommands: SlashCommandInfo[],
-  predicate: (command: SlashCommandInfo) => boolean,
+	slashCommands: SlashCommandInfo[],
+	predicate: (command: SlashCommandInfo) => boolean,
 ): SlashCommandInfo | undefined {
-  const matches = slashCommands.filter(predicate);
-  return matches.length === 1 ? matches[0] : undefined;
+	const matches = slashCommands.filter(predicate);
+	return matches.length === 1 ? matches[0] : undefined;
 }
 
 export function getTelepiNativeCommandMenu(
-  command: NormalizedSlashCommand,
-  slashCommands: SlashCommandInfo[],
+	command: NormalizedSlashCommand,
+	slashCommands: SlashCommandInfo[],
 ): TelepiNativeCommandMenu | undefined {
-  if (command.text !== `/${command.name}`) {
-    return undefined;
-  }
+	if (command.text !== `/${command.name}`) {
+		return undefined;
+	}
 
-  const matchingCommand = getOnlyMatchingCommand(slashCommands, (slashCommand) => slashCommand.name === command.name);
-  if (!matchingCommand) {
-    return undefined;
-  }
+	const matchingCommand = getOnlyMatchingCommand(
+		slashCommands,
+		(slashCommand) => slashCommand.name === command.name,
+	);
+	if (!matchingCommand) {
+		return undefined;
+	}
 
-  const entries = getTelepiNativeCommandMenuEntries(matchingCommand);
-  if (!entries) {
-    return undefined;
-  }
+	const entries = getTelepiNativeCommandMenuEntries(matchingCommand);
+	if (!entries) {
+		return undefined;
+	}
 
-  return {
-    name: matchingCommand.name,
-    bareCommandText: `/${matchingCommand.name}`,
-    title: `/${matchingCommand.name}`,
-    entries,
-  };
+	return {
+		name: matchingCommand.name,
+		bareCommandText: `/${matchingCommand.name}`,
+		title: `/${matchingCommand.name}`,
+		entries,
+	};
 }
 
 export function rewriteSlashCommandForTelegram(
-  command: NormalizedSlashCommand,
-  _slashCommands: SlashCommandInfo[],
+	command: NormalizedSlashCommand,
+	_slashCommands: SlashCommandInfo[],
 ): string {
-  return command.text;
+	return command.text;
 }
 
-export function getCommandPickerFilterName(filter: CommandPickerFilter): string {
-  switch (filter) {
-    case "telepi":
-      return "TelePi";
-    case "pi":
-      return "Pi";
-    case "all":
-    default:
-      return "All";
-  }
+export function getCommandPickerFilterName(
+	filter: CommandPickerFilter,
+): string {
+	switch (filter) {
+		case "telepi":
+			return "TelePi";
+		case "pi":
+			return "Pi";
+		case "all":
+		default:
+			return "All";
+	}
 }
 
-export function getCommandPickerCounts(entries: CommandPickerEntry[]): Record<CommandPickerFilter, number> {
-  return {
-    all: entries.length,
-    telepi: entries.filter((entry) => entry.kind === "telepi").length,
-    pi: entries.filter((entry) => entry.kind === "pi").length,
-  };
+export function getCommandPickerCounts(
+	entries: CommandPickerEntry[],
+): Record<CommandPickerFilter, number> {
+	return {
+		all: entries.length,
+		telepi: entries.filter((entry) => entry.kind === "telepi").length,
+		pi: entries.filter((entry) => entry.kind === "pi").length,
+	};
 }
 
 export function filterCommandPickerEntries(
-  entries: CommandPickerEntry[],
-  filter: CommandPickerFilter,
+	entries: CommandPickerEntry[],
+	filter: CommandPickerFilter,
 ): CommandPickerEntry[] {
-  if (filter === "all") {
-    return entries;
-  }
+	if (filter === "all") {
+		return entries;
+	}
 
-  return entries.filter((entry) => entry.kind === filter);
+	return entries.filter((entry) => entry.kind === filter);
 }
 
-export function buildCommandPickerEntries(slashCommands: SlashCommandInfo[]): CommandPickerEntry[] {
-  const getSlashCommandArgumentHint = createSlashCommandArgumentHintResolver();
-  const telepiEntries = TELEPI_BOT_COMMANDS
-    .filter((command) => command.command !== "commands")
-    .map((command, index) => ({
-      id: index,
-      kind: "telepi" as const,
-      command: command.command,
-      description: command.description,
-      label: `📱 /${command.command}`,
-      commandText: `/${command.command}`,
-    }));
+export function buildCommandPickerEntries(
+	slashCommands: SlashCommandInfo[],
+): CommandPickerEntry[] {
+	const getSlashCommandArgumentHint = createSlashCommandArgumentHintResolver();
+	const telepiEntries = TELEPI_BOT_COMMANDS.filter(
+		(command) => command.command !== "commands",
+	).map((command, index) => ({
+		id: index,
+		kind: "telepi" as const,
+		command: command.command,
+		description: command.description,
+		label: `📱 /${command.command}`,
+		commandText: `/${command.command}`,
+	}));
 
-  const piEntries = slashCommands.map((command, index) => ({
-    id: telepiEntries.length + index,
-    kind: "pi" as const,
-    name: command.name,
-    description: command.description ?? command.source,
-    label: getPiSlashCommandLabel(command, getSlashCommandArgumentHint),
-    commandText: `/${command.name}`,
-    source: command.source,
-  }));
+	const piEntries = slashCommands.map((command, index) => ({
+		id: telepiEntries.length + index,
+		kind: "pi" as const,
+		name: command.name,
+		description: command.description ?? command.source,
+		label: getPiSlashCommandLabel(command, getSlashCommandArgumentHint),
+		commandText: `/${command.name}`,
+		source: command.source,
+	}));
 
-  return [...telepiEntries, ...piEntries];
+	return [...telepiEntries, ...piEntries];
 }
 
 function isTelegramNativeCommandName(name: string): boolean {
-  return /^[a-z0-9_]{1,32}$/.test(name);
+	return /^[a-z0-9_]{1,32}$/.test(name);
 }
 
 export function buildChatScopedCommands(
-  slashCommands: SlashCommandInfo[],
+	slashCommands: SlashCommandInfo[],
 ): Array<{ command: string; description: string }> {
-  const commands: Array<{ command: string; description: string }> = TELEPI_BOT_COMMANDS.map((command) => ({
-    command: command.command,
-    description: command.description,
-  }));
-  const seen = new Set(TELEPI_LOCAL_COMMAND_NAMES);
+	const commands: Array<{ command: string; description: string }> =
+		TELEPI_BOT_COMMANDS.map((command) => ({
+			command: command.command,
+			description: command.description,
+		}));
+	const seen = new Set(TELEPI_LOCAL_COMMAND_NAMES);
 
-  for (const slashCommand of slashCommands) {
-    const name = slashCommand.name.replace(/^\/+/, "").trim().toLowerCase();
-    if (!isTelegramNativeCommandName(name) || seen.has(name)) {
-      continue;
-    }
+	for (const slashCommand of slashCommands) {
+		const name = slashCommand.name.replace(/^\/+/, "").trim().toLowerCase();
+		if (!isTelegramNativeCommandName(name) || seen.has(name)) {
+			continue;
+		}
 
-    seen.add(name);
-    commands.push({
-      command: name,
-      description: trimLine(`Pi: ${slashCommand.description ?? slashCommand.source}`, 256),
-    });
-  }
+		seen.add(name);
+		commands.push({
+			command: name,
+			description: trimLine(
+				`Pi: ${slashCommand.description ?? slashCommand.source}`,
+				256,
+			),
+		});
+	}
 
-  if (commands.length > 100) {
-    console.warn(`Telegram supports at most 100 commands per scope; truncating ${commands.length} commands to 100.`);
-  }
+	if (commands.length > 100) {
+		console.warn(
+			`Telegram supports at most 100 commands per scope; truncating ${commands.length} commands to 100.`,
+		);
+	}
 
-  return commands.slice(0, 100);
+	return commands.slice(0, 100);
 }
 
-export function buildChatScopedCommandSignature(commands: Array<{ command: string; description: string }>): string {
-  return JSON.stringify(commands);
+export function buildChatScopedCommandSignature(
+	commands: Array<{ command: string; description: string }>,
+): string {
+	return JSON.stringify(commands);
 }

--- a/src/model-scope.ts
+++ b/src/model-scope.ts
@@ -1,159 +1,201 @@
-import { type ModelRegistry, type SettingsManager } from "@mariozechner/pi-coding-agent";
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type {
+	ModelRegistry,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
 import { minimatch } from "minimatch";
-import type { Api, Model } from "@mariozechner/pi-ai";
 
 export interface ScopedModelOption {
-  model: Model<Api>;
-  thinkingLevel?: ThinkingLevel;
+	model: Model<Api>;
+	thinkingLevel?: ThinkingLevel;
 }
 
-const THINKING_LEVELS = new Set<ThinkingLevel>(["minimal", "low", "medium", "high", "xhigh"]);
+const THINKING_LEVELS = new Set<ThinkingLevel>([
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+]);
 
 export async function resolveScopedModels(
-  settingsManager: SettingsManager,
-  modelRegistry: ModelRegistry,
+	settingsManager: SettingsManager,
+	modelRegistry: ModelRegistry,
 ): Promise<ScopedModelOption[]> {
-  const patterns = settingsManager.getEnabledModels();
-  if (!patterns || patterns.length === 0) {
-    return [];
-  }
+	const patterns = settingsManager.getEnabledModels();
+	if (!patterns || patterns.length === 0) {
+		return [];
+	}
 
-  const availableModels = await modelRegistry.getAvailable();
-  const scopedModels: ScopedModelOption[] = [];
+	const availableModels = await modelRegistry.getAvailable();
+	const scopedModels: ScopedModelOption[] = [];
 
-  for (const rawPattern of patterns) {
-    const pattern = rawPattern.trim();
-    if (!pattern) {
-      continue;
-    }
+	for (const rawPattern of patterns) {
+		const pattern = rawPattern.trim();
+		if (!pattern) {
+			continue;
+		}
 
-    if (hasGlob(pattern)) {
-      const { modelPattern, thinkingLevel } = splitThinkingLevel(pattern);
-      const matches = availableModels.filter((model) => matchesPattern(modelPattern, model));
-      if (matches.length === 0) {
-        console.warn(`Warning: No models match pattern "${pattern}"`);
-        continue;
-      }
+		if (hasGlob(pattern)) {
+			const { modelPattern, thinkingLevel } = splitThinkingLevel(pattern);
+			const matches = availableModels.filter((model) =>
+				matchesPattern(modelPattern, model),
+			);
+			if (matches.length === 0) {
+				console.warn(`Warning: No models match pattern "${pattern}"`);
+				continue;
+			}
 
-      for (const model of matches) {
-        addUniqueScopedModel(scopedModels, model, thinkingLevel);
-      }
-      continue;
-    }
+			for (const model of matches) {
+				addUniqueScopedModel(scopedModels, model, thinkingLevel);
+			}
+			continue;
+		}
 
-    const { modelPattern, thinkingLevel } = splitThinkingLevel(pattern);
-    const model = findModel(modelPattern, availableModels);
-    if (!model) {
-      console.warn(`Warning: No models match pattern "${pattern}"`);
-      continue;
-    }
+		const { modelPattern, thinkingLevel } = splitThinkingLevel(pattern);
+		const model = findModel(modelPattern, availableModels);
+		if (!model) {
+			console.warn(`Warning: No models match pattern "${pattern}"`);
+			continue;
+		}
 
-    addUniqueScopedModel(scopedModels, model, thinkingLevel);
-  }
+		addUniqueScopedModel(scopedModels, model, thinkingLevel);
+	}
 
-  return scopedModels;
+	return scopedModels;
 }
 
 export function resolveInitialScopedModelSelection(options: {
-  configuredModel: Model<Api> | undefined;
-  scopedModels: ScopedModelOption[];
-  settingsManager: SettingsManager;
-  modelRegistry: ModelRegistry;
-  hasExistingSession: boolean;
+	configuredModel: Model<Api> | undefined;
+	scopedModels: ScopedModelOption[];
+	settingsManager: SettingsManager;
+	modelRegistry: ModelRegistry;
+	hasExistingSession: boolean;
 }): { model: Model<Api> | undefined; thinkingLevel?: ThinkingLevel } {
-  const { configuredModel, scopedModels, settingsManager, modelRegistry, hasExistingSession } = options;
+	const {
+		configuredModel,
+		scopedModels,
+		settingsManager,
+		modelRegistry,
+		hasExistingSession,
+	} = options;
 
-  if (configuredModel || hasExistingSession || scopedModels.length === 0) {
-    return { model: configuredModel, thinkingLevel: undefined };
-  }
+	if (configuredModel || hasExistingSession || scopedModels.length === 0) {
+		return { model: configuredModel, thinkingLevel: undefined };
+	}
 
-  const defaultProvider = settingsManager.getDefaultProvider();
-  const defaultModelId = settingsManager.getDefaultModel();
-  const defaultModel = defaultProvider && defaultModelId
-    ? modelRegistry.find(defaultProvider, defaultModelId)
-    : undefined;
+	const defaultProvider = settingsManager.getDefaultProvider();
+	const defaultModelId = settingsManager.getDefaultModel();
+	const defaultModel =
+		defaultProvider && defaultModelId
+			? modelRegistry.find(defaultProvider, defaultModelId)
+			: undefined;
 
-  const selectedScopedModel = defaultModel
-    ? scopedModels.find((scoped) => scoped.model.provider === defaultModel.provider && scoped.model.id === defaultModel.id)
-    : undefined;
-  const fallbackScopedModel = selectedScopedModel ?? scopedModels[0];
+	const selectedScopedModel = defaultModel
+		? scopedModels.find(
+				(scoped) =>
+					scoped.model.provider === defaultModel.provider &&
+					scoped.model.id === defaultModel.id,
+			)
+		: undefined;
+	const fallbackScopedModel = selectedScopedModel ?? scopedModels[0];
 
-  return {
-    model: fallbackScopedModel?.model,
-    thinkingLevel: fallbackScopedModel?.thinkingLevel,
-  };
+	return {
+		model: fallbackScopedModel?.model,
+		thinkingLevel: fallbackScopedModel?.thinkingLevel,
+	};
 }
 
 function hasGlob(pattern: string): boolean {
-  return pattern.includes("*") || pattern.includes("?") || pattern.includes("[");
+	return (
+		pattern.includes("*") || pattern.includes("?") || pattern.includes("[")
+	);
 }
 
-function splitThinkingLevel(pattern: string): { modelPattern: string; thinkingLevel?: ThinkingLevel } {
-  const colonIndex = pattern.lastIndexOf(":");
-  if (colonIndex === -1) {
-    return { modelPattern: pattern };
-  }
+function splitThinkingLevel(pattern: string): {
+	modelPattern: string;
+	thinkingLevel?: ThinkingLevel;
+} {
+	const colonIndex = pattern.lastIndexOf(":");
+	if (colonIndex === -1) {
+		return { modelPattern: pattern };
+	}
 
-  const suffix = pattern.slice(colonIndex + 1).trim();
-  if (!THINKING_LEVELS.has(suffix as ThinkingLevel)) {
-    return { modelPattern: pattern };
-  }
+	const suffix = pattern.slice(colonIndex + 1).trim();
+	if (!THINKING_LEVELS.has(suffix as ThinkingLevel)) {
+		return { modelPattern: pattern };
+	}
 
-  return {
-    modelPattern: pattern.slice(0, colonIndex),
-    thinkingLevel: suffix as ThinkingLevel,
-  };
+	return {
+		modelPattern: pattern.slice(0, colonIndex),
+		thinkingLevel: suffix as ThinkingLevel,
+	};
 }
 
 function matchesPattern(pattern: string, model: Model<Api>): boolean {
-  const fullId = `${model.provider}/${model.id}`;
-  return minimatch(fullId, pattern, { nocase: true }) || minimatch(model.id, pattern, { nocase: true });
+	const fullId = `${model.provider}/${model.id}`;
+	return (
+		minimatch(fullId, pattern, { nocase: true }) ||
+		minimatch(model.id, pattern, { nocase: true })
+	);
 }
 
-function findModel(pattern: string, availableModels: Model<Api>[]): Model<Api> | undefined {
-  const normalized = pattern.toLowerCase();
-  const exactCanonical = availableModels.find((model) => `${model.provider}/${model.id}`.toLowerCase() === normalized);
-  if (exactCanonical) {
-    return exactCanonical;
-  }
+function findModel(
+	pattern: string,
+	availableModels: Model<Api>[],
+): Model<Api> | undefined {
+	const normalized = pattern.toLowerCase();
+	const exactCanonical = availableModels.find(
+		(model) => `${model.provider}/${model.id}`.toLowerCase() === normalized,
+	);
+	if (exactCanonical) {
+		return exactCanonical;
+	}
 
-  const exactIdMatches = availableModels.filter((model) => model.id.toLowerCase() === normalized);
-  if (exactIdMatches.length === 1) {
-    return exactIdMatches[0];
-  }
-  if (exactIdMatches.length > 1) {
-    return undefined;
-  }
+	const exactIdMatches = availableModels.filter(
+		(model) => model.id.toLowerCase() === normalized,
+	);
+	if (exactIdMatches.length === 1) {
+		return exactIdMatches[0];
+	}
+	if (exactIdMatches.length > 1) {
+		return undefined;
+	}
 
-  const partialMatches = availableModels.filter((model) =>
-    model.id.toLowerCase().includes(normalized) || model.name?.toLowerCase().includes(normalized),
-  );
-  if (partialMatches.length === 0) {
-    return undefined;
-  }
+	const partialMatches = availableModels.filter(
+		(model) =>
+			model.id.toLowerCase().includes(normalized) ||
+			model.name?.toLowerCase().includes(normalized),
+	);
+	if (partialMatches.length === 0) {
+		return undefined;
+	}
 
-  const aliases = partialMatches.filter((model) => isAlias(model.id));
-  const candidates = aliases.length > 0 ? aliases : partialMatches;
-  return [...candidates].sort((left, right) => right.id.localeCompare(left.id))[0];
+	const aliases = partialMatches.filter((model) => isAlias(model.id));
+	const candidates = aliases.length > 0 ? aliases : partialMatches;
+	return [...candidates].sort((left, right) =>
+		right.id.localeCompare(left.id),
+	)[0];
 }
 
 function addUniqueScopedModel(
-  scopedModels: ScopedModelOption[],
-  model: Model<Api>,
-  thinkingLevel?: ThinkingLevel,
+	scopedModels: ScopedModelOption[],
+	model: Model<Api>,
+	thinkingLevel?: ThinkingLevel,
 ): void {
-  const exists = scopedModels.some((scoped) =>
-    scoped.model.provider === model.provider && scoped.model.id === model.id,
-  );
-  if (!exists) {
-    scopedModels.push({ model, thinkingLevel });
-  }
+	const exists = scopedModels.some(
+		(scoped) =>
+			scoped.model.provider === model.provider && scoped.model.id === model.id,
+	);
+	if (!exists) {
+		scopedModels.push({ model, thinkingLevel });
+	}
 }
 
 function isAlias(modelId: string): boolean {
-  if (modelId.endsWith("-latest")) {
-    return true;
-  }
-  return !/-\d{8}$/.test(modelId);
+	if (modelId.endsWith("-latest")) {
+		return true;
+	}
+	return !/-\d{8}$/.test(modelId);
 }

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -1,41 +1,43 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import {
-  AuthStorage,
-  createAgentSessionFromServices,
-  createAgentSessionRuntime,
-  createAgentSessionServices,
-  createCodingTools,
-  getAgentDir,
-  ModelRegistry,
-  SessionManager,
-  SettingsManager,
-  type AgentSession,
-  type AgentSessionRuntime,
-  type ContextUsage,
-  type CreateAgentSessionRuntimeFactory,
-  type ResourceDiagnostic,
-  type ResourceLoader,
-  type SessionEntry,
-  type SessionStats,
-  type SlashCommandInfo,
-} from "@mariozechner/pi-coding-agent";
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
-import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
+	type AgentSession,
+	type AgentSessionRuntime,
+	AuthStorage,
+	type ContextUsage,
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+	createCodingTools,
+	getAgentDir,
+	ModelRegistry,
+	type ResourceDiagnostic,
+	type ResourceLoader,
+	type SessionEntry,
+	SessionManager,
+	type SessionStats,
+	SettingsManager,
+	type SlashCommandInfo,
+} from "@earendil-works/pi-coding-agent";
 
 import type { TelePiConfig } from "./config.js";
-import { createProviderResponseNoticeExtension } from "./provider-response-notices.js";
 import {
-  resolveInitialScopedModelSelection,
-  resolveScopedModels,
+	resolveInitialScopedModelSelection,
+	resolveScopedModels,
 } from "./model-scope.js";
 import {
-  readSessionHeader,
-  resolveSessionPathForRuntime,
-  resolveWorkspacePathForRuntime,
+	readSessionHeader,
+	resolveSessionPathForRuntime,
+	resolveWorkspacePathForRuntime,
 } from "./pi-session-paths.js";
-import { describeEntry, type SessionTreeNodeLike as SessionTreeNode } from "./tree.js";
+import { createProviderResponseNoticeExtension } from "./provider-response-notices.js";
+import {
+	describeEntry,
+	type SessionTreeNodeLike as SessionTreeNode,
+} from "./tree.js";
 
 /**
  * Default timeout (seconds) for bash commands in TelePi sessions.
@@ -46,84 +48,92 @@ import { describeEntry, type SessionTreeNodeLike as SessionTreeNode } from "./tr
  */
 const DEFAULT_BASH_TIMEOUT_SECONDS = 120;
 const TELEPI_LAUNCHD_LABEL = "com.telepi";
-const TELEPI_SELF_MANAGEMENT_ERROR =
-  `Blocked TelePi self-management command. launchctl commands targeting ${TELEPI_LAUNCHD_LABEL} cannot run from inside a TelePi session. Manage the launchd service from a separate shell instead.`;
+const TELEPI_SELF_MANAGEMENT_ERROR = `Blocked TelePi self-management command. launchctl commands targeting ${TELEPI_LAUNCHD_LABEL} cannot run from inside a TelePi session. Manage the launchd service from a separate shell instead.`;
 
 export interface PiSessionCallbacks {
-  onTextDelta: (delta: string) => void;
-  onToolStart: (toolName: string, toolCallId: string) => void;
-  onToolUpdate: (toolCallId: string, partialResult: string) => void;
-  onToolEnd: (toolCallId: string, isError: boolean) => void;
-  onAgentEnd: () => void;
+	onTextDelta: (delta: string) => void;
+	onToolStart: (toolName: string, toolCallId: string) => void;
+	onToolUpdate: (toolCallId: string, partialResult: string) => void;
+	onToolEnd: (toolCallId: string, isError: boolean) => void;
+	onAgentEnd: () => void;
 }
 
 export interface PiSessionDiagnostic {
-  type: "info" | "warning" | "error";
-  message: string;
+	type: "info" | "warning" | "error";
+	message: string;
 }
 
 export interface PiSessionInfo {
-  sessionId: string;
-  sessionFile?: string;
-  workspace: string;
-  sessionName?: string;
-  modelFallbackMessage?: string;
-  model?: string;
-  diagnostics?: PiSessionDiagnostic[];
+	sessionId: string;
+	sessionFile?: string;
+	workspace: string;
+	sessionName?: string;
+	modelFallbackMessage?: string;
+	model?: string;
+	diagnostics?: PiSessionDiagnostic[];
 }
 
 export interface PiSessionSwitchResult extends PiSessionInfo {
-  cancelled: boolean;
+	cancelled: boolean;
 }
 
 export interface PiSessionModelOption {
-  provider: string;
-  id: string;
-  name: string;
-  current: boolean;
-  thinkingLevel?: ThinkingLevel;
+	provider: string;
+	id: string;
+	name: string;
+	current: boolean;
+	thinkingLevel?: ThinkingLevel;
 }
 
 export interface PiSessionContext {
-  chatId: number | string;
-  messageThreadId?: number;
+	chatId: number | string;
+	messageThreadId?: number;
 }
 
 export interface ResolvedSessionReference {
-  id: string;
-  path: string;
-  cwd?: string;
-  workspaceWarning?: string;
-  matchType: "path" | "id" | "prefix";
+	id: string;
+	path: string;
+	cwd?: string;
+	workspaceWarning?: string;
+	matchType: "path" | "id" | "prefix";
 }
 
-type RuntimeNewSessionOptions = NonNullable<Parameters<AgentSessionRuntime["newSession"]>[0]>;
-type RuntimeSwitchSessionOptions = NonNullable<Parameters<AgentSessionRuntime["switchSession"]>[1]>;
-type RuntimeForkOptions = NonNullable<Parameters<AgentSessionRuntime["fork"]>[1]>;
+type RuntimeNewSessionOptions = NonNullable<
+	Parameters<AgentSessionRuntime["newSession"]>[0]
+>;
+type RuntimeSwitchSessionOptions = NonNullable<
+	Parameters<AgentSessionRuntime["switchSession"]>[1]
+>;
+type RuntimeForkOptions = NonNullable<
+	Parameters<AgentSessionRuntime["fork"]>[1]
+>;
 
 export interface PiSessionNewSessionOptions extends RuntimeNewSessionOptions {
-  workspace?: string;
+	workspace?: string;
 }
 
-export type PiSessionSwitchOptions = Pick<RuntimeSwitchSessionOptions, "withSession"> & {
-  workspace?: string;
+export type PiSessionSwitchOptions = Pick<
+	RuntimeSwitchSessionOptions,
+	"withSession"
+> & {
+	workspace?: string;
 };
 
 export type PiSessionForkOptions = RuntimeForkOptions;
 
 class SessionReferenceResolutionError extends Error {
-  readonly code = "SESSION_REFERENCE_RESOLUTION_ERROR";
+	readonly code = "SESSION_REFERENCE_RESOLUTION_ERROR";
 
-  constructor(message: string) {
-    super(message);
-    this.name = "SessionReferenceResolutionError";
-  }
+	constructor(message: string) {
+		super(message);
+		this.name = "SessionReferenceResolutionError";
+	}
 }
 
 interface PiSessionHandle {
-  runtime: AgentSessionRuntime;
-  getSlashCommands: () => SlashCommandInfo[];
-  dispose: () => Promise<void>;
+	runtime: AgentSessionRuntime;
+	getSlashCommands: () => SlashCommandInfo[];
+	dispose: () => Promise<void>;
 }
 
 /**
@@ -141,1387 +151,1579 @@ interface PiSessionHandle {
 type BashToolArgs = { command: string; timeout?: number };
 
 function splitShellCommandSegments(command: string): string[] {
-  const segments: string[] = [];
-  let current = "";
-  let quote: "\"" | "'" | undefined;
-  let escaped = false;
+	const segments: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let escaped = false;
 
-  const pushSegment = () => {
-    const trimmed = current.trim();
-    if (trimmed) {
-      segments.push(trimmed);
-    }
-    current = "";
-  };
+	const pushSegment = () => {
+		const trimmed = current.trim();
+		if (trimmed) {
+			segments.push(trimmed);
+		}
+		current = "";
+	};
 
-  for (let index = 0; index < command.length; index += 1) {
-    const character = command[index];
+	for (let index = 0; index < command.length; index += 1) {
+		const character = command[index];
 
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
+		if (escaped) {
+			current += character;
+			escaped = false;
+			continue;
+		}
 
-    if (character === "\\" && quote !== "'") {
-      current += character;
-      escaped = true;
-      continue;
-    }
+		if (character === "\\" && quote !== "'") {
+			current += character;
+			escaped = true;
+			continue;
+		}
 
-    if (quote) {
-      current += character;
-      if (character === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
+		if (quote) {
+			current += character;
+			if (character === quote) {
+				quote = undefined;
+			}
+			continue;
+		}
 
-    if (character === "\"" || character === "'") {
-      current += character;
-      quote = character;
-      continue;
-    }
+		if (character === '"' || character === "'") {
+			current += character;
+			quote = character;
+			continue;
+		}
 
-    if (character === ";" || character === "\n") {
-      pushSegment();
-      continue;
-    }
+		if (character === ";" || character === "\n") {
+			pushSegment();
+			continue;
+		}
 
-    if (character === "&") {
-      pushSegment();
-      if (command[index + 1] === "&") {
-        index += 1;
-      }
-      continue;
-    }
+		if (character === "&") {
+			pushSegment();
+			if (command[index + 1] === "&") {
+				index += 1;
+			}
+			continue;
+		}
 
-    if (character === "|") {
-      pushSegment();
-      if (command[index + 1] === "|") {
-        index += 1;
-      }
-      continue;
-    }
+		if (character === "|") {
+			pushSegment();
+			if (command[index + 1] === "|") {
+				index += 1;
+			}
+			continue;
+		}
 
-    current += character;
-  }
+		current += character;
+	}
 
-  pushSegment();
-  return segments;
+	pushSegment();
+	return segments;
 }
 
 function tokenizeShellCommand(command: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: "\"" | "'" | undefined;
-  let escaped = false;
+	const tokens: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let escaped = false;
 
-  const pushToken = () => {
-    if (current) {
-      tokens.push(current);
-      current = "";
-    }
-  };
+	const pushToken = () => {
+		if (current) {
+			tokens.push(current);
+			current = "";
+		}
+	};
 
-  for (let index = 0; index < command.length; index += 1) {
-    const character = command[index];
+	for (let index = 0; index < command.length; index += 1) {
+		const character = command[index];
 
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
+		if (escaped) {
+			current += character;
+			escaped = false;
+			continue;
+		}
 
-    if (character === "\\" && quote !== "'") {
-      escaped = true;
-      continue;
-    }
+		if (character === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
 
-    if (quote) {
-      if (character === quote) {
-        quote = undefined;
-        continue;
-      }
-      current += character;
-      continue;
-    }
+		if (quote) {
+			if (character === quote) {
+				quote = undefined;
+				continue;
+			}
+			current += character;
+			continue;
+		}
 
-    if (character === "\"" || character === "'") {
-      quote = character;
-      continue;
-    }
+		if (character === '"' || character === "'") {
+			quote = character;
+			continue;
+		}
 
-    if (/\s/.test(character)) {
-      pushToken();
-      continue;
-    }
+		if (/\s/.test(character)) {
+			pushToken();
+			continue;
+		}
 
-    current += character;
-  }
+		current += character;
+	}
 
-  pushToken();
-  return tokens;
+	pushToken();
+	return tokens;
 }
 
 function getExecutableName(token: string): string {
-  return path.posix.basename(token.replace(/^[()]+|[()]+$/g, "")).toLowerCase();
+	return path.posix.basename(token.replace(/^[()]+|[()]+$/g, "")).toLowerCase();
 }
 
 function isEnvironmentAssignment(token: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+	return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
 function stripCommandPrefixes(tokens: string[]): string[] {
-  let index = 0;
+	let index = 0;
 
-  while (index < tokens.length) {
-    const token = tokens[index];
-    const executableName = getExecutableName(token);
+	while (index < tokens.length) {
+		const token = tokens[index];
+		const executableName = getExecutableName(token);
 
-    if (isEnvironmentAssignment(token)) {
-      index += 1;
-      continue;
-    }
+		if (isEnvironmentAssignment(token)) {
+			index += 1;
+			continue;
+		}
 
-    if (executableName === "env") {
-      index += 1;
-      while (index < tokens.length && (tokens[index].startsWith("-") || isEnvironmentAssignment(tokens[index]))) {
-        index += 1;
-      }
-      continue;
-    }
+		if (executableName === "env") {
+			index += 1;
+			while (
+				index < tokens.length &&
+				(tokens[index].startsWith("-") ||
+					isEnvironmentAssignment(tokens[index]))
+			) {
+				index += 1;
+			}
+			continue;
+		}
 
-    if (executableName === "sudo" || executableName === "command" || executableName === "nohup") {
-      index += 1;
-      while (index < tokens.length && tokens[index].startsWith("-")) {
-        index += 1;
-      }
-      continue;
-    }
+		if (
+			executableName === "sudo" ||
+			executableName === "command" ||
+			executableName === "nohup"
+		) {
+			index += 1;
+			while (index < tokens.length && tokens[index].startsWith("-")) {
+				index += 1;
+			}
+			continue;
+		}
 
-    break;
-  }
+		break;
+	}
 
-  return tokens.slice(index);
+	return tokens.slice(index);
 }
 
 function extractShellWrapperCommand(tokens: string[]): string | undefined {
-  for (let index = 1; index < tokens.length; index += 1) {
-    const token = tokens[index];
+	for (let index = 1; index < tokens.length; index += 1) {
+		const token = tokens[index];
 
-    if (token === "-c") {
-      return tokens[index + 1];
-    }
+		if (token === "-c") {
+			return tokens[index + 1];
+		}
 
-    if (/^-[A-Za-z]*c$/.test(token)) {
-      return tokens[index + 1];
-    }
+		if (/^-[A-Za-z]*c$/.test(token)) {
+			return tokens[index + 1];
+		}
 
-    if (token.startsWith("-c") && token.length > 2) {
-      return token.slice(2);
-    }
-  }
+		if (token.startsWith("-c") && token.length > 2) {
+			return token.slice(2);
+		}
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function isBlockedTelepiSelfManagementCommand(command: string): boolean {
-  for (const segment of splitShellCommandSegments(command)) {
-    const tokens = stripCommandPrefixes(tokenizeShellCommand(segment));
-    const executable = tokens[0];
-    if (!executable) {
-      continue;
-    }
+	for (const segment of splitShellCommandSegments(command)) {
+		const tokens = stripCommandPrefixes(tokenizeShellCommand(segment));
+		const executable = tokens[0];
+		if (!executable) {
+			continue;
+		}
 
-    const executableName = getExecutableName(executable);
-    if (executableName === "launchctl") {
-      return tokens.some((token) => token.toLowerCase().includes(TELEPI_LAUNCHD_LABEL));
-    }
+		const executableName = getExecutableName(executable);
+		if (executableName === "launchctl") {
+			return tokens.some((token) =>
+				token.toLowerCase().includes(TELEPI_LAUNCHD_LABEL),
+			);
+		}
 
-    if (["bash", "sh", "zsh", "dash", "fish", "ksh"].includes(executableName)) {
-      const nestedCommand = extractShellWrapperCommand(tokens);
-      if (nestedCommand && isBlockedTelepiSelfManagementCommand(nestedCommand)) {
-        return true;
-      }
-    }
-  }
+		if (["bash", "sh", "zsh", "dash", "fish", "ksh"].includes(executableName)) {
+			const nestedCommand = extractShellWrapperCommand(tokens);
+			if (
+				nestedCommand &&
+				isBlockedTelepiSelfManagementCommand(nestedCommand)
+			) {
+				return true;
+			}
+		}
+	}
 
-  return false;
+	return false;
 }
 
 function getBlockedBashCommandReason(command: string): string | undefined {
-  if (isBlockedTelepiSelfManagementCommand(command)) {
-    return TELEPI_SELF_MANAGEMENT_ERROR;
-  }
+	if (isBlockedTelepiSelfManagementCommand(command)) {
+		return TELEPI_SELF_MANAGEMENT_ERROR;
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function patchBashTimeout(session: AgentSession): void {
-  const tools = session.agent.state.tools;
-  const patched = tools.map((tool) => {
-    if (tool.name !== "bash") return tool;
+	const tools = session.agent.state.tools;
+	const patched = tools.map((tool) => {
+		if (tool.name !== "bash") return tool;
 
-    const originalExecute = tool.execute;
-    const execute: typeof originalExecute = (toolCallId, params, signal, onUpdate) =>
-      originalExecute(
-        toolCallId,
-        withDefaultBashTimeout(params),
-        signal,
-        onUpdate,
-      );
+		const originalExecute = tool.execute;
+		const execute: typeof originalExecute = (
+			toolCallId,
+			params,
+			signal,
+			onUpdate,
+		) =>
+			originalExecute(
+				toolCallId,
+				withDefaultBashTimeout(params),
+				signal,
+				onUpdate,
+			);
 
-    return {
-      ...tool,
-      description:
-        tool.description +
-        ` Commands time out after ${DEFAULT_BASH_TIMEOUT_SECONDS} seconds by default. Pass a longer timeout for slow commands (e.g. npm install, test suites).`,
-      execute,
-    };
-  });
-  session.agent.state.tools = patched;
+		return {
+			...tool,
+			description:
+				tool.description +
+				` Commands time out after ${DEFAULT_BASH_TIMEOUT_SECONDS} seconds by default. Pass a longer timeout for slow commands (e.g. npm install, test suites).`,
+			execute,
+		};
+	});
+	session.agent.state.tools = patched;
 }
 
 function withDefaultBashTimeout<T>(params: T): T {
-  if (!isBashToolInput(params)) {
-    return params;
-  }
+	if (!isBashToolInput(params)) {
+		return params;
+	}
 
-  const blockedReason = getBlockedBashCommandReason(params.command);
-  if (blockedReason) {
-    throw new Error(blockedReason);
-  }
+	const blockedReason = getBlockedBashCommandReason(params.command);
+	if (blockedReason) {
+		throw new Error(blockedReason);
+	}
 
-  return {
-    ...params,
-    timeout: params.timeout ?? DEFAULT_BASH_TIMEOUT_SECONDS,
-  } as T;
+	return {
+		...params,
+		timeout: params.timeout ?? DEFAULT_BASH_TIMEOUT_SECONDS,
+	} as T;
 }
 
-function isBashToolInput(value: unknown): value is { command: string; timeout?: number } {
-  return typeof value === "object"
-    && value !== null
-    && "command" in value
-    && typeof value.command === "string"
-    && (!("timeout" in value) || value.timeout === undefined || typeof value.timeout === "number");
+function isBashToolInput(
+	value: unknown,
+): value is { command: string; timeout?: number } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"command" in value &&
+		typeof value.command === "string" &&
+		(!("timeout" in value) ||
+			value.timeout === undefined ||
+			typeof value.timeout === "number")
+	);
 }
 
 function getDesiredBuiltInToolNames(cwd: string): string[] {
-  return [...new Set(createCodingTools(cwd).map((tool) => tool.name))];
+	return [...new Set(createCodingTools(cwd).map((tool) => tool.name))];
 }
 
-function ensureBuiltInToolActivation(session: AgentSession, builtInToolNames: string[]): void {
-  if (builtInToolNames.length === 0) {
-    return;
-  }
+function ensureBuiltInToolActivation(
+	session: AgentSession,
+	builtInToolNames: string[],
+): void {
+	if (builtInToolNames.length === 0) {
+		return;
+	}
 
-  const currentActiveToolNames = session.getActiveToolNames();
-  const nextActiveToolNames = [...new Set([...currentActiveToolNames, ...builtInToolNames])];
-  const changed = nextActiveToolNames.length !== currentActiveToolNames.length
-    || nextActiveToolNames.some((toolName, index) => toolName !== currentActiveToolNames[index]);
+	const currentActiveToolNames = session.getActiveToolNames();
+	const nextActiveToolNames = [
+		...new Set([...currentActiveToolNames, ...builtInToolNames]),
+	];
+	const changed =
+		nextActiveToolNames.length !== currentActiveToolNames.length ||
+		nextActiveToolNames.some(
+			(toolName, index) => toolName !== currentActiveToolNames[index],
+		);
 
-  if (!changed) {
-    return;
-  }
+	if (!changed) {
+		return;
+	}
 
-  session.setActiveToolsByName(nextActiveToolNames);
+	session.setActiveToolsByName(nextActiveToolNames);
 }
 
 export async function createPiSession(
-  config: TelePiConfig,
-  overrideSessionPath?: string,
-  overrideWorkspace?: string,
+	config: TelePiConfig,
+	overrideSessionPath?: string,
+	overrideWorkspace?: string,
 ): Promise<PiSessionHandle> {
-  const workspace = overrideWorkspace ?? config.workspace;
-  return createPiSessionHandle(
-    config,
-    workspace,
-    createSessionManager(config, workspace, overrideSessionPath, overrideWorkspace !== undefined),
-  );
+	const workspace = overrideWorkspace ?? config.workspace;
+	return createPiSessionHandle(
+		config,
+		workspace,
+		createSessionManager(
+			config,
+			workspace,
+			overrideSessionPath,
+			overrideWorkspace !== undefined,
+		),
+	);
 }
 
 async function createNewPiSession(
-  config: TelePiConfig,
-  workspace: string,
-  options?: Pick<PiSessionNewSessionOptions, "parentSession" | "setup">,
+	config: TelePiConfig,
+	workspace: string,
+	options?: Pick<PiSessionNewSessionOptions, "parentSession" | "setup">,
 ): Promise<PiSessionHandle> {
-  const sessionManager = SessionManager.create(workspace);
-  if (options?.parentSession) {
-    sessionManager.newSession({ parentSession: options.parentSession });
-  }
+	const sessionManager = SessionManager.create(workspace);
+	if (options?.parentSession) {
+		sessionManager.newSession({ parentSession: options.parentSession });
+	}
 
-  const handle = await createPiSessionHandle(config, workspace, sessionManager, { reason: "new" });
+	const handle = await createPiSessionHandle(
+		config,
+		workspace,
+		sessionManager,
+		{ reason: "new" },
+	);
 
-  try {
-    await applySessionSetup(handle.runtime.session, options?.setup);
-    return handle;
-  } catch (error) {
-    try {
-      await handle.dispose();
-    } catch (disposeError) {
-      console.error("Failed to dispose session after setup error:", disposeError);
-    }
-    throw error;
-  }
+	try {
+		await applySessionSetup(handle.runtime.session, options?.setup);
+		return handle;
+	} catch (error) {
+		try {
+			await handle.dispose();
+		} catch (disposeError) {
+			console.error(
+				"Failed to dispose session after setup error:",
+				disposeError,
+			);
+		}
+		throw error;
+	}
 }
 
 async function createPiSessionHandle(
-  config: TelePiConfig,
-  workspace: string,
-  sessionManager: SessionManager,
-  initialSessionStartEvent?: { reason: "new" | "resume" | "fork" },
+	config: TelePiConfig,
+	workspace: string,
+	sessionManager: SessionManager,
+	initialSessionStartEvent?: { reason: "new" | "resume" | "fork" },
 ): Promise<PiSessionHandle> {
-  const authStorage = AuthStorage.create();
-  let getSlashCommands = (): SlashCommandInfo[] => [];
-  const createRuntime: CreateAgentSessionRuntimeFactory = async ({
-    cwd,
-    agentDir,
-    sessionManager: runtimeSessionManager,
-    sessionStartEvent,
-  }) => {
-    const settingsManager = SettingsManager.create(cwd);
-    const modelRegistry = ModelRegistry.create(authStorage);
-    const services = await createAgentSessionServices({
-      cwd,
-      agentDir,
-      authStorage,
-      modelRegistry,
-      settingsManager,
-      resourceLoaderOptions: {
-        extensionFactories: [createProviderResponseNoticeExtension()],
-      },
-    });
-    const configuredModel = resolveModelOverride(services.modelRegistry, config.piModel);
-    const scopedModels = await resolveScopedModels(services.settingsManager, services.modelRegistry);
-    const hasExistingSession = sessionStartEvent?.reason !== "new"
-      && Boolean(runtimeSessionManager.getSessionFile?.());
-    const { model, thinkingLevel } = resolveInitialScopedModelSelection({
-      configuredModel,
-      scopedModels,
-      settingsManager: services.settingsManager,
-      modelRegistry: services.modelRegistry,
-      hasExistingSession,
-    });
+	const authStorage = AuthStorage.create();
+	let getSlashCommands = (): SlashCommandInfo[] => [];
+	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
+		cwd,
+		agentDir,
+		sessionManager: runtimeSessionManager,
+		sessionStartEvent,
+	}) => {
+		const settingsManager = SettingsManager.create(cwd);
+		const modelRegistry = ModelRegistry.create(authStorage);
+		const services = await createAgentSessionServices({
+			cwd,
+			agentDir,
+			authStorage,
+			modelRegistry,
+			settingsManager,
+			resourceLoaderOptions: {
+				extensionFactories: [createProviderResponseNoticeExtension()],
+			},
+		});
+		const configuredModel = resolveModelOverride(
+			services.modelRegistry,
+			config.piModel,
+		);
+		const scopedModels = await resolveScopedModels(
+			services.settingsManager,
+			services.modelRegistry,
+		);
+		const hasExistingSession =
+			sessionStartEvent?.reason !== "new" &&
+			Boolean(runtimeSessionManager.getSessionFile?.());
+		const { model, thinkingLevel } = resolveInitialScopedModelSelection({
+			configuredModel,
+			scopedModels,
+			settingsManager: services.settingsManager,
+			modelRegistry: services.modelRegistry,
+			hasExistingSession,
+		});
 
-    const desiredBuiltInToolNames = getDesiredBuiltInToolNames(cwd);
-    const result = await createAgentSessionFromServices({
-      services,
-      sessionManager: runtimeSessionManager,
-      sessionStartEvent,
-      model,
-      thinkingLevel,
-      scopedModels,
-    });
-    ensureBuiltInToolActivation(result.session, desiredBuiltInToolNames);
-    getSlashCommands = () => result.extensionsResult.runtime.getCommands?.() ?? [];
-    patchBashTimeout(result.session);
+		const desiredBuiltInToolNames = getDesiredBuiltInToolNames(cwd);
+		const result = await createAgentSessionFromServices({
+			services,
+			sessionManager: runtimeSessionManager,
+			sessionStartEvent,
+			model,
+			thinkingLevel,
+			scopedModels,
+		});
+		ensureBuiltInToolActivation(result.session, desiredBuiltInToolNames);
+		getSlashCommands = () =>
+			result.extensionsResult.runtime.getCommands?.() ?? [];
+		patchBashTimeout(result.session);
 
-    return {
-      ...result,
-      services,
-      diagnostics: dedupeDiagnostics([
-        ...services.diagnostics,
-        ...collectSettingsDiagnostics(settingsManager),
-        ...collectSessionResourceDiagnostics(services.resourceLoader, result.session),
-      ]),
-    };
-  };
+		return {
+			...result,
+			services,
+			diagnostics: dedupeDiagnostics([
+				...services.diagnostics,
+				...collectSettingsDiagnostics(settingsManager),
+				...collectSessionResourceDiagnostics(
+					services.resourceLoader,
+					result.session,
+				),
+			]),
+		};
+	};
 
-  const runtime = await createAgentSessionRuntime(createRuntime, {
-    cwd: workspace,
-    agentDir: getAgentDir(),
-    sessionManager,
-    ...(initialSessionStartEvent ? {
-      sessionStartEvent: {
-        type: "session_start",
-        reason: initialSessionStartEvent.reason,
-      },
-    } : {}),
-  });
+	const runtime = await createAgentSessionRuntime(createRuntime, {
+		cwd: workspace,
+		agentDir: getAgentDir(),
+		sessionManager,
+		...(initialSessionStartEvent
+			? {
+					sessionStartEvent: {
+						type: "session_start",
+						reason: initialSessionStartEvent.reason,
+					},
+				}
+			: {}),
+	});
 
-  return {
-    runtime,
-    getSlashCommands: () => getSlashCommands(),
-    dispose: async () => {
-      await runtime.dispose();
-    },
-  };
+	return {
+		runtime,
+		getSlashCommands: () => getSlashCommands(),
+		dispose: async () => {
+			await runtime.dispose();
+		},
+	};
 }
 
 export function subscribeToSession(
-  session: AgentSession,
-  callbacks: PiSessionCallbacks,
+	session: AgentSession,
+	callbacks: PiSessionCallbacks,
 ): () => void {
-  return session.subscribe((event) => {
-    switch (event.type) {
-      case "message_update":
-        if (event.assistantMessageEvent.type === "text_delta") {
-          callbacks.onTextDelta(event.assistantMessageEvent.delta);
-        }
-        break;
-      case "tool_execution_start":
-        callbacks.onToolStart(event.toolName, event.toolCallId);
-        break;
-      case "tool_execution_update":
-        callbacks.onToolUpdate(event.toolCallId, stringifyToolData(event.partialResult));
-        break;
-      case "tool_execution_end":
-        callbacks.onToolEnd(event.toolCallId, event.isError);
-        break;
-      case "agent_end":
-        callbacks.onAgentEnd();
-        break;
-      default:
-        break;
-    }
-  });
+	return session.subscribe((event) => {
+		switch (event.type) {
+			case "message_update":
+				if (event.assistantMessageEvent.type === "text_delta") {
+					callbacks.onTextDelta(event.assistantMessageEvent.delta);
+				}
+				break;
+			case "tool_execution_start":
+				callbacks.onToolStart(event.toolName, event.toolCallId);
+				break;
+			case "tool_execution_update":
+				callbacks.onToolUpdate(
+					event.toolCallId,
+					stringifyToolData(event.partialResult),
+				);
+				break;
+			case "tool_execution_end":
+				callbacks.onToolEnd(event.toolCallId, event.isError);
+				break;
+			case "agent_end":
+				callbacks.onAgentEnd();
+				break;
+			default:
+				break;
+		}
+	});
 }
 
-export async function promptSession(session: AgentSession, text: string, images?: ImageContent[]): Promise<void> {
-  try {
-    if (images && images.length > 0) {
-      await session.prompt(text, { images });
-      return;
-    }
+export async function promptSession(
+	session: AgentSession,
+	text: string,
+	images?: ImageContent[],
+): Promise<void> {
+	try {
+		if (images && images.length > 0) {
+			await session.prompt(text, { images });
+			return;
+		}
 
-    await session.prompt(text);
-  } catch (error) {
-    throw wrapError("Pi session prompt failed", error);
-  }
+		await session.prompt(text);
+	} catch (error) {
+		throw wrapError("Pi session prompt failed", error);
+	}
 }
 
 export class PiSessionService {
-  private handle?: PiSessionHandle;
-  private currentWorkspace: string;
-  private sessionCallbacks?: PiSessionCallbacks;
-  private sessionUnsubscribe?: () => void;
-  private extensionBindings?: Parameters<AgentSession["bindExtensions"]>[0];
-
-  private constructor(private readonly config: TelePiConfig) {
-    this.currentWorkspace = config.workspace;
-  }
-
-  static async create(config: TelePiConfig): Promise<PiSessionService> {
-    const service = new PiSessionService(config);
-    service.handle = await createPiSession(config);
-    service.currentWorkspace = service.handle.runtime.cwd;
-    return service;
-  }
-
-  getSession(): AgentSession {
-    return this.getHandle().runtime.session;
-  }
-
-  isStreaming(): boolean {
-    return this.handle?.runtime.session.isStreaming ?? false;
-  }
-
-  hasActiveSession(): boolean {
-    return this.handle !== undefined;
-  }
-
-  getCurrentWorkspace(): string {
-    return this.currentWorkspace;
-  }
-
-  getInfo(): PiSessionInfo {
-    if (!this.handle) {
-      return {
-        sessionId: "(no active session)",
-        sessionFile: undefined,
-        workspace: this.currentWorkspace,
-        sessionName: undefined,
-        modelFallbackMessage: undefined,
-        model: undefined,
-      };
-    }
-
-    const session = this.handle.runtime.session;
-    const model = session.model;
-    const diagnostics = this.handle.runtime.diagnostics.length > 0
-      ? [...this.handle.runtime.diagnostics]
-      : undefined;
-
-    return {
-      sessionId: session.sessionId,
-      sessionFile: session.sessionFile,
-      workspace: this.currentWorkspace,
-      sessionName: session.sessionName,
-      modelFallbackMessage: this.handle.runtime.modelFallbackMessage,
-      model: model ? `${model.provider}/${model.id}` : undefined,
-      ...(diagnostics ? { diagnostics } : {}),
-    };
-  }
-
-  subscribe(callbacks: PiSessionCallbacks): () => void {
-    this.sessionCallbacks = callbacks;
-    this.rebindSessionSubscription();
-
-    return () => {
-      if (this.sessionCallbacks === callbacks) {
-        this.sessionCallbacks = undefined;
-        this.sessionUnsubscribe?.();
-        this.sessionUnsubscribe = undefined;
-      }
-    };
-  }
-
-  async prompt(text: string, images?: ImageContent[]): Promise<void> {
-    this.reloadAuthStorage();
-    await promptSession(this.getSession(), text, images);
-  }
-
-  async bindExtensions(bindings: Parameters<AgentSession["bindExtensions"]>[0]): Promise<void> {
-    this.extensionBindings = bindings;
-    await this.bindExtensionsToCurrentSession();
-  }
-
-  async listSlashCommands(): Promise<SlashCommandInfo[]> {
-    const commands = this.getHandle().getSlashCommands();
-    const deduped = new Map<string, SlashCommandInfo>();
-
-    for (const command of commands) {
-      const name = command.name.replace(/^\/+/, "").trim();
-      if (!name || deduped.has(name)) {
-        continue;
-      }
-      deduped.set(name, {
-        ...command,
-        name,
-      });
-    }
-
-    return [...deduped.values()].sort((left, right) => left.name.localeCompare(right.name));
-  }
-
-  async abort(): Promise<void> {
-    if (!this.handle) {
-      return;
-    }
-    await this.handle.runtime.session.abort();
-  }
-
-  getContextUsage(): ContextUsage | undefined {
-    return this.handle?.runtime.session.getContextUsage();
-  }
-
-  getSessionStats(): SessionStats | undefined {
-    return this.handle?.runtime.session.getSessionStats();
-  }
-
-  async listAllSessions(): Promise<
-    Array<{
-      id: string;
-      firstMessage: string;
-      path: string;
-      messageCount: number;
-      cwd: string;
-      modified: Date;
-      name?: string;
-    }>
-  > {
-    const sessions = await SessionManager.listAll();
-    sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
-    return sessions.map((s) => ({
-      id: s.id,
-      firstMessage: s.firstMessage,
-      path: s.path,
-      messageCount: s.messageCount,
-      cwd: s.cwd,
-      modified: s.modified,
-      name: s.name,
-    }));
-  }
-
-  async listWorkspaces(): Promise<string[]> {
-    const sessions = await SessionManager.listAll();
-    const workspaces = new Set<string>();
-    for (const session of sessions) {
-      if (session.cwd) {
-        workspaces.add(session.cwd);
-      }
-    }
-    return [...workspaces].sort();
-  }
-
-  async newSession(
-    request?: string | PiSessionNewSessionOptions,
-  ): Promise<{ info: PiSessionInfo; created: boolean }> {
-    const options = normalizeNewSessionOptions(request);
-    const effectiveWorkspace = options.workspace ?? this.currentWorkspace;
-
-    if ((!this.handle || effectiveWorkspace !== this.currentWorkspace) && options.withSession) {
-      throw new Error("TelePi only supports withSession callbacks for runtime-backed new-session replacements.");
-    }
-
-    if (!this.handle || effectiveWorkspace !== this.currentWorkspace) {
-      const nextHandle = await createNewPiSession(this.config, effectiveWorkspace, options);
-      await this.replaceHandle(nextHandle);
-      return { info: this.getInfo(), created: true };
-    }
-
-    const previousSession = this.getSession();
-    const previousWorkspace = this.currentWorkspace;
-    const result = await this.getHandle().runtime.newSession({
-      parentSession: options.parentSession,
-      setup: options.setup,
-      withSession: options.withSession,
-    });
-    await this.rebindAfterRuntimeSessionReplacement(previousSession, previousWorkspace);
-    return { info: this.getInfo(), created: !result.cancelled };
-  }
-
-  async listModels(showAll = false): Promise<PiSessionModelOption[]> {
-    this.reloadAuthStorage();
-    const session = this.getSession();
-    const currentModel = session.model;
-    const availableModels = this.getModelRegistry().getAvailable();
-    const availableKeys = new Set(availableModels.map((model) => `${model.provider}/${model.id}`));
-    const scopedThinkingLevels = new Map(
-      session.scopedModels.map((scoped) => [
-        `${scoped.model.provider}/${scoped.model.id}`,
-        scoped.thinkingLevel,
-      ]),
-    );
-    const available = showAll || session.scopedModels.length === 0
-      ? availableModels
-      : session.scopedModels
-          .map((scoped) => scoped.model)
-          .filter((model) => availableKeys.has(`${model.provider}/${model.id}`));
-
-    return available.map((model) => ({
-      provider: model.provider,
-      id: model.id,
-      name: model.name,
-      current: currentModel
-        ? model.provider === currentModel.provider && model.id === currentModel.id
-        : false,
-      thinkingLevel: scopedThinkingLevels.get(`${model.provider}/${model.id}`),
-    }));
-  }
-
-  async setModel(provider: string, modelId: string, thinkingLevel?: ThinkingLevel): Promise<string> {
-    this.reloadAuthStorage();
-    const session = this.getSession();
-    const modelRegistry = this.getModelRegistry();
-    const model = modelRegistry.find(provider, modelId);
-    if (!model) {
-      throw new Error(`Model not found: ${provider}/${modelId}`);
-    }
-    await session.setModel(model);
-    if (thinkingLevel !== undefined) {
-      session.setThinkingLevel(thinkingLevel);
-    }
-    return `${model.provider}/${model.id}`;
-  }
-
-  async resolveSessionReference(sessionReference: string): Promise<ResolvedSessionReference> {
-    const normalizedReference = sessionReference.trim();
-    if (!normalizedReference) {
-      throw new SessionReferenceResolutionError("Session reference cannot be empty.");
-    }
-
-    const remappedReferencePath = resolveSessionPathForRuntime(normalizedReference);
-    const looksLikePath = normalizedReference.includes("/")
-      || normalizedReference.includes("\\")
-      || normalizedReference.endsWith(".jsonl")
-      || normalizedReference.startsWith("~");
-    if (looksLikePath) {
-      if (!existsSync(remappedReferencePath)) {
-        throw new SessionReferenceResolutionError(`Saved session not found: ${normalizedReference}`);
-      }
-
-      const header = readSessionHeader(remappedReferencePath);
-
-      let indexedWorkspace: string | undefined;
-      try {
-        const indexedMatch = (await this.listAllSessions()).find((session) =>
-          session.path === normalizedReference
-          || session.path === remappedReferencePath
-          || resolveSessionPathForRuntime(session.path) === remappedReferencePath
-        );
-        indexedWorkspace = indexedMatch?.cwd;
-      } catch {
-        indexedWorkspace = undefined;
-      }
-
-      const workspaceResolution = this.resolveSessionWorkspace(indexedWorkspace ?? header?.cwd);
-      return {
-        id: header?.id ?? path.basename(remappedReferencePath),
-        path: remappedReferencePath,
-        cwd: workspaceResolution.cwd,
-        ...(workspaceResolution.workspaceWarning
-          ? { workspaceWarning: workspaceResolution.workspaceWarning }
-          : {}),
-        matchType: "path",
-      };
-    }
-
-    const allSessions = await this.listAllSessions();
-    const currentWorkspaceSessions = allSessions.filter((session) => session.cwd === this.currentWorkspace);
-
-    const exactIdMatch = currentWorkspaceSessions.find((session) => session.id === normalizedReference)
-      ?? allSessions.find((session) => session.id === normalizedReference);
-    if (exactIdMatch) {
-      const workspaceResolution = this.resolveSessionWorkspace(exactIdMatch.cwd);
-      return {
-        id: exactIdMatch.id,
-        path: exactIdMatch.path,
-        cwd: workspaceResolution.cwd,
-        ...(workspaceResolution.workspaceWarning
-          ? { workspaceWarning: workspaceResolution.workspaceWarning }
-          : {}),
-        matchType: "id",
-      };
-    }
-
-    const localPrefixMatches = currentWorkspaceSessions.filter((session) => session.id.startsWith(normalizedReference));
-    if (localPrefixMatches.length === 1) {
-      const [prefixMatch] = localPrefixMatches;
-      const workspaceResolution = this.resolveSessionWorkspace(prefixMatch.cwd);
-      return {
-        id: prefixMatch.id,
-        path: prefixMatch.path,
-        cwd: workspaceResolution.cwd,
-        ...(workspaceResolution.workspaceWarning
-          ? { workspaceWarning: workspaceResolution.workspaceWarning }
-          : {}),
-        matchType: "prefix",
-      };
-    }
-
-    if (localPrefixMatches.length > 1) {
-      throw new SessionReferenceResolutionError(
-        `Session ID prefix "${normalizedReference}" matches ${localPrefixMatches.length} saved sessions in the current workspace. Use more characters or /sessions to pick one.`,
-      );
-    }
-
-    const prefixMatches = allSessions.filter((session) => session.id.startsWith(normalizedReference));
-    if (prefixMatches.length === 1) {
-      const [prefixMatch] = prefixMatches;
-      const workspaceResolution = this.resolveSessionWorkspace(prefixMatch.cwd);
-      return {
-        id: prefixMatch.id,
-        path: prefixMatch.path,
-        cwd: workspaceResolution.cwd,
-        ...(workspaceResolution.workspaceWarning
-          ? { workspaceWarning: workspaceResolution.workspaceWarning }
-          : {}),
-        matchType: "prefix",
-      };
-    }
-
-    if (prefixMatches.length > 1) {
-      throw new SessionReferenceResolutionError(
-        `Session ID prefix "${normalizedReference}" matches ${prefixMatches.length} saved sessions. Use more characters or /sessions to pick one.`,
-      );
-    }
-
-    throw new SessionReferenceResolutionError(
-      `No saved session matches "${normalizedReference}". Use /sessions to browse, or pass a full session path or session ID.`,
-    );
-  }
-
-  /**
-   * Best-effort helper for UI flows that want a workspace hint before switching.
-   * Missing sessions and transient session-index failures should both surface as
-   * "no workspace available" so callers can safely fall back.
-   */
-  async resolveWorkspaceForSession(sessionPath: string): Promise<string | undefined> {
-    try {
-      return (await this.tryResolveSessionReference(sessionPath))?.cwd;
-    } catch {
-      return undefined;
-    }
-  }
-
-  async switchSession(
-    sessionPath: string,
-    request?: string | PiSessionSwitchOptions,
-  ): Promise<PiSessionSwitchResult> {
-    const options = normalizeSwitchSessionOptions(request);
-    const resolvedReference = await this.tryResolveSessionReference(sessionPath);
-    const runtimeSessionPath = resolvedReference?.path ?? resolveSessionPathForRuntime(sessionPath);
-    const effectiveWorkspace = options.workspace
-      ?? resolvedReference?.cwd
-      ?? this.currentWorkspace;
-
-    if (!this.handle && options.withSession) {
-      throw new Error("TelePi only supports withSession callbacks for runtime-backed session switches.");
-    }
-
-    if (!this.handle) {
-      const nextHandle = await createPiSession(this.config, runtimeSessionPath, effectiveWorkspace);
-      await this.replaceHandle(nextHandle);
-      return {
-        ...this.getInfo(),
-        cancelled: false,
-      };
-    }
-
-    const previousSession = this.getSession();
-    const previousWorkspace = this.currentWorkspace;
-    const result = await this.getHandle().runtime.switchSession(runtimeSessionPath, {
-      cwdOverride: effectiveWorkspace,
-      withSession: options.withSession,
-    });
-    await this.rebindAfterRuntimeSessionReplacement(previousSession, previousWorkspace);
-    return {
-      ...this.getInfo(),
-      cancelled: result.cancelled,
-    };
-  }
-
-  private async tryResolveSessionReference(
-    sessionPath: string,
-  ): Promise<ResolvedSessionReference | undefined> {
-    try {
-      return await this.resolveSessionReference(sessionPath);
-    } catch (error) {
-      if (error instanceof SessionReferenceResolutionError) {
-        return undefined;
-      }
-
-      throw error;
-    }
-  }
-
-  private resolveSessionWorkspace(workspace: string | undefined): {
-    cwd?: string;
-    workspaceWarning?: string;
-  } {
-    const resolvedWorkspace = resolveWorkspacePathForRuntime(workspace);
-    if (resolvedWorkspace) {
-      return { cwd: resolvedWorkspace };
-    }
-
-    if (!workspace) {
-      return {};
-    }
-
-    return {
-      cwd: undefined,
-      workspaceWarning:
-        `Saved workspace ${workspace} is unavailable in this TelePi runtime. Continuing in the current workspace instead.`,
-    };
-  }
-
-  private getUnavailableSavedWorkspace(sessionFile: string): string | undefined {
-    const header = readSessionHeader(sessionFile);
-    if (!header?.cwd || header.cwd === this.currentWorkspace) {
-      return undefined;
-    }
-
-    return resolveWorkspacePathForRuntime(header.cwd) ? undefined : header.cwd;
-  }
-
-  getTree(): SessionTreeNode[] {
-    return this.getSession().sessionManager.getTree();
-  }
-
-  getLeafId(): string | null {
-    return this.getSession().sessionManager.getLeafId();
-  }
-
-  getEntry(id: string): SessionEntry | undefined {
-    return this.getSession().sessionManager.getEntry(id);
-  }
-
-  getChildren(id: string): SessionEntry[] {
-    return this.getSession().sessionManager.getChildren(id);
-  }
-
-  async navigateTree(
-    targetId: string,
-    options?: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string },
-  ): Promise<{ editorText?: string; cancelled: boolean }> {
-    return this.getSession().navigateTree(targetId, options);
-  }
-
-  async fork(entryId: string, options?: PiSessionForkOptions): Promise<{ cancelled: boolean }> {
-    const previousSession = this.getSession();
-    const previousWorkspace = this.currentWorkspace;
-    const result = await this.getHandle().runtime.fork(entryId, options);
-    await this.rebindAfterRuntimeSessionReplacement(previousSession, previousWorkspace);
-    return { cancelled: result.cancelled };
-  }
-
-  async reload(): Promise<void> {
-    await this.getSession().reload();
-  }
-
-  setLabel(targetId: string, label: string): void {
-    this.getSession().sessionManager.appendLabelChange(targetId, label);
-  }
-
-  getLabels(): Array<{ id: string; label: string; description: string }> {
-    const tree = this.getTree();
-    const labels: Array<{ id: string; label: string; description: string }> = [];
-
-    const walk = (node: SessionTreeNode): void => {
-      if (node.label) {
-        labels.push({
-          id: node.entry.id,
-          label: node.label,
-          description: describeEntry(node.entry),
-        });
-      }
-
-      for (const child of node.children) {
-        walk(child);
-      }
-    };
-
-    for (const root of tree) {
-      walk(root);
-    }
-
-    return labels;
-  }
-
-  async handback(): Promise<{ sessionFile?: string; workspace: string }> {
-    const info = {
-      sessionFile: this.handle?.runtime.session.sessionFile,
-      workspace: this.currentWorkspace,
-    };
-
-    const unavailableWorkspace = info.sessionFile
-      ? this.getUnavailableSavedWorkspace(info.sessionFile)
-      : undefined;
-    if (unavailableWorkspace) {
-      throw new Error(
-        `Cannot hand back this session while its saved workspace is unavailable (${unavailableWorkspace}). Reopen it from a valid workspace first.`,
-      );
-    }
-
-    const previousHandle = this.handle;
-    this.sessionUnsubscribe?.();
-    this.sessionUnsubscribe = undefined;
-    this.handle = undefined;
-
-    try {
-      await previousHandle?.dispose();
-    } catch (error) {
-      console.error("Failed to dispose session during handback:", error);
-    }
-
-    return info;
-  }
-
-  dispose(): void {
-    this.sessionUnsubscribe?.();
-    this.sessionUnsubscribe = undefined;
-
-    const handle = this.handle;
-    this.handle = undefined;
-    if (!handle) {
-      return;
-    }
-
-    void handle.dispose().catch((error) => {
-      console.error("Failed to dispose Pi session:", error);
-    });
-  }
-
-  private getHandle(): PiSessionHandle {
-    if (!this.handle) {
-      throw new Error("Pi session is not initialized");
-    }
-    return this.handle;
-  }
-
-  private reloadAuthStorage(): void {
-    this.getHandle().runtime.services.authStorage.reload();
-  }
-
-  private getModelRegistry(): ModelRegistry {
-    return this.getHandle().runtime.services.modelRegistry;
-  }
-
-  private async replaceHandle(nextHandle: PiSessionHandle): Promise<void> {
-    const previousHandle = this.handle;
-    const previousSession = previousHandle?.runtime.session;
-    const previousWorkspace = this.currentWorkspace;
-    this.handle = nextHandle;
-
-    try {
-      await this.rebindAfterSessionReplacement(previousSession);
-    } catch (error) {
-      await this.disposeHandleAfterRebindFailure(nextHandle, previousWorkspace, error);
-    } finally {
-      try {
-        await previousHandle?.dispose();
-      } catch (error) {
-        console.error("Failed to dispose previous session:", error);
-      }
-    }
-  }
-
-  private async bindExtensionsToCurrentSession(): Promise<void> {
-    if (!this.extensionBindings || !this.handle) {
-      return;
-    }
-
-    await this.getSession().bindExtensions(this.extensionBindings);
-  }
-
-  private rebindSessionSubscription(): void {
-    this.sessionUnsubscribe?.();
-    this.sessionUnsubscribe = undefined;
-
-    if (!this.sessionCallbacks || !this.handle) {
-      return;
-    }
-
-    this.sessionUnsubscribe = subscribeToSession(this.getSession(), this.sessionCallbacks);
-  }
-
-  private async disposeHandleAfterRebindFailure(
-    handle: PiSessionHandle | undefined,
-    previousWorkspace: string,
-    error: unknown,
-  ): Promise<never> {
-    this.sessionUnsubscribe?.();
-    this.sessionUnsubscribe = undefined;
-    this.handle = undefined;
-    this.currentWorkspace = previousWorkspace;
-
-    try {
-      await handle?.dispose();
-    } catch (disposeError) {
-      console.error("Failed to dispose replacement session after rebinding error:", disposeError);
-    }
-
-    throw error;
-  }
-
-  private async rebindAfterRuntimeSessionReplacement(
-    previousSession: AgentSession | undefined,
-    previousWorkspace: string,
-  ): Promise<void> {
-    try {
-      await this.rebindAfterSessionReplacement(previousSession);
-    } catch (error) {
-      await this.disposeHandleAfterRebindFailure(this.handle, previousWorkspace, error);
-    }
-  }
-
-  private async rebindAfterSessionReplacement(previousSession?: AgentSession): Promise<void> {
-    if (!this.handle) {
-      return;
-    }
-
-    const currentSession = this.getSession();
-    // AgentSessionRuntime replacements track the effective workspace on runtime.cwd.
-    // TelePi treats runtime.cwd as the source of truth after every runtime-driven
-    // session replacement while keeping these flows serialized through the service instance.
-    this.currentWorkspace = this.handle.runtime.cwd;
-    if (previousSession === currentSession) {
-      return;
-    }
-
-    await this.bindExtensionsToCurrentSession();
-    this.rebindSessionSubscription();
-  }
+	private handle?: PiSessionHandle;
+	private currentWorkspace: string;
+	private sessionCallbacks?: PiSessionCallbacks;
+	private sessionUnsubscribe?: () => void;
+	private extensionBindings?: Parameters<AgentSession["bindExtensions"]>[0];
+
+	private constructor(private readonly config: TelePiConfig) {
+		this.currentWorkspace = config.workspace;
+	}
+
+	static async create(config: TelePiConfig): Promise<PiSessionService> {
+		const service = new PiSessionService(config);
+		service.handle = await createPiSession(config);
+		service.currentWorkspace = service.handle.runtime.cwd;
+		return service;
+	}
+
+	getSession(): AgentSession {
+		return this.getHandle().runtime.session;
+	}
+
+	isStreaming(): boolean {
+		return this.handle?.runtime.session.isStreaming ?? false;
+	}
+
+	hasActiveSession(): boolean {
+		return this.handle !== undefined;
+	}
+
+	getCurrentWorkspace(): string {
+		return this.currentWorkspace;
+	}
+
+	getInfo(): PiSessionInfo {
+		if (!this.handle) {
+			return {
+				sessionId: "(no active session)",
+				sessionFile: undefined,
+				workspace: this.currentWorkspace,
+				sessionName: undefined,
+				modelFallbackMessage: undefined,
+				model: undefined,
+			};
+		}
+
+		const session = this.handle.runtime.session;
+		const model = session.model;
+		const diagnostics =
+			this.handle.runtime.diagnostics.length > 0
+				? [...this.handle.runtime.diagnostics]
+				: undefined;
+
+		return {
+			sessionId: session.sessionId,
+			sessionFile: session.sessionFile,
+			workspace: this.currentWorkspace,
+			sessionName: session.sessionName,
+			modelFallbackMessage: this.handle.runtime.modelFallbackMessage,
+			model: model ? `${model.provider}/${model.id}` : undefined,
+			...(diagnostics ? { diagnostics } : {}),
+		};
+	}
+
+	subscribe(callbacks: PiSessionCallbacks): () => void {
+		this.sessionCallbacks = callbacks;
+		this.rebindSessionSubscription();
+
+		return () => {
+			if (this.sessionCallbacks === callbacks) {
+				this.sessionCallbacks = undefined;
+				this.sessionUnsubscribe?.();
+				this.sessionUnsubscribe = undefined;
+			}
+		};
+	}
+
+	async prompt(text: string, images?: ImageContent[]): Promise<void> {
+		this.reloadAuthStorage();
+		await promptSession(this.getSession(), text, images);
+	}
+
+	async bindExtensions(
+		bindings: Parameters<AgentSession["bindExtensions"]>[0],
+	): Promise<void> {
+		this.extensionBindings = bindings;
+		await this.bindExtensionsToCurrentSession();
+	}
+
+	async listSlashCommands(): Promise<SlashCommandInfo[]> {
+		const commands = this.getHandle().getSlashCommands();
+		const deduped = new Map<string, SlashCommandInfo>();
+
+		for (const command of commands) {
+			const name = command.name.replace(/^\/+/, "").trim();
+			if (!name || deduped.has(name)) {
+				continue;
+			}
+			deduped.set(name, {
+				...command,
+				name,
+			});
+		}
+
+		return [...deduped.values()].sort((left, right) =>
+			left.name.localeCompare(right.name),
+		);
+	}
+
+	async abort(): Promise<void> {
+		if (!this.handle) {
+			return;
+		}
+		await this.handle.runtime.session.abort();
+	}
+
+	getContextUsage(): ContextUsage | undefined {
+		return this.handle?.runtime.session.getContextUsage();
+	}
+
+	getSessionStats(): SessionStats | undefined {
+		return this.handle?.runtime.session.getSessionStats();
+	}
+
+	async listAllSessions(): Promise<
+		Array<{
+			id: string;
+			firstMessage: string;
+			path: string;
+			messageCount: number;
+			cwd: string;
+			modified: Date;
+			name?: string;
+		}>
+	> {
+		const sessions = await SessionManager.listAll();
+		sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+		return sessions.map((s) => ({
+			id: s.id,
+			firstMessage: s.firstMessage,
+			path: s.path,
+			messageCount: s.messageCount,
+			cwd: s.cwd,
+			modified: s.modified,
+			name: s.name,
+		}));
+	}
+
+	async listWorkspaces(): Promise<string[]> {
+		const sessions = await SessionManager.listAll();
+		const workspaces = new Set<string>();
+		for (const session of sessions) {
+			if (session.cwd) {
+				workspaces.add(session.cwd);
+			}
+		}
+		return [...workspaces].sort();
+	}
+
+	async newSession(
+		request?: string | PiSessionNewSessionOptions,
+	): Promise<{ info: PiSessionInfo; created: boolean }> {
+		const options = normalizeNewSessionOptions(request);
+		const effectiveWorkspace = options.workspace ?? this.currentWorkspace;
+
+		if (
+			(!this.handle || effectiveWorkspace !== this.currentWorkspace) &&
+			options.withSession
+		) {
+			throw new Error(
+				"TelePi only supports withSession callbacks for runtime-backed new-session replacements.",
+			);
+		}
+
+		if (!this.handle || effectiveWorkspace !== this.currentWorkspace) {
+			const nextHandle = await createNewPiSession(
+				this.config,
+				effectiveWorkspace,
+				options,
+			);
+			await this.replaceHandle(nextHandle);
+			return { info: this.getInfo(), created: true };
+		}
+
+		const previousSession = this.getSession();
+		const previousWorkspace = this.currentWorkspace;
+		const result = await this.getHandle().runtime.newSession({
+			parentSession: options.parentSession,
+			setup: options.setup,
+			withSession: options.withSession,
+		});
+		await this.rebindAfterRuntimeSessionReplacement(
+			previousSession,
+			previousWorkspace,
+		);
+		return { info: this.getInfo(), created: !result.cancelled };
+	}
+
+	async listModels(showAll = false): Promise<PiSessionModelOption[]> {
+		this.reloadAuthStorage();
+		const session = this.getSession();
+		const currentModel = session.model;
+		const availableModels = this.getModelRegistry().getAvailable();
+		const availableKeys = new Set(
+			availableModels.map((model) => `${model.provider}/${model.id}`),
+		);
+		const scopedThinkingLevels = new Map(
+			session.scopedModels.map((scoped) => [
+				`${scoped.model.provider}/${scoped.model.id}`,
+				scoped.thinkingLevel,
+			]),
+		);
+		const available =
+			showAll || session.scopedModels.length === 0
+				? availableModels
+				: session.scopedModels
+						.map((scoped) => scoped.model)
+						.filter((model) =>
+							availableKeys.has(`${model.provider}/${model.id}`),
+						);
+
+		return available.map((model) => ({
+			provider: model.provider,
+			id: model.id,
+			name: model.name,
+			current: currentModel
+				? model.provider === currentModel.provider &&
+					model.id === currentModel.id
+				: false,
+			thinkingLevel: scopedThinkingLevels.get(`${model.provider}/${model.id}`),
+		}));
+	}
+
+	async setModel(
+		provider: string,
+		modelId: string,
+		thinkingLevel?: ThinkingLevel,
+	): Promise<string> {
+		this.reloadAuthStorage();
+		const session = this.getSession();
+		const modelRegistry = this.getModelRegistry();
+		const model = modelRegistry.find(provider, modelId);
+		if (!model) {
+			throw new Error(`Model not found: ${provider}/${modelId}`);
+		}
+		await session.setModel(model);
+		if (thinkingLevel !== undefined) {
+			session.setThinkingLevel(thinkingLevel);
+		}
+		return `${model.provider}/${model.id}`;
+	}
+
+	async resolveSessionReference(
+		sessionReference: string,
+	): Promise<ResolvedSessionReference> {
+		const normalizedReference = sessionReference.trim();
+		if (!normalizedReference) {
+			throw new SessionReferenceResolutionError(
+				"Session reference cannot be empty.",
+			);
+		}
+
+		const remappedReferencePath =
+			resolveSessionPathForRuntime(normalizedReference);
+		const looksLikePath =
+			normalizedReference.includes("/") ||
+			normalizedReference.includes("\\") ||
+			normalizedReference.endsWith(".jsonl") ||
+			normalizedReference.startsWith("~");
+		if (looksLikePath) {
+			if (!existsSync(remappedReferencePath)) {
+				throw new SessionReferenceResolutionError(
+					`Saved session not found: ${normalizedReference}`,
+				);
+			}
+
+			const header = readSessionHeader(remappedReferencePath);
+
+			let indexedWorkspace: string | undefined;
+			try {
+				const indexedMatch = (await this.listAllSessions()).find(
+					(session) =>
+						session.path === normalizedReference ||
+						session.path === remappedReferencePath ||
+						resolveSessionPathForRuntime(session.path) ===
+							remappedReferencePath,
+				);
+				indexedWorkspace = indexedMatch?.cwd;
+			} catch {
+				indexedWorkspace = undefined;
+			}
+
+			const workspaceResolution = this.resolveSessionWorkspace(
+				indexedWorkspace ?? header?.cwd,
+			);
+			return {
+				id: header?.id ?? path.basename(remappedReferencePath),
+				path: remappedReferencePath,
+				cwd: workspaceResolution.cwd,
+				...(workspaceResolution.workspaceWarning
+					? { workspaceWarning: workspaceResolution.workspaceWarning }
+					: {}),
+				matchType: "path",
+			};
+		}
+
+		const allSessions = await this.listAllSessions();
+		const currentWorkspaceSessions = allSessions.filter(
+			(session) => session.cwd === this.currentWorkspace,
+		);
+
+		const exactIdMatch =
+			currentWorkspaceSessions.find(
+				(session) => session.id === normalizedReference,
+			) ?? allSessions.find((session) => session.id === normalizedReference);
+		if (exactIdMatch) {
+			const workspaceResolution = this.resolveSessionWorkspace(
+				exactIdMatch.cwd,
+			);
+			return {
+				id: exactIdMatch.id,
+				path: exactIdMatch.path,
+				cwd: workspaceResolution.cwd,
+				...(workspaceResolution.workspaceWarning
+					? { workspaceWarning: workspaceResolution.workspaceWarning }
+					: {}),
+				matchType: "id",
+			};
+		}
+
+		const localPrefixMatches = currentWorkspaceSessions.filter((session) =>
+			session.id.startsWith(normalizedReference),
+		);
+		if (localPrefixMatches.length === 1) {
+			const [prefixMatch] = localPrefixMatches;
+			const workspaceResolution = this.resolveSessionWorkspace(prefixMatch.cwd);
+			return {
+				id: prefixMatch.id,
+				path: prefixMatch.path,
+				cwd: workspaceResolution.cwd,
+				...(workspaceResolution.workspaceWarning
+					? { workspaceWarning: workspaceResolution.workspaceWarning }
+					: {}),
+				matchType: "prefix",
+			};
+		}
+
+		if (localPrefixMatches.length > 1) {
+			throw new SessionReferenceResolutionError(
+				`Session ID prefix "${normalizedReference}" matches ${localPrefixMatches.length} saved sessions in the current workspace. Use more characters or /sessions to pick one.`,
+			);
+		}
+
+		const prefixMatches = allSessions.filter((session) =>
+			session.id.startsWith(normalizedReference),
+		);
+		if (prefixMatches.length === 1) {
+			const [prefixMatch] = prefixMatches;
+			const workspaceResolution = this.resolveSessionWorkspace(prefixMatch.cwd);
+			return {
+				id: prefixMatch.id,
+				path: prefixMatch.path,
+				cwd: workspaceResolution.cwd,
+				...(workspaceResolution.workspaceWarning
+					? { workspaceWarning: workspaceResolution.workspaceWarning }
+					: {}),
+				matchType: "prefix",
+			};
+		}
+
+		if (prefixMatches.length > 1) {
+			throw new SessionReferenceResolutionError(
+				`Session ID prefix "${normalizedReference}" matches ${prefixMatches.length} saved sessions. Use more characters or /sessions to pick one.`,
+			);
+		}
+
+		throw new SessionReferenceResolutionError(
+			`No saved session matches "${normalizedReference}". Use /sessions to browse, or pass a full session path or session ID.`,
+		);
+	}
+
+	/**
+	 * Best-effort helper for UI flows that want a workspace hint before switching.
+	 * Missing sessions and transient session-index failures should both surface as
+	 * "no workspace available" so callers can safely fall back.
+	 */
+	async resolveWorkspaceForSession(
+		sessionPath: string,
+	): Promise<string | undefined> {
+		try {
+			return (await this.tryResolveSessionReference(sessionPath))?.cwd;
+		} catch {
+			return undefined;
+		}
+	}
+
+	async switchSession(
+		sessionPath: string,
+		request?: string | PiSessionSwitchOptions,
+	): Promise<PiSessionSwitchResult> {
+		const options = normalizeSwitchSessionOptions(request);
+		const resolvedReference =
+			await this.tryResolveSessionReference(sessionPath);
+		const runtimeSessionPath =
+			resolvedReference?.path ?? resolveSessionPathForRuntime(sessionPath);
+		const effectiveWorkspace =
+			options.workspace ?? resolvedReference?.cwd ?? this.currentWorkspace;
+
+		if (!this.handle && options.withSession) {
+			throw new Error(
+				"TelePi only supports withSession callbacks for runtime-backed session switches.",
+			);
+		}
+
+		if (!this.handle) {
+			const nextHandle = await createPiSession(
+				this.config,
+				runtimeSessionPath,
+				effectiveWorkspace,
+			);
+			await this.replaceHandle(nextHandle);
+			return {
+				...this.getInfo(),
+				cancelled: false,
+			};
+		}
+
+		const previousSession = this.getSession();
+		const previousWorkspace = this.currentWorkspace;
+		const result = await this.getHandle().runtime.switchSession(
+			runtimeSessionPath,
+			{
+				cwdOverride: effectiveWorkspace,
+				withSession: options.withSession,
+			},
+		);
+		await this.rebindAfterRuntimeSessionReplacement(
+			previousSession,
+			previousWorkspace,
+		);
+		return {
+			...this.getInfo(),
+			cancelled: result.cancelled,
+		};
+	}
+
+	private async tryResolveSessionReference(
+		sessionPath: string,
+	): Promise<ResolvedSessionReference | undefined> {
+		try {
+			return await this.resolveSessionReference(sessionPath);
+		} catch (error) {
+			if (error instanceof SessionReferenceResolutionError) {
+				return undefined;
+			}
+
+			throw error;
+		}
+	}
+
+	private resolveSessionWorkspace(workspace: string | undefined): {
+		cwd?: string;
+		workspaceWarning?: string;
+	} {
+		const resolvedWorkspace = resolveWorkspacePathForRuntime(workspace);
+		if (resolvedWorkspace) {
+			return { cwd: resolvedWorkspace };
+		}
+
+		if (!workspace) {
+			return {};
+		}
+
+		return {
+			cwd: undefined,
+			workspaceWarning: `Saved workspace ${workspace} is unavailable in this TelePi runtime. Continuing in the current workspace instead.`,
+		};
+	}
+
+	private getUnavailableSavedWorkspace(
+		sessionFile: string,
+	): string | undefined {
+		const header = readSessionHeader(sessionFile);
+		if (!header?.cwd || header.cwd === this.currentWorkspace) {
+			return undefined;
+		}
+
+		return resolveWorkspacePathForRuntime(header.cwd) ? undefined : header.cwd;
+	}
+
+	getTree(): SessionTreeNode[] {
+		return this.getSession().sessionManager.getTree();
+	}
+
+	getLeafId(): string | null {
+		return this.getSession().sessionManager.getLeafId();
+	}
+
+	getEntry(id: string): SessionEntry | undefined {
+		return this.getSession().sessionManager.getEntry(id);
+	}
+
+	getChildren(id: string): SessionEntry[] {
+		return this.getSession().sessionManager.getChildren(id);
+	}
+
+	async navigateTree(
+		targetId: string,
+		options?: {
+			summarize?: boolean;
+			customInstructions?: string;
+			replaceInstructions?: boolean;
+			label?: string;
+		},
+	): Promise<{ editorText?: string; cancelled: boolean }> {
+		return this.getSession().navigateTree(targetId, options);
+	}
+
+	async fork(
+		entryId: string,
+		options?: PiSessionForkOptions,
+	): Promise<{ cancelled: boolean }> {
+		const previousSession = this.getSession();
+		const previousWorkspace = this.currentWorkspace;
+		const result = await this.getHandle().runtime.fork(entryId, options);
+		await this.rebindAfterRuntimeSessionReplacement(
+			previousSession,
+			previousWorkspace,
+		);
+		return { cancelled: result.cancelled };
+	}
+
+	async reload(): Promise<void> {
+		await this.getSession().reload();
+	}
+
+	setLabel(targetId: string, label: string): void {
+		this.getSession().sessionManager.appendLabelChange(targetId, label);
+	}
+
+	getLabels(): Array<{ id: string; label: string; description: string }> {
+		const tree = this.getTree();
+		const labels: Array<{ id: string; label: string; description: string }> =
+			[];
+
+		const walk = (node: SessionTreeNode): void => {
+			if (node.label) {
+				labels.push({
+					id: node.entry.id,
+					label: node.label,
+					description: describeEntry(node.entry),
+				});
+			}
+
+			for (const child of node.children) {
+				walk(child);
+			}
+		};
+
+		for (const root of tree) {
+			walk(root);
+		}
+
+		return labels;
+	}
+
+	async handback(): Promise<{ sessionFile?: string; workspace: string }> {
+		const info = {
+			sessionFile: this.handle?.runtime.session.sessionFile,
+			workspace: this.currentWorkspace,
+		};
+
+		const unavailableWorkspace = info.sessionFile
+			? this.getUnavailableSavedWorkspace(info.sessionFile)
+			: undefined;
+		if (unavailableWorkspace) {
+			throw new Error(
+				`Cannot hand back this session while its saved workspace is unavailable (${unavailableWorkspace}). Reopen it from a valid workspace first.`,
+			);
+		}
+
+		const previousHandle = this.handle;
+		this.sessionUnsubscribe?.();
+		this.sessionUnsubscribe = undefined;
+		this.handle = undefined;
+
+		try {
+			await previousHandle?.dispose();
+		} catch (error) {
+			console.error("Failed to dispose session during handback:", error);
+		}
+
+		return info;
+	}
+
+	dispose(): void {
+		this.sessionUnsubscribe?.();
+		this.sessionUnsubscribe = undefined;
+
+		const handle = this.handle;
+		this.handle = undefined;
+		if (!handle) {
+			return;
+		}
+
+		void handle.dispose().catch((error) => {
+			console.error("Failed to dispose Pi session:", error);
+		});
+	}
+
+	private getHandle(): PiSessionHandle {
+		if (!this.handle) {
+			throw new Error("Pi session is not initialized");
+		}
+		return this.handle;
+	}
+
+	private reloadAuthStorage(): void {
+		this.getHandle().runtime.services.authStorage.reload();
+	}
+
+	private getModelRegistry(): ModelRegistry {
+		return this.getHandle().runtime.services.modelRegistry;
+	}
+
+	private async replaceHandle(nextHandle: PiSessionHandle): Promise<void> {
+		const previousHandle = this.handle;
+		const previousSession = previousHandle?.runtime.session;
+		const previousWorkspace = this.currentWorkspace;
+		this.handle = nextHandle;
+
+		try {
+			await this.rebindAfterSessionReplacement(previousSession);
+		} catch (error) {
+			await this.disposeHandleAfterRebindFailure(
+				nextHandle,
+				previousWorkspace,
+				error,
+			);
+		} finally {
+			try {
+				await previousHandle?.dispose();
+			} catch (error) {
+				console.error("Failed to dispose previous session:", error);
+			}
+		}
+	}
+
+	private async bindExtensionsToCurrentSession(): Promise<void> {
+		if (!this.extensionBindings || !this.handle) {
+			return;
+		}
+
+		await this.getSession().bindExtensions(this.extensionBindings);
+	}
+
+	private rebindSessionSubscription(): void {
+		this.sessionUnsubscribe?.();
+		this.sessionUnsubscribe = undefined;
+
+		if (!this.sessionCallbacks || !this.handle) {
+			return;
+		}
+
+		this.sessionUnsubscribe = subscribeToSession(
+			this.getSession(),
+			this.sessionCallbacks,
+		);
+	}
+
+	private async disposeHandleAfterRebindFailure(
+		handle: PiSessionHandle | undefined,
+		previousWorkspace: string,
+		error: unknown,
+	): Promise<never> {
+		this.sessionUnsubscribe?.();
+		this.sessionUnsubscribe = undefined;
+		this.handle = undefined;
+		this.currentWorkspace = previousWorkspace;
+
+		try {
+			await handle?.dispose();
+		} catch (disposeError) {
+			console.error(
+				"Failed to dispose replacement session after rebinding error:",
+				disposeError,
+			);
+		}
+
+		throw error;
+	}
+
+	private async rebindAfterRuntimeSessionReplacement(
+		previousSession: AgentSession | undefined,
+		previousWorkspace: string,
+	): Promise<void> {
+		try {
+			await this.rebindAfterSessionReplacement(previousSession);
+		} catch (error) {
+			await this.disposeHandleAfterRebindFailure(
+				this.handle,
+				previousWorkspace,
+				error,
+			);
+		}
+	}
+
+	private async rebindAfterSessionReplacement(
+		previousSession?: AgentSession,
+	): Promise<void> {
+		if (!this.handle) {
+			return;
+		}
+
+		const currentSession = this.getSession();
+		// AgentSessionRuntime replacements track the effective workspace on runtime.cwd.
+		// TelePi treats runtime.cwd as the source of truth after every runtime-driven
+		// session replacement while keeping these flows serialized through the service instance.
+		this.currentWorkspace = this.handle.runtime.cwd;
+		if (previousSession === currentSession) {
+			return;
+		}
+
+		await this.bindExtensionsToCurrentSession();
+		this.rebindSessionSubscription();
+	}
 }
 
 export function getPiSessionContextKey(context: PiSessionContext): string {
-  return `${String(context.chatId)}::${context.messageThreadId ?? "root"}`;
+	return `${String(context.chatId)}::${context.messageThreadId ?? "root"}`;
 }
 
 export class PiSessionRegistry {
-  private readonly services = new Map<string, PiSessionService>();
-  private readonly inflight = new Map<string, Promise<PiSessionService>>();
-  private readonly generations = new Map<string, number>();
-  private bootstrapSessionPath?: string;
+	private readonly services = new Map<string, PiSessionService>();
+	private readonly inflight = new Map<string, Promise<PiSessionService>>();
+	private readonly generations = new Map<string, number>();
+	private bootstrapSessionPath?: string;
 
-  private constructor(private readonly config: TelePiConfig) {
-    this.bootstrapSessionPath = config.piSessionPath;
-  }
+	private constructor(private readonly config: TelePiConfig) {
+		this.bootstrapSessionPath = config.piSessionPath;
+	}
 
-  static async create(config: TelePiConfig): Promise<PiSessionRegistry> {
-    return new PiSessionRegistry(config);
-  }
+	static async create(config: TelePiConfig): Promise<PiSessionRegistry> {
+		return new PiSessionRegistry(config);
+	}
 
-  has(context: PiSessionContext): boolean {
-    return this.services.has(getPiSessionContextKey(context));
-  }
+	has(context: PiSessionContext): boolean {
+		return this.services.has(getPiSessionContextKey(context));
+	}
 
-  get(context: PiSessionContext): PiSessionService | undefined {
-    return this.services.get(getPiSessionContextKey(context));
-  }
+	get(context: PiSessionContext): PiSessionService | undefined {
+		return this.services.get(getPiSessionContextKey(context));
+	}
 
-  getInfo(context: PiSessionContext): PiSessionInfo {
-    return this.get(context)?.getInfo() ?? {
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: this.config.workspace,
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    };
-  }
+	getInfo(context: PiSessionContext): PiSessionInfo {
+		return (
+			this.get(context)?.getInfo() ?? {
+				sessionId: "(no active session)",
+				sessionFile: undefined,
+				workspace: this.config.workspace,
+				sessionName: undefined,
+				modelFallbackMessage: undefined,
+				model: undefined,
+			}
+		);
+	}
 
-  async getOrCreate(context: PiSessionContext): Promise<PiSessionService> {
-    const key = getPiSessionContextKey(context);
-    const existing = this.services.get(key);
-    if (existing) {
-      return existing;
-    }
+	async getOrCreate(context: PiSessionContext): Promise<PiSessionService> {
+		const key = getPiSessionContextKey(context);
+		const existing = this.services.get(key);
+		if (existing) {
+			return existing;
+		}
 
-    const inflight = this.inflight.get(key);
-    if (inflight) {
-      return inflight;
-    }
+		const inflight = this.inflight.get(key);
+		if (inflight) {
+			return inflight;
+		}
 
-    const generation = this.bumpGeneration(key);
-    const createPromise = PiSessionService.create(this.createServiceConfig())
-      .then((service) => {
-        this.inflight.delete(key);
+		const generation = this.bumpGeneration(key);
+		const createPromise = PiSessionService.create(this.createServiceConfig())
+			.then((service) => {
+				this.inflight.delete(key);
 
-        if (this.generations.get(key) !== generation) {
-          service.dispose();
-          const replacement = this.services.get(key);
-          if (replacement) {
-            return replacement;
-          }
-          throw new Error("Session removed during initialization");
-        }
+				if (this.generations.get(key) !== generation) {
+					service.dispose();
+					const replacement = this.services.get(key);
+					if (replacement) {
+						return replacement;
+					}
+					throw new Error("Session removed during initialization");
+				}
 
-        this.services.set(key, service);
-        return service;
-      })
-      .catch((error) => {
-        this.inflight.delete(key);
-        throw error;
-      });
+				this.services.set(key, service);
+				return service;
+			})
+			.catch((error) => {
+				this.inflight.delete(key);
+				throw error;
+			});
 
-    this.inflight.set(key, createPromise);
-    return createPromise;
-  }
+		this.inflight.set(key, createPromise);
+		return createPromise;
+	}
 
-  remove(context: PiSessionContext): void {
-    const key = getPiSessionContextKey(context);
-    this.bumpGeneration(key);
-    const service = this.services.get(key);
-    service?.dispose();
-    this.services.delete(key);
-    this.inflight.delete(key);
-  }
+	remove(context: PiSessionContext): void {
+		const key = getPiSessionContextKey(context);
+		this.bumpGeneration(key);
+		const service = this.services.get(key);
+		service?.dispose();
+		this.services.delete(key);
+		this.inflight.delete(key);
+	}
 
-  dispose(): void {
-    const allKeys = new Set<string>([...this.services.keys(), ...this.inflight.keys()]);
-    for (const key of allKeys) {
-      this.bumpGeneration(key);
-    }
-    for (const service of this.services.values()) {
-      service.dispose();
-    }
-    this.services.clear();
-    this.inflight.clear();
-  }
+	dispose(): void {
+		const allKeys = new Set<string>([
+			...this.services.keys(),
+			...this.inflight.keys(),
+		]);
+		for (const key of allKeys) {
+			this.bumpGeneration(key);
+		}
+		for (const service of this.services.values()) {
+			service.dispose();
+		}
+		this.services.clear();
+		this.inflight.clear();
+	}
 
-  private createServiceConfig(): TelePiConfig {
-    const initialSessionPath = this.consumeBootstrapSessionPath();
-    return {
-      ...this.config,
-      telegramAllowedUserIdSet: new Set(this.config.telegramAllowedUserIds),
-      piSessionPath: initialSessionPath,
-    };
-  }
+	private createServiceConfig(): TelePiConfig {
+		const initialSessionPath = this.consumeBootstrapSessionPath();
+		return {
+			...this.config,
+			telegramAllowedUserIdSet: new Set(this.config.telegramAllowedUserIds),
+			piSessionPath: initialSessionPath,
+		};
+	}
 
-  private consumeBootstrapSessionPath(): string | undefined {
-    const sessionPath = this.bootstrapSessionPath;
-    this.bootstrapSessionPath = undefined;
-    return sessionPath;
-  }
+	private consumeBootstrapSessionPath(): string | undefined {
+		const sessionPath = this.bootstrapSessionPath;
+		this.bootstrapSessionPath = undefined;
+		return sessionPath;
+	}
 
-  private bumpGeneration(key: string): number {
-    const nextGeneration = (this.generations.get(key) ?? 0) + 1;
-    this.generations.set(key, nextGeneration);
-    return nextGeneration;
-  }
+	private bumpGeneration(key: string): number {
+		const nextGeneration = (this.generations.get(key) ?? 0) + 1;
+		this.generations.set(key, nextGeneration);
+		return nextGeneration;
+	}
 }
 
 function normalizeNewSessionOptions(
-  request?: string | PiSessionNewSessionOptions,
+	request?: string | PiSessionNewSessionOptions,
 ): PiSessionNewSessionOptions {
-  if (typeof request === "string") {
-    return { workspace: request };
-  }
+	if (typeof request === "string") {
+		return { workspace: request };
+	}
 
-  return request ?? {};
+	return request ?? {};
 }
 
 function normalizeSwitchSessionOptions(
-  request?: string | PiSessionSwitchOptions,
+	request?: string | PiSessionSwitchOptions,
 ): PiSessionSwitchOptions {
-  if (typeof request === "string") {
-    return { workspace: request };
-  }
+	if (typeof request === "string") {
+		return { workspace: request };
+	}
 
-  return request ?? {};
+	return request ?? {};
 }
 
 async function applySessionSetup(
-  session: AgentSession,
-  setup?: PiSessionNewSessionOptions["setup"],
+	session: AgentSession,
+	setup?: PiSessionNewSessionOptions["setup"],
 ): Promise<void> {
-  if (!setup) {
-    return;
-  }
+	if (!setup) {
+		return;
+	}
 
-  await setup(session.sessionManager);
-  session.agent.state.messages = session.sessionManager.buildSessionContext().messages;
+	await setup(session.sessionManager);
+	session.agent.state.messages =
+		session.sessionManager.buildSessionContext().messages;
 }
 
-function collectSettingsDiagnostics(settingsManager: SettingsManager): PiSessionDiagnostic[] {
-  return (settingsManager.drainErrors?.() ?? []).map(({ scope, error }): PiSessionDiagnostic => ({
-    type: "warning",
-    message: `${humanizeDiagnosticScope(scope)} settings: ${error.message}`,
-  }));
+function collectSettingsDiagnostics(
+	settingsManager: SettingsManager,
+): PiSessionDiagnostic[] {
+	return (settingsManager.drainErrors?.() ?? []).map(
+		({ scope, error }): PiSessionDiagnostic => ({
+			type: "warning",
+			message: `${humanizeDiagnosticScope(scope)} settings: ${error.message}`,
+		}),
+	);
 }
 
 function collectSessionResourceDiagnostics(
-  resourceLoader: ResourceLoader,
-  session: AgentSession,
+	resourceLoader: ResourceLoader,
+	session: AgentSession,
 ): PiSessionDiagnostic[] {
-  return [
-    ...(resourceLoader.getExtensions?.().errors ?? []).map(({ path, error }): PiSessionDiagnostic => ({
-      type: "error",
-      message: `Failed to load extension "${path}": ${error}`,
-    })),
-    ...normalizeResourceDiagnostics("Skill", resourceLoader.getSkills?.().diagnostics ?? []),
-    ...normalizeResourceDiagnostics("Prompt", resourceLoader.getPrompts?.().diagnostics ?? []),
-    ...normalizeResourceDiagnostics("Theme", resourceLoader.getThemes?.().diagnostics ?? []),
-    ...normalizeResourceDiagnostics("Extension", session.extensionRunner?.getCommandDiagnostics?.() ?? []),
-    ...normalizeResourceDiagnostics("Extension", session.extensionRunner?.getShortcutDiagnostics?.() ?? []),
-  ];
+	return [
+		...(resourceLoader.getExtensions?.().errors ?? []).map(
+			({ path, error }): PiSessionDiagnostic => ({
+				type: "error",
+				message: `Failed to load extension "${path}": ${error}`,
+			}),
+		),
+		...normalizeResourceDiagnostics(
+			"Skill",
+			resourceLoader.getSkills?.().diagnostics ?? [],
+		),
+		...normalizeResourceDiagnostics(
+			"Prompt",
+			resourceLoader.getPrompts?.().diagnostics ?? [],
+		),
+		...normalizeResourceDiagnostics(
+			"Theme",
+			resourceLoader.getThemes?.().diagnostics ?? [],
+		),
+		...normalizeResourceDiagnostics(
+			"Extension",
+			session.extensionRunner?.getCommandDiagnostics?.() ?? [],
+		),
+		...normalizeResourceDiagnostics(
+			"Extension",
+			session.extensionRunner?.getShortcutDiagnostics?.() ?? [],
+		),
+	];
 }
 
 function normalizeResourceDiagnostics(
-  label: string,
-  diagnostics: ResourceDiagnostic[],
+	label: string,
+	diagnostics: ResourceDiagnostic[],
 ): PiSessionDiagnostic[] {
-  return diagnostics.map((diagnostic) => {
-    if (diagnostic.type === "collision" && diagnostic.collision) {
-      return {
-        type: "warning",
-        message:
-          `${label} collision (${diagnostic.collision.name}): using ${diagnostic.collision.winnerPath}, skipped ${diagnostic.collision.loserPath}`,
-      };
-    }
+	return diagnostics.map((diagnostic) => {
+		if (diagnostic.type === "collision" && diagnostic.collision) {
+			return {
+				type: "warning",
+				message: `${label} collision (${diagnostic.collision.name}): using ${diagnostic.collision.winnerPath}, skipped ${diagnostic.collision.loserPath}`,
+			};
+		}
 
-    const location = diagnostic.path ? ` (${diagnostic.path})` : "";
-    return {
-      type: diagnostic.type === "error" ? "error" : "warning",
-      message: `${label} issue${location}: ${diagnostic.message}`,
-    };
-  });
+		const location = diagnostic.path ? ` (${diagnostic.path})` : "";
+		return {
+			type: diagnostic.type === "error" ? "error" : "warning",
+			message: `${label} issue${location}: ${diagnostic.message}`,
+		};
+	});
 }
 
-function dedupeDiagnostics(diagnostics: PiSessionDiagnostic[]): PiSessionDiagnostic[] {
-  const seen = new Set<string>();
-  const deduped: PiSessionDiagnostic[] = [];
+function dedupeDiagnostics(
+	diagnostics: PiSessionDiagnostic[],
+): PiSessionDiagnostic[] {
+	const seen = new Set<string>();
+	const deduped: PiSessionDiagnostic[] = [];
 
-  for (const diagnostic of diagnostics) {
-    const key = `${diagnostic.type}:${diagnostic.message}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(diagnostic);
-  }
+	for (const diagnostic of diagnostics) {
+		const key = `${diagnostic.type}:${diagnostic.message}`;
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		deduped.push(diagnostic);
+	}
 
-  return deduped;
+	return deduped;
 }
 
 function humanizeDiagnosticScope(scope: string): string {
-  if (!scope) {
-    return "Unknown";
-  }
+	if (!scope) {
+		return "Unknown";
+	}
 
-  return scope.charAt(0).toUpperCase() + scope.slice(1);
+	return scope.charAt(0).toUpperCase() + scope.slice(1);
 }
 
 function createSessionManager(
-  config: TelePiConfig,
-  workspace: string,
-  overrideSessionPath?: string,
-  hasWorkspaceOverride = false,
+	config: TelePiConfig,
+	workspace: string,
+	overrideSessionPath?: string,
+	hasWorkspaceOverride = false,
 ): SessionManager {
-  const sessionPath = overrideSessionPath ?? config.piSessionPath;
-  if (sessionPath) {
-    const runtimeSessionPath = resolveSessionPathForRuntime(sessionPath);
-    const headerWorkspace = resolveWorkspacePathForRuntime(readSessionHeader(runtimeSessionPath)?.cwd);
-    return SessionManager.open(
-      runtimeSessionPath,
-      undefined,
-      hasWorkspaceOverride ? workspace : (headerWorkspace ?? workspace),
-    );
-  }
+	const sessionPath = overrideSessionPath ?? config.piSessionPath;
+	if (sessionPath) {
+		const runtimeSessionPath = resolveSessionPathForRuntime(sessionPath);
+		const headerWorkspace = resolveWorkspacePathForRuntime(
+			readSessionHeader(runtimeSessionPath)?.cwd,
+		);
+		return SessionManager.open(
+			runtimeSessionPath,
+			undefined,
+			hasWorkspaceOverride ? workspace : (headerWorkspace ?? workspace),
+		);
+	}
 
-  return SessionManager.create(workspace);
+	return SessionManager.create(workspace);
 }
 
 function resolveModelOverride(
-  modelRegistry: ModelRegistry,
-  modelRef: string | undefined,
+	modelRegistry: ModelRegistry,
+	modelRef: string | undefined,
 ): Model<Api> | undefined {
-  if (!modelRef) {
-    return undefined;
-  }
+	if (!modelRef) {
+		return undefined;
+	}
 
-  const normalized = modelRef.trim();
-  const slashIndex = normalized.indexOf("/");
+	const normalized = modelRef.trim();
+	const slashIndex = normalized.indexOf("/");
 
-  if (slashIndex >= 0) {
-    const provider = normalized.slice(0, slashIndex).trim();
-    const rawModelId = normalized.slice(slashIndex + 1).trim();
-    const modelId = rawModelId.split(":")[0]?.trim();
+	if (slashIndex >= 0) {
+		const provider = normalized.slice(0, slashIndex).trim();
+		const rawModelId = normalized.slice(slashIndex + 1).trim();
+		const modelId = rawModelId.split(":")[0]?.trim();
 
-    if (!provider || !modelId) {
-      throw new Error(`Invalid PI_MODEL value: ${modelRef}`);
-    }
+		if (!provider || !modelId) {
+			throw new Error(`Invalid PI_MODEL value: ${modelRef}`);
+		}
 
-    const model = modelRegistry.find(provider, modelId);
-    if (!model) {
-      throw new Error(`Could not resolve PI_MODEL: ${modelRef}`);
-    }
+		const model = modelRegistry.find(provider, modelId);
+		if (!model) {
+			throw new Error(`Could not resolve PI_MODEL: ${modelRef}`);
+		}
 
-    return model;
-  }
+		return model;
+	}
 
-  const matches = modelRegistry.getAll().filter((model) => model.id === normalized);
-  if (matches.length === 0) {
-    throw new Error(`Could not resolve PI_MODEL: ${modelRef}`);
-  }
+	const matches = modelRegistry
+		.getAll()
+		.filter((model) => model.id === normalized);
+	if (matches.length === 0) {
+		throw new Error(`Could not resolve PI_MODEL: ${modelRef}`);
+	}
 
-  if (matches.length > 1) {
-    const providers = matches.map((model) => model.provider).join(", ");
-    throw new Error(`PI_MODEL is ambiguous. Use provider/modelId instead. Matches: ${providers}`);
-  }
+	if (matches.length > 1) {
+		const providers = matches.map((model) => model.provider).join(", ");
+		throw new Error(
+			`PI_MODEL is ambiguous. Use provider/modelId instead. Matches: ${providers}`,
+		);
+	}
 
-  return matches[0];
+	return matches[0];
 }
 
 function stringifyToolData(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
+	if (typeof value === "string") {
+		return value;
+	}
 
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
 }
 
 function wrapError(message: string, error: unknown): Error {
-  if (error instanceof Error) {
-    return new Error(`${message}: ${error.message}`, { cause: error });
-  }
+	if (error instanceof Error) {
+		return new Error(`${message}: ${error.message}`, { cause: error });
+	}
 
-  return new Error(`${message}: ${String(error)}`);
+	return new Error(`${message}: ${String(error)}`);
 }

--- a/src/provider-response-notices.ts
+++ b/src/provider-response-notices.ts
@@ -1,151 +1,156 @@
-import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 
 import type { TelegramExtensionNoticeType } from "./telegram-ui-context.js";
 
 export interface ProviderResponseNoticeEvent {
-  status: number;
-  headers: Record<string, string>;
+	status: number;
+	headers: Record<string, string>;
 }
 
 export interface ProviderResponseNotice {
-  message: string;
-  type: TelegramExtensionNoticeType;
+	message: string;
+	type: TelegramExtensionNoticeType;
 }
 
 export function getProviderResponseNotice(
-  event: ProviderResponseNoticeEvent,
+	event: ProviderResponseNoticeEvent,
 ): ProviderResponseNotice | undefined {
-  if (event.status >= 200 && event.status < 300) {
-    return undefined;
-  }
+	if (event.status >= 200 && event.status < 300) {
+		return undefined;
+	}
 
-  const headers = normalizeHeaders(event.headers);
-  const warning = formatWarningHeader(headers.warning);
-  const retryAfter = formatRetryAfter(headers["retry-after"]);
-  const requestId = firstHeader(headers, [
-    "request-id",
-    "x-request-id",
-    "anthropic-request-id",
-    "openai-request-id",
-  ]);
+	const headers = normalizeHeaders(event.headers);
+	const warning = formatWarningHeader(headers.warning);
+	const retryAfter = formatRetryAfter(headers["retry-after"]);
+	const requestId = firstHeader(headers, [
+		"request-id",
+		"x-request-id",
+		"anthropic-request-id",
+		"openai-request-id",
+	]);
 
-  if (event.status === 401 || event.status === 403) {
-    // Auth/access failures need operator action; surfacing Retry-After here would
-    // imply a transient backoff signal when the credentials or permissions are the issue.
-    return {
-      message: joinSentences(
-        `Provider authentication failed (HTTP ${event.status}). Check API credentials or provider access.`,
-        warning ? `Provider warning: ${warning}.` : undefined,
-        requestId ? `Request ID: ${requestId}.` : undefined,
-      ),
-      type: "error",
-    };
-  }
+	if (event.status === 401 || event.status === 403) {
+		// Auth/access failures need operator action; surfacing Retry-After here would
+		// imply a transient backoff signal when the credentials or permissions are the issue.
+		return {
+			message: joinSentences(
+				`Provider authentication failed (HTTP ${event.status}). Check API credentials or provider access.`,
+				warning ? `Provider warning: ${warning}.` : undefined,
+				requestId ? `Request ID: ${requestId}.` : undefined,
+			),
+			type: "error",
+		};
+	}
 
-  if (event.status === 429) {
-    return {
-      message: joinSentences(
-        "Provider rate limit reached (HTTP 429). Please retry shortly.",
-        retryAfter ? `Retry after ${retryAfter}.` : undefined,
-        warning ? `Provider warning: ${warning}.` : undefined,
-        requestId ? `Request ID: ${requestId}.` : undefined,
-      ),
-      type: "warning",
-    };
-  }
+	if (event.status === 429) {
+		return {
+			message: joinSentences(
+				"Provider rate limit reached (HTTP 429). Please retry shortly.",
+				retryAfter ? `Retry after ${retryAfter}.` : undefined,
+				warning ? `Provider warning: ${warning}.` : undefined,
+				requestId ? `Request ID: ${requestId}.` : undefined,
+			),
+			type: "warning",
+		};
+	}
 
-  if (event.status === 408 || event.status >= 500) {
-    return {
-      message: joinSentences(
-        `Provider appears unavailable or degraded (HTTP ${event.status}). Please retry later.`,
-        retryAfter ? `Retry after ${retryAfter}.` : undefined,
-        warning ? `Provider warning: ${warning}.` : undefined,
-        requestId ? `Request ID: ${requestId}.` : undefined,
-      ),
-      type: "warning",
-    };
-  }
+	if (event.status === 408 || event.status >= 500) {
+		return {
+			message: joinSentences(
+				`Provider appears unavailable or degraded (HTTP ${event.status}). Please retry later.`,
+				retryAfter ? `Retry after ${retryAfter}.` : undefined,
+				warning ? `Provider warning: ${warning}.` : undefined,
+				requestId ? `Request ID: ${requestId}.` : undefined,
+			),
+			type: "warning",
+		};
+	}
 
-  if (warning || retryAfter) {
-    return {
-      message: joinSentences(
-        `Provider reported an issue (HTTP ${event.status}).`,
-        retryAfter ? `Retry after ${retryAfter}.` : undefined,
-        warning ? `Provider warning: ${warning}.` : undefined,
-        requestId ? `Request ID: ${requestId}.` : undefined,
-      ),
-      type: "warning",
-    };
-  }
+	if (warning || retryAfter) {
+		return {
+			message: joinSentences(
+				`Provider reported an issue (HTTP ${event.status}).`,
+				retryAfter ? `Retry after ${retryAfter}.` : undefined,
+				warning ? `Provider warning: ${warning}.` : undefined,
+				requestId ? `Request ID: ${requestId}.` : undefined,
+			),
+			type: "warning",
+		};
+	}
 
-  return undefined;
+	return undefined;
 }
 
 export function createProviderResponseNoticeExtension(): ExtensionFactory {
-  return (pi) => {
-    pi.on("after_provider_response", (event, ctx) => {
-      const notice = getProviderResponseNotice({
-        status: event.status,
-        headers: event.headers,
-      });
-      if (!notice) {
-        return;
-      }
+	return (pi) => {
+		pi.on("after_provider_response", (event, ctx) => {
+			const notice = getProviderResponseNotice({
+				status: event.status,
+				headers: event.headers,
+			});
+			if (!notice) {
+				return;
+			}
 
-      // If the SDK/client ever starts retrying provider calls internally, this hook
-      // will fire for each attempted response. Keep any future dedupe at this edge so
-      // getProviderResponseNotice stays a pure mapper for direct unit coverage.
-      ctx.ui.notify(notice.message, notice.type);
-    });
-  };
+			// If the SDK/client ever starts retrying provider calls internally, this hook
+			// will fire for each attempted response. Keep any future dedupe at this edge so
+			// getProviderResponseNotice stays a pure mapper for direct unit coverage.
+			ctx.ui.notify(notice.message, notice.type);
+		});
+	};
 }
 
-function normalizeHeaders(headers: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers)
-      .map(([name, value]) => [name.toLowerCase(), value.trim()])
-      .filter((entry) => entry[1].length > 0),
-  );
+function normalizeHeaders(
+	headers: Record<string, string>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers)
+			.map(([name, value]) => [name.toLowerCase(), value.trim()])
+			.filter((entry) => entry[1].length > 0),
+	);
 }
 
-function firstHeader(headers: Record<string, string>, names: string[]): string | undefined {
-  for (const name of names) {
-    const value = headers[name];
-    if (value) {
-      return value;
-    }
-  }
+function firstHeader(
+	headers: Record<string, string>,
+	names: string[],
+): string | undefined {
+	for (const name of names) {
+		const value = headers[name];
+		if (value) {
+			return value;
+		}
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function formatRetryAfter(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
+	if (!value) {
+		return undefined;
+	}
 
-  if (/^\d+$/.test(value)) {
-    const seconds = Number.parseInt(value, 10);
-    return `${seconds} second${seconds === 1 ? "" : "s"}`;
-  }
+	if (/^\d+$/.test(value)) {
+		const seconds = Number.parseInt(value, 10);
+		return `${seconds} second${seconds === 1 ? "" : "s"}`;
+	}
 
-  return value;
+	return value;
 }
 
 function formatWarningHeader(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
+	if (!value) {
+		return undefined;
+	}
 
-  const quotedMessage = value.match(/"([^"]+)"/);
-  const trimmed = (quotedMessage?.[1] ?? value)
-    .replace(/^\d{3}\s+/u, "")
-    .replace(/^"|"$/gu, "")
-    .trim();
+	const quotedMessage = value.match(/"([^"]+)"/);
+	const trimmed = (quotedMessage?.[1] ?? value)
+		.replace(/^\d{3}\s+/u, "")
+		.replace(/^"|"$/gu, "")
+		.trim();
 
-  return trimmed || undefined;
+	return trimmed || undefined;
 }
 
 function joinSentences(...parts: Array<string | undefined>): string {
-  return parts.filter((part): part is string => Boolean(part)).join(" ");
+	return parts.filter((part): part is string => Boolean(part)).join(" ");
 }

--- a/src/telegram-ui-context.ts
+++ b/src/telegram-ui-context.ts
@@ -1,127 +1,150 @@
-import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 
 export type TelegramExtensionNoticeType = "info" | "warning" | "error";
 
 type TelegramThemeShim = Pick<
-  ExtensionUIContext["theme"],
-  | "fg"
-  | "bg"
-  | "bold"
-  | "italic"
-  | "underline"
-  | "inverse"
-  | "strikethrough"
-  | "getFgAnsi"
-  | "getBgAnsi"
-  | "getColorMode"
-  | "getThinkingBorderColor"
-  | "getBashModeBorderColor"
+	ExtensionUIContext["theme"],
+	| "fg"
+	| "bg"
+	| "bold"
+	| "italic"
+	| "underline"
+	| "inverse"
+	| "strikethrough"
+	| "getFgAnsi"
+	| "getBgAnsi"
+	| "getColorMode"
+	| "getThinkingBorderColor"
+	| "getBashModeBorderColor"
 >;
 
 const passthroughText = (text: string): string => text;
 
 const plainTextTheme: TelegramThemeShim = {
-  fg(_color, text) {
-    return text;
-  },
-  bg(_color, text) {
-    return text;
-  },
-  bold: passthroughText,
-  italic: passthroughText,
-  underline: passthroughText,
-  inverse: passthroughText,
-  strikethrough: passthroughText,
-  getFgAnsi() {
-    return "";
-  },
-  getBgAnsi() {
-    return "";
-  },
-  getColorMode() {
-    return "truecolor";
-  },
-  getThinkingBorderColor() {
-    return passthroughText;
-  },
-  getBashModeBorderColor() {
-    return passthroughText;
-  },
+	fg(_color, text) {
+		return text;
+	},
+	bg(_color, text) {
+		return text;
+	},
+	bold: passthroughText,
+	italic: passthroughText,
+	underline: passthroughText,
+	inverse: passthroughText,
+	strikethrough: passthroughText,
+	getFgAnsi() {
+		return "";
+	},
+	getBgAnsi() {
+		return "";
+	},
+	getColorMode() {
+		return "truecolor";
+	},
+	getThinkingBorderColor() {
+		return passthroughText;
+	},
+	getBashModeBorderColor() {
+		return passthroughText;
+	},
 };
 
 export interface CreateTelegramUIContextOptions {
-  notify: (message: string, type?: TelegramExtensionNoticeType) => void;
-  select?: (title: string, options: string[], dialogOptions?: { signal?: AbortSignal; timeout?: number }) => Promise<string | undefined>;
-  confirm?: (title: string, message: string, dialogOptions?: { signal?: AbortSignal; timeout?: number }) => Promise<boolean>;
-  input?: (title: string, placeholder?: string, dialogOptions?: { signal?: AbortSignal; timeout?: number }) => Promise<string | undefined>;
+	notify: (message: string, type?: TelegramExtensionNoticeType) => void;
+	select?: (
+		title: string,
+		options: string[],
+		dialogOptions?: { signal?: AbortSignal; timeout?: number },
+	) => Promise<string | undefined>;
+	confirm?: (
+		title: string,
+		message: string,
+		dialogOptions?: { signal?: AbortSignal; timeout?: number },
+	) => Promise<boolean>;
+	input?: (
+		title: string,
+		placeholder?: string,
+		dialogOptions?: { signal?: AbortSignal; timeout?: number },
+	) => Promise<string | undefined>;
 }
 
 function unsupported(method: string): never {
-  throw new Error(`TelePi does not yet support extension UI method '${method}'.`);
+	throw new Error(
+		`TelePi does not yet support extension UI method '${method}'.`,
+	);
 }
 
-export function createTelegramUIContext(options: CreateTelegramUIContextOptions): ExtensionUIContext {
-  return {
-    async select(title, choices, dialogOptions) {
-      if (!options.select) {
-        unsupported("select");
-      }
-      return options.select(title, choices, dialogOptions);
-    },
-    async confirm(title, message, dialogOptions) {
-      if (!options.confirm) {
-        unsupported("confirm");
-      }
-      return options.confirm(title, message, dialogOptions);
-    },
-    async input(title, placeholder, dialogOptions) {
-      if (!options.input) {
-        unsupported("input");
-      }
-      return options.input(title, placeholder, dialogOptions);
-    },
-    notify(message, type) {
-      options.notify(message, type);
-    },
-    onTerminalInput() {
-      return () => {};
-    },
-    setStatus() {},
-    setWorkingMessage() {},
-    setWorkingIndicator() {},
-    setHiddenThinkingLabel() {},
-    setWidget() {},
-    setFooter() {},
-    setHeader() {},
-    setTitle() {},
-    async custom() {
-      unsupported("custom");
-    },
-    pasteToEditor() {},
-    setEditorText() {},
-    getEditorText() {
-      return "";
-    },
-    async editor() {
-      unsupported("editor");
-    },
-    addAutocompleteProvider() {},
-    setEditorComponent() {},
-    // Pi exposes ctx.ui.theme in degraded UI modes like RPC. TelePi does not render ANSI,
-    // so we provide a plain-text shim instead of the interactive terminal Theme instance.
-    theme: plainTextTheme as unknown as ExtensionUIContext["theme"],
-    getAllThemes() {
-      return [];
-    },
-    getTheme() {
-      return undefined;
-    },
-    setTheme() {
-      return { success: false, error: "TelePi does not support theme switching through extension UI." };
-    },
-    getToolsExpanded() {
-      return false;
-    },
-    setToolsExpanded() {},
-  };
+export function createTelegramUIContext(
+	options: CreateTelegramUIContextOptions,
+): ExtensionUIContext {
+	return {
+		async select(title, choices, dialogOptions) {
+			if (!options.select) {
+				unsupported("select");
+			}
+			return options.select(title, choices, dialogOptions);
+		},
+		async confirm(title, message, dialogOptions) {
+			if (!options.confirm) {
+				unsupported("confirm");
+			}
+			return options.confirm(title, message, dialogOptions);
+		},
+		async input(title, placeholder, dialogOptions) {
+			if (!options.input) {
+				unsupported("input");
+			}
+			return options.input(title, placeholder, dialogOptions);
+		},
+		notify(message, type) {
+			options.notify(message, type);
+		},
+		onTerminalInput() {
+			return () => {};
+		},
+		setStatus() {},
+		setWorkingMessage() {},
+		setWorkingVisible() {},
+		setWorkingIndicator() {},
+		setHiddenThinkingLabel() {},
+		setWidget() {},
+		setFooter() {},
+		setHeader() {},
+		setTitle() {},
+		async custom() {
+			unsupported("custom");
+		},
+		pasteToEditor() {},
+		setEditorText() {},
+		getEditorText() {
+			return "";
+		},
+		async editor() {
+			unsupported("editor");
+		},
+		addAutocompleteProvider() {},
+		setEditorComponent() {},
+		getEditorComponent() {
+			return undefined;
+		},
+		// Pi exposes ctx.ui.theme in degraded UI modes like RPC. TelePi does not render ANSI,
+		// so we provide a plain-text shim instead of the interactive terminal Theme instance.
+		theme: plainTextTheme as unknown as ExtensionUIContext["theme"],
+		getAllThemes() {
+			return [];
+		},
+		getTheme() {
+			return undefined;
+		},
+		setTheme() {
+			return {
+				success: false,
+				error: "TelePi does not support theme switching through extension UI.",
+			};
+		},
+		getToolsExpanded() {
+			return false;
+		},
+		setToolsExpanded() {},
+	};
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,12 +1,12 @@
-import type { SessionEntry } from "@mariozechner/pi-coding-agent";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 
 import { NOOP_PAGE_CALLBACK_DATA } from "./callback-data.js";
 import { escapeHTML } from "./format.js";
 
 export interface SessionTreeNodeLike {
-  entry: SessionEntry;
-  children: SessionTreeNodeLike[];
-  label?: string;
+	entry: SessionEntry;
+	children: SessionTreeNodeLike[];
+	label?: string;
 }
 
 const DEFAULT_TREE_LIMIT = 10;
@@ -18,653 +18,735 @@ const TREE_BUTTON_PAGE_LIMIT = 6;
 type TreeEntryLike = { type: string; id?: string; [key: string]: any };
 
 type DisplayNode = {
-  node: SessionTreeNodeLike;
-  children: DisplayNode[];
+	node: SessionTreeNodeLike;
+	children: DisplayNode[];
 };
 
 type FlatDisplayNode = {
-  node: SessionTreeNodeLike;
-  depth: number;
-  isLast: boolean;
-  ancestorHasNext: boolean[];
+	node: SessionTreeNodeLike;
+	depth: number;
+	isLast: boolean;
+	ancestorHasNext: boolean[];
 };
 
 type TreePage = {
-  nodes: FlatDisplayNode[];
-  startIndex: number;
-  endIndex: number;
+	nodes: FlatDisplayNode[];
+	startIndex: number;
+	endIndex: number;
 };
 
 export interface TreeButton {
-  label: string;
-  callbackData: string;
+	label: string;
+	callbackData: string;
 }
 
 export interface TreeRenderResult {
-  text: string;
-  buttons: TreeButton[];
-  totalEntries: number;
-  shownEntries: number;
-  page: number;
-  totalPages: number;
+	text: string;
+	buttons: TreeButton[];
+	totalEntries: number;
+	shownEntries: number;
+	page: number;
+	totalPages: number;
 }
 
 export type TreeFilterMode = "default" | "user-only" | "all-with-buttons";
 
 export function truncateText(text: string, maxLen: number): string {
-  if (maxLen <= 0) {
-    return "";
-  }
+	if (maxLen <= 0) {
+		return "";
+	}
 
-  if (text.length <= maxLen) {
-    return text;
-  }
+	if (text.length <= maxLen) {
+		return text;
+	}
 
-  if (maxLen === 1) {
-    return "…";
-  }
+	if (maxLen === 1) {
+		return "…";
+	}
 
-  return `${text.slice(0, maxLen - 1)}…`;
+	return `${text.slice(0, maxLen - 1)}…`;
 }
 
 export function describeEntry(entry: TreeEntryLike): string {
-  switch (entry.type) {
-    case "message": {
-      const role = entry.message?.role;
-      if (role === "user") {
-        return `user: ${formatQuotedText(extractTextContent(entry.message?.content))}`;
-      }
+	switch (entry.type) {
+		case "message": {
+			const role = entry.message?.role;
+			if (role === "user") {
+				return `user: ${formatQuotedText(extractTextContent(entry.message?.content))}`;
+			}
 
-      if (role === "assistant") {
-        const text = extractTextContent(entry.message?.content);
-        if (text) {
-          return `assistant: ${formatQuotedText(text)}`;
-        }
+			if (role === "assistant") {
+				const text = extractTextContent(entry.message?.content);
+				if (text) {
+					return `assistant: ${formatQuotedText(text)}`;
+				}
 
-        const toolName = extractToolCallName(entry.message?.content);
-        if (toolName) {
-          return `assistant: [tool ${toolName}]`;
-        }
+				const toolName = extractToolCallName(entry.message?.content);
+				if (toolName) {
+					return `assistant: [tool ${toolName}]`;
+				}
 
-        return "assistant: [no text]";
-      }
+				return "assistant: [no text]";
+			}
 
-      if (role === "toolResult") {
-        return `toolResult: ${entry.message?.toolName ?? "tool"}`;
-      }
+			if (role === "toolResult") {
+				return `toolResult: ${entry.message?.toolName ?? "tool"}`;
+			}
 
-      if (role) {
-        return `[${role}]`;
-      }
+			if (role) {
+				return `[${role}]`;
+			}
 
-      return "[message]";
-    }
-    case "compaction":
-      return "[compaction]";
-    case "branch_summary":
-      return "[branch summary]";
-    case "model_change":
-      return `[model ${entry.provider ?? "unknown"}/${entry.modelId ?? "unknown"}]`;
-    case "thinking_level_change":
-      return `[thinking level ${entry.thinkingLevel ?? "unknown"}]`;
-    case "custom":
-    case "custom_message":
-      return `[custom ${entry.customType ?? "unknown"}]`;
-    case "label":
-      return `[label ${entry.label ?? ""}]`;
-    case "session_info":
-      return `[session ${entry.name ?? "unnamed"}]`;
-    default:
-      return `[${entry.type}]`;
-  }
+			return "[message]";
+		}
+		case "compaction":
+			return "[compaction]";
+		case "branch_summary":
+			return "[branch summary]";
+		case "model_change":
+			return `[model ${entry.provider ?? "unknown"}/${entry.modelId ?? "unknown"}]`;
+		case "thinking_level_change":
+			return `[thinking level ${entry.thinkingLevel ?? "unknown"}]`;
+		case "custom":
+		case "custom_message":
+			return `[custom ${entry.customType ?? "unknown"}]`;
+		case "label":
+			return `[label ${entry.label ?? ""}]`;
+		case "session_info":
+			return `[session ${entry.name ?? "unnamed"}]`;
+		default:
+			return `[${entry.type}]`;
+	}
 }
 
 export function renderTree(
-  tree: SessionTreeNodeLike[],
-  leafId: string | null,
-  options: {
-    mode?: TreeFilterMode;
-    limit?: number;
-    page?: number;
-  } = {},
+	tree: SessionTreeNodeLike[],
+	leafId: string | null,
+	options: {
+		mode?: TreeFilterMode;
+		limit?: number;
+		page?: number;
+	} = {},
 ): TreeRenderResult {
-  if (tree.length === 0) {
-    return {
-      text: "Session tree is empty.",
-      buttons: [],
-      totalEntries: 0,
-      shownEntries: 0,
-      page: 0,
-      totalPages: 0,
-    };
-  }
+	if (tree.length === 0) {
+		return {
+			text: "Session tree is empty.",
+			buttons: [],
+			totalEntries: 0,
+			shownEntries: 0,
+			page: 0,
+			totalPages: 0,
+		};
+	}
 
-  const mode = options.mode ?? "default";
-  const pageEntryLimit = Math.max(1, options.limit ?? DEFAULT_TREE_LIMIT);
-  const displayTree = buildDisplayTree(tree, mode);
-  const flattened = flattenDisplayTree(displayTree);
+	const mode = options.mode ?? "default";
+	const pageEntryLimit = Math.max(1, options.limit ?? DEFAULT_TREE_LIMIT);
+	const displayTree = buildDisplayTree(tree, mode);
+	const flattened = flattenDisplayTree(displayTree);
 
-  if (flattened.length === 0) {
-    return {
-      text: buildTreeHtml(
-        ["No matching entries."],
-        {
-          totalEntries: 0,
-          shownEntries: 0,
-          page: 0,
-          totalPages: 0,
-          rangeStart: 0,
-          rangeEnd: 0,
-          mode,
-          focusPage: 0,
-          showFocusNote: false,
-        },
-      ),
-      buttons: buildTreeButtons([], [], leafId, mode, 0, 0, 0),
-      totalEntries: 0,
-      shownEntries: 0,
-      page: 0,
-      totalPages: 0,
-    };
-  }
+	if (flattened.length === 0) {
+		return {
+			text: buildTreeHtml(["No matching entries."], {
+				totalEntries: 0,
+				shownEntries: 0,
+				page: 0,
+				totalPages: 0,
+				rangeStart: 0,
+				rangeEnd: 0,
+				mode,
+				focusPage: 0,
+				showFocusNote: false,
+			}),
+			buttons: buildTreeButtons([], [], leafId, mode, 0, 0, 0),
+			totalEntries: 0,
+			shownEntries: 0,
+			page: 0,
+			totalPages: 0,
+		};
+	}
 
-  const totalEntries = flattened.length;
-  const pages = buildTreePages(flattened, leafId, mode, pageEntryLimit);
-  const focusIndex = getFocusIndex(tree, flattened, leafId);
-  const focusPage = getPageIndexForEntry(pages, focusIndex);
-  const safePage = clampPage(options.page ?? focusPage, pages.length);
-  const visiblePage = pages[safePage] ?? pages[0];
-  const visibleNodes = visiblePage?.nodes ?? [];
-  const pageBaseDepth = visibleNodes.reduce((minDepth, flatNode) => Math.min(minDepth, flatNode.depth), Number.POSITIVE_INFINITY);
-  const renderedLines = visibleNodes.map((flatNode) =>
-    renderTreeLine(flatNode, leafId, Number.isFinite(pageBaseDepth) ? pageBaseDepth : 0)
-  );
-  const html = buildTreeHtml(renderedLines, {
-    totalEntries,
-    shownEntries: visibleNodes.length,
-    page: safePage,
-    totalPages: pages.length,
-    rangeStart: visibleNodes.length === 0 ? 0 : visiblePage.startIndex + 1,
-    rangeEnd: visibleNodes.length === 0 ? 0 : visiblePage.endIndex + 1,
-    mode,
-    focusPage,
-    showFocusNote: leafId !== null,
-  });
-  const buttons = buildTreeButtons(flattened, visibleNodes, leafId, mode, safePage, pages.length, focusIndex);
+	const totalEntries = flattened.length;
+	const pages = buildTreePages(flattened, leafId, mode, pageEntryLimit);
+	const focusIndex = getFocusIndex(tree, flattened, leafId);
+	const focusPage = getPageIndexForEntry(pages, focusIndex);
+	const safePage = clampPage(options.page ?? focusPage, pages.length);
+	const visiblePage = pages[safePage] ?? pages[0];
+	const visibleNodes = visiblePage?.nodes ?? [];
+	const pageBaseDepth = visibleNodes.reduce(
+		(minDepth, flatNode) => Math.min(minDepth, flatNode.depth),
+		Number.POSITIVE_INFINITY,
+	);
+	const renderedLines = visibleNodes.map((flatNode) =>
+		renderTreeLine(
+			flatNode,
+			leafId,
+			Number.isFinite(pageBaseDepth) ? pageBaseDepth : 0,
+		),
+	);
+	const html = buildTreeHtml(renderedLines, {
+		totalEntries,
+		shownEntries: visibleNodes.length,
+		page: safePage,
+		totalPages: pages.length,
+		rangeStart: visibleNodes.length === 0 ? 0 : visiblePage.startIndex + 1,
+		rangeEnd: visibleNodes.length === 0 ? 0 : visiblePage.endIndex + 1,
+		mode,
+		focusPage,
+		showFocusNote: leafId !== null,
+	});
+	const buttons = buildTreeButtons(
+		flattened,
+		visibleNodes,
+		leafId,
+		mode,
+		safePage,
+		pages.length,
+		focusIndex,
+	);
 
-  return {
-    text: html,
-    buttons,
-    totalEntries,
-    shownEntries: visibleNodes.length,
-    page: safePage,
-    totalPages: pages.length,
-  };
+	return {
+		text: html,
+		buttons,
+		totalEntries,
+		shownEntries: visibleNodes.length,
+		page: safePage,
+		totalPages: pages.length,
+	};
 }
 
 export function renderBranchConfirmation(
-  entry: { type: string; id: string; [key: string]: any },
-  children: Array<{ type: string; id: string; [key: string]: any }>,
-  leafId: string | null,
-  labels: Map<string, string>,
+	entry: { type: string; id: string; [key: string]: any },
+	children: Array<{ type: string; id: string; [key: string]: any }>,
+	leafId: string | null,
+	labels: Map<string, string>,
 ): { text: string; buttons: TreeButton[] } {
-  const lines = [
-    "<b>Navigate to this point?</b>",
-    "",
-    `${renderEntryRef(entry.id)} ${escapeHTML(describeEntry(entry))}`,
-  ];
+	const lines = [
+		"<b>Navigate to this point?</b>",
+		"",
+		`${renderEntryRef(entry.id)} ${escapeHTML(describeEntry(entry))}`,
+	];
 
-  if (children.length > 0) {
-    lines.push("", "<b>Children</b>");
-    for (const child of children) {
-      const active = child.id === leafId ? " ← active" : "";
-      const label = labels.get(child.id);
-      const labelText = label ? ` <b>[${escapeHTML(label)}]</b>` : "";
-      lines.push(`${renderEntryRef(child.id)} ${escapeHTML(describeEntry(child))}${labelText}${escapeHTML(active)}`);
-    }
-  }
+	if (children.length > 0) {
+		lines.push("", "<b>Children</b>");
+		for (const child of children) {
+			const active = child.id === leafId ? " ← active" : "";
+			const label = labels.get(child.id);
+			const labelText = label ? ` <b>[${escapeHTML(label)}]</b>` : "";
+			lines.push(
+				`${renderEntryRef(child.id)} ${escapeHTML(describeEntry(child))}${labelText}${escapeHTML(active)}`,
+			);
+		}
+	}
 
-  lines.push("", "Choose how to navigate:");
+	lines.push("", "Choose how to navigate:");
 
-  return {
-    text: lines.join("\n"),
-    buttons: [
-      { label: "🔀 Navigate here", callbackData: `tree_go_${entry.id}` },
-      { label: "📝 Navigate + Summarize", callbackData: `tree_sum_${entry.id}` },
-      { label: "❌ Cancel", callbackData: "tree_cancel" },
-    ],
-  };
+	return {
+		text: lines.join("\n"),
+		buttons: [
+			{ label: "🔀 Navigate here", callbackData: `tree_go_${entry.id}` },
+			{
+				label: "📝 Navigate + Summarize",
+				callbackData: `tree_sum_${entry.id}`,
+			},
+			{ label: "❌ Cancel", callbackData: "tree_cancel" },
+		],
+	};
 }
 
 export function renderLabels(tree: SessionTreeNodeLike[]): string {
-  const labeled: string[] = [];
+	const labeled: string[] = [];
 
-  const walk = (node: SessionTreeNodeLike): void => {
-    if (node.label) {
-      labeled.push(
-        `🏷️ ${renderEntryRef(node.entry.id)} <b>[${escapeHTML(node.label)}]</b> — ${escapeHTML(describeEntry(node.entry))}`,
-      );
-    }
+	const walk = (node: SessionTreeNodeLike): void => {
+		if (node.label) {
+			labeled.push(
+				`🏷️ ${renderEntryRef(node.entry.id)} <b>[${escapeHTML(node.label)}]</b> — ${escapeHTML(describeEntry(node.entry))}`,
+			);
+		}
 
-    for (const child of node.children) {
-      walk(child);
-    }
-  };
+		for (const child of node.children) {
+			walk(child);
+		}
+	};
 
-  for (const root of tree) {
-    walk(root);
-  }
+	for (const root of tree) {
+		walk(root);
+	}
 
-  if (labeled.length === 0) {
-    return "No labels set.";
-  }
+	if (labeled.length === 0) {
+		return "No labels set.";
+	}
 
-  return labeled.join("\n");
+	return labeled.join("\n");
 }
 
-function buildDisplayTree(tree: SessionTreeNodeLike[], mode: TreeFilterMode): DisplayNode[] {
-  const result: DisplayNode[] = [];
+function buildDisplayTree(
+	tree: SessionTreeNodeLike[],
+	mode: TreeFilterMode,
+): DisplayNode[] {
+	const result: DisplayNode[] = [];
 
-  for (const node of tree) {
-    const visibleChildren = buildDisplayTree(node.children, mode);
-    if (shouldIncludeEntry(node.entry, mode)) {
-      result.push({ node, children: visibleChildren });
-    } else {
-      result.push(...visibleChildren);
-    }
-  }
+	for (const node of tree) {
+		const visibleChildren = buildDisplayTree(node.children, mode);
+		if (shouldIncludeEntry(node.entry, mode)) {
+			result.push({ node, children: visibleChildren });
+		} else {
+			result.push(...visibleChildren);
+		}
+	}
 
-  return result;
+	return result;
 }
 
-function flattenDisplayTree(nodes: DisplayNode[], depth = 0, ancestorHasNext: boolean[] = []): FlatDisplayNode[] {
-  const result: FlatDisplayNode[] = [];
+function flattenDisplayTree(
+	nodes: DisplayNode[],
+	depth = 0,
+	ancestorHasNext: boolean[] = [],
+): FlatDisplayNode[] {
+	const result: FlatDisplayNode[] = [];
 
-  nodes.forEach((node, index) => {
-    const isLast = index === nodes.length - 1;
-    result.push({
-      node: node.node,
-      depth,
-      isLast,
-      ancestorHasNext,
-    });
-    result.push(...flattenDisplayTree(node.children, depth + 1, [...ancestorHasNext, !isLast]));
-  });
+	nodes.forEach((node, index) => {
+		const isLast = index === nodes.length - 1;
+		result.push({
+			node: node.node,
+			depth,
+			isLast,
+			ancestorHasNext,
+		});
+		result.push(
+			...flattenDisplayTree(node.children, depth + 1, [
+				...ancestorHasNext,
+				!isLast,
+			]),
+		);
+	});
 
-  return result;
+	return result;
 }
 
-function shouldIncludeEntry(entry: SessionEntry, mode: TreeFilterMode): boolean {
-  if (mode === "user-only") {
-    return entry.type === "message" && entry.message.role === "user";
-  }
+function shouldIncludeEntry(
+	entry: SessionEntry,
+	mode: TreeFilterMode,
+): boolean {
+	if (mode === "user-only") {
+		return entry.type === "message" && entry.message.role === "user";
+	}
 
-  return true;
+	return true;
 }
 
 function buildTreePages(
-  flattened: FlatDisplayNode[],
-  leafId: string | null,
-  mode: TreeFilterMode,
-  pageEntryLimit: number,
+	flattened: FlatDisplayNode[],
+	leafId: string | null,
+	mode: TreeFilterMode,
+	pageEntryLimit: number,
 ): TreePage[] {
-  const pages: TreePage[] = [];
-  let currentNodes: FlatDisplayNode[] = [];
-  let currentStartIndex = 0;
-  let currentNavButtonCount = 0;
+	const pages: TreePage[] = [];
+	let currentNodes: FlatDisplayNode[] = [];
+	let currentStartIndex = 0;
+	let currentNavButtonCount = 0;
 
-  flattened.forEach((flatNode, index) => {
-    const nextButtonCount = getNavButton(flatNode.node, leafId, mode) ? 1 : 0;
-    const wouldOverflowEntryLimit = currentNodes.length >= pageEntryLimit;
-    const wouldOverflowButtonLimit = currentNodes.length > 0
-      && currentNavButtonCount + nextButtonCount > TREE_BUTTON_PAGE_LIMIT;
+	flattened.forEach((flatNode, index) => {
+		const nextButtonCount = getNavButton(flatNode.node, leafId, mode) ? 1 : 0;
+		const wouldOverflowEntryLimit = currentNodes.length >= pageEntryLimit;
+		const wouldOverflowButtonLimit =
+			currentNodes.length > 0 &&
+			currentNavButtonCount + nextButtonCount > TREE_BUTTON_PAGE_LIMIT;
 
-    if (currentNodes.length > 0 && (wouldOverflowEntryLimit || wouldOverflowButtonLimit)) {
-      pages.push({
-        nodes: currentNodes,
-        startIndex: currentStartIndex,
-        endIndex: index - 1,
-      });
-      currentNodes = [];
-      currentStartIndex = index;
-      currentNavButtonCount = 0;
-    }
+		if (
+			currentNodes.length > 0 &&
+			(wouldOverflowEntryLimit || wouldOverflowButtonLimit)
+		) {
+			pages.push({
+				nodes: currentNodes,
+				startIndex: currentStartIndex,
+				endIndex: index - 1,
+			});
+			currentNodes = [];
+			currentStartIndex = index;
+			currentNavButtonCount = 0;
+		}
 
-    currentNodes.push(flatNode);
-    currentNavButtonCount += nextButtonCount;
-  });
+		currentNodes.push(flatNode);
+		currentNavButtonCount += nextButtonCount;
+	});
 
-  if (currentNodes.length > 0) {
-    pages.push({
-      nodes: currentNodes,
-      startIndex: currentStartIndex,
-      endIndex: flattened.length - 1,
-    });
-  }
+	if (currentNodes.length > 0) {
+		pages.push({
+			nodes: currentNodes,
+			startIndex: currentStartIndex,
+			endIndex: flattened.length - 1,
+		});
+	}
 
-  return pages.length > 0 ? pages : [{ nodes: [], startIndex: 0, endIndex: 0 }];
+	return pages.length > 0 ? pages : [{ nodes: [], startIndex: 0, endIndex: 0 }];
 }
 
 function getFocusIndex(
-  tree: SessionTreeNodeLike[],
-  flattened: FlatDisplayNode[],
-  leafId: string | null,
+	tree: SessionTreeNodeLike[],
+	flattened: FlatDisplayNode[],
+	leafId: string | null,
 ): number {
-  if (flattened.length === 0) {
-    return 0;
-  }
+	if (flattened.length === 0) {
+		return 0;
+	}
 
-  if (!leafId) {
-    return flattened.length - 1;
-  }
+	if (!leafId) {
+		return flattened.length - 1;
+	}
 
-  const exactIndex = flattened.findIndex((flatNode) => flatNode.node.entry.id === leafId);
-  if (exactIndex >= 0) {
-    return exactIndex;
-  }
+	const exactIndex = flattened.findIndex(
+		(flatNode) => flatNode.node.entry.id === leafId,
+	);
+	if (exactIndex >= 0) {
+		return exactIndex;
+	}
 
-  const ancestorIds = collectAncestorIds(tree, leafId);
-  for (let index = flattened.length - 1; index >= 0; index -= 1) {
-    if (ancestorIds.has(flattened[index]!.node.entry.id)) {
-      return index;
-    }
-  }
+	const ancestorIds = collectAncestorIds(tree, leafId);
+	for (let index = flattened.length - 1; index >= 0; index -= 1) {
+		if (ancestorIds.has(flattened[index]!.node.entry.id)) {
+			return index;
+		}
+	}
 
-  return flattened.length - 1;
+	return flattened.length - 1;
 }
 
-function collectAncestorIds(tree: SessionTreeNodeLike[], leafId: string): Set<string> {
-  const parentById = new Map<string, string | null>();
+function collectAncestorIds(
+	tree: SessionTreeNodeLike[],
+	leafId: string,
+): Set<string> {
+	const parentById = new Map<string, string | null>();
 
-  const walk = (node: SessionTreeNodeLike): void => {
-    parentById.set(node.entry.id, node.entry.parentId ?? null);
-    for (const child of node.children) {
-      walk(child);
-    }
-  };
+	const walk = (node: SessionTreeNodeLike): void => {
+		parentById.set(node.entry.id, node.entry.parentId ?? null);
+		for (const child of node.children) {
+			walk(child);
+		}
+	};
 
-  for (const root of tree) {
-    walk(root);
-  }
+	for (const root of tree) {
+		walk(root);
+	}
 
-  const result = new Set<string>();
-  const visited = new Set<string>();
-  let currentId: string | null = leafId;
-  while (currentId && !visited.has(currentId)) {
-    visited.add(currentId);
-    result.add(currentId);
-    currentId = parentById.get(currentId) ?? null;
-  }
+	const result = new Set<string>();
+	const visited = new Set<string>();
+	let currentId: string | null = leafId;
+	while (currentId && !visited.has(currentId)) {
+		visited.add(currentId);
+		result.add(currentId);
+		currentId = parentById.get(currentId) ?? null;
+	}
 
-  return result;
+	return result;
 }
 
 function getPageIndexForEntry(pages: TreePage[], entryIndex: number): number {
-  const safeEntryIndex = Math.max(0, entryIndex);
-  const pageIndex = pages.findIndex((page) => safeEntryIndex >= page.startIndex && safeEntryIndex <= page.endIndex);
-  return pageIndex >= 0 ? pageIndex : 0;
+	const safeEntryIndex = Math.max(0, entryIndex);
+	const pageIndex = pages.findIndex(
+		(page) =>
+			safeEntryIndex >= page.startIndex && safeEntryIndex <= page.endIndex,
+	);
+	return pageIndex >= 0 ? pageIndex : 0;
 }
 
 function clampPage(page: number, totalPages: number): number {
-  if (totalPages <= 0) {
-    return 0;
-  }
+	if (totalPages <= 0) {
+		return 0;
+	}
 
-  return Math.max(0, Math.min(page, totalPages - 1));
+	return Math.max(0, Math.min(page, totalPages - 1));
 }
 
-function renderTreeLine(flatNode: FlatDisplayNode, leafId: string | null, baseDepth = 0): string {
-  const { node, depth, isLast, ancestorHasNext } = flatNode;
-  const relativeDepth = Math.max(0, depth - baseDepth);
-  const visibleAncestors = relativeDepth > 0 ? ancestorHasNext.slice(-relativeDepth) : [];
-  const hiddenPrefix = baseDepth > 0 && relativeDepth === 0 ? "… " : "";
-  const indent = visibleAncestors.map((hasNext) => (hasNext ? "│  " : "   ")).join("");
-  const connector = relativeDepth === 0 ? "" : isLast ? "└─ " : "├─ ";
-  const shortId = node.entry.id.slice(0, 4);
-  const label = node.label ? ` [${node.label}]` : "";
-  const active = node.entry.id === leafId ? " ← active" : "";
-  return `${hiddenPrefix}${indent}${connector}${shortId} ${describeEntry(node.entry)}${label}${active}`;
+function renderTreeLine(
+	flatNode: FlatDisplayNode,
+	leafId: string | null,
+	baseDepth = 0,
+): string {
+	const { node, depth, isLast, ancestorHasNext } = flatNode;
+	const relativeDepth = Math.max(0, depth - baseDepth);
+	const visibleAncestors =
+		relativeDepth > 0 ? ancestorHasNext.slice(-relativeDepth) : [];
+	const hiddenPrefix = baseDepth > 0 && relativeDepth === 0 ? "… " : "";
+	const indent = visibleAncestors
+		.map((hasNext) => (hasNext ? "│  " : "   "))
+		.join("");
+	const connector = relativeDepth === 0 ? "" : isLast ? "└─ " : "├─ ";
+	const shortId = node.entry.id.slice(0, 4);
+	const label = node.label ? ` [${node.label}]` : "";
+	const active = node.entry.id === leafId ? " ← active" : "";
+	return `${hiddenPrefix}${indent}${connector}${shortId} ${describeEntry(node.entry)}${label}${active}`;
 }
 
 function buildTreeHtml(
-  lines: string[],
-  details: {
-    totalEntries: number;
-    shownEntries: number;
-    page: number;
-    totalPages: number;
-    rangeStart: number;
-    rangeEnd: number;
-    mode: TreeFilterMode;
-    focusPage: number;
-    showFocusNote: boolean;
-  },
+	lines: string[],
+	details: {
+		totalEntries: number;
+		shownEntries: number;
+		page: number;
+		totalPages: number;
+		rangeStart: number;
+		rangeEnd: number;
+		mode: TreeFilterMode;
+		focusPage: number;
+		showFocusNote: boolean;
+	},
 ): string {
-  const notes: string[] = [];
-  const pageLabel = `Page ${details.page + 1}/${Math.max(details.totalPages, 1)}`;
+	const notes: string[] = [];
+	const pageLabel = `Page ${details.page + 1}/${Math.max(details.totalPages, 1)}`;
 
-  if (details.totalEntries === 0) {
-    notes.push(`${pageLabel} · no matching entries.`);
-  } else {
-    notes.push(`${pageLabel} · entries ${details.rangeStart}-${details.rangeEnd} of ${details.totalEntries}.`);
-  }
+	if (details.totalEntries === 0) {
+		notes.push(`${pageLabel} · no matching entries.`);
+	} else {
+		notes.push(
+			`${pageLabel} · entries ${details.rangeStart}-${details.rangeEnd} of ${details.totalEntries}.`,
+		);
+	}
 
-  if (details.mode === "default") {
-    if (details.showFocusNote && details.page === details.focusPage) {
-      notes.push("Current branch context.");
-    } else if (details.showFocusNote) {
-      notes.push(`Current branch page: ${details.focusPage + 1}/${Math.max(details.totalPages, 1)}.`);
-    }
-  } else if (details.mode === "user-only") {
-    notes.push("Filter: user messages only.");
-  } else if (details.mode === "all-with-buttons") {
-    notes.push("Filter: all entries with navigation buttons.");
-  }
+	if (details.mode === "default") {
+		if (details.showFocusNote && details.page === details.focusPage) {
+			notes.push("Current branch context.");
+		} else if (details.showFocusNote) {
+			notes.push(
+				`Current branch page: ${details.focusPage + 1}/${Math.max(details.totalPages, 1)}.`,
+			);
+		}
+	} else if (details.mode === "user-only") {
+		notes.push("Filter: user messages only.");
+	} else if (details.mode === "all-with-buttons") {
+		notes.push("Filter: all entries with navigation buttons.");
+	}
 
-  const notesHtml = `<i>${escapeHTML(notes.join(" "))}</i>`;
-  const renderHtml = (renderedLines: string[]): string => [wrapTreeText(renderedLines.join("\n")), notesHtml].join("\n");
+	const notesHtml = `<i>${escapeHTML(notes.join(" "))}</i>`;
+	const renderHtml = (renderedLines: string[]): string =>
+		[wrapTreeText(renderedLines.join("\n")), notesHtml].join("\n");
 
-  const html = renderHtml(lines);
-  if (html.length <= TELEGRAM_TREE_TEXT_LIMIT) {
-    return html;
-  }
+	const html = renderHtml(lines);
+	if (html.length <= TELEGRAM_TREE_TEXT_LIMIT) {
+		return html;
+	}
 
-  for (const width of [220, 160, 120, 90, 60, 40]) {
-    const compactHtml = renderHtml(lines.map((line) => truncateText(line, width)));
-    if (compactHtml.length <= TELEGRAM_TREE_TEXT_LIMIT) {
-      return compactHtml;
-    }
-  }
+	for (const width of [220, 160, 120, 90, 60, 40]) {
+		const compactHtml = renderHtml(
+			lines.map((line) => truncateText(line, width)),
+		);
+		if (compactHtml.length <= TELEGRAM_TREE_TEXT_LIMIT) {
+			return compactHtml;
+		}
+	}
 
-  let emergencyBudget = TELEGRAM_TREE_TEXT_LIMIT - notesHtml.length - 16;
-  while (emergencyBudget > 40) {
-    const emergencyHtml = renderHtml([truncateText(lines.join("\n"), emergencyBudget)]);
-    if (emergencyHtml.length <= TELEGRAM_TREE_TEXT_LIMIT) {
-      return emergencyHtml;
-    }
-    emergencyBudget -= 50;
-  }
+	let emergencyBudget = TELEGRAM_TREE_TEXT_LIMIT - notesHtml.length - 16;
+	while (emergencyBudget > 40) {
+		const emergencyHtml = renderHtml([
+			truncateText(lines.join("\n"), emergencyBudget),
+		]);
+		if (emergencyHtml.length <= TELEGRAM_TREE_TEXT_LIMIT) {
+			return emergencyHtml;
+		}
+		emergencyBudget -= 50;
+	}
 
-  return renderHtml([truncateText(lines.join("\n"), 40)]);
+	return renderHtml([truncateText(lines.join("\n"), 40)]);
 }
 
 function buildTreeButtons(
-  flattened: FlatDisplayNode[],
-  visibleNodes: FlatDisplayNode[],
-  leafId: string | null,
-  mode: TreeFilterMode,
-  page: number,
-  totalPages: number,
-  focusIndex: number,
+	flattened: FlatDisplayNode[],
+	visibleNodes: FlatDisplayNode[],
+	leafId: string | null,
+	mode: TreeFilterMode,
+	page: number,
+	totalPages: number,
+	focusIndex: number,
 ): TreeButton[] {
-  const buttons: TreeButton[] = [];
-  const seenIds = new Set<string>();
+	const buttons: TreeButton[] = [];
+	const seenIds = new Set<string>();
 
-  const pushNavButton = (flatNode: FlatDisplayNode): void => {
-    const button = getNavButton(flatNode.node, leafId, mode);
-    if (!button || seenIds.has(flatNode.node.entry.id)) {
-      return;
-    }
+	const pushNavButton = (flatNode: FlatDisplayNode): void => {
+		const button = getNavButton(flatNode.node, leafId, mode);
+		if (!button || seenIds.has(flatNode.node.entry.id)) {
+			return;
+		}
 
-    buttons.push(button);
-    seenIds.add(flatNode.node.entry.id);
-  };
+		buttons.push(button);
+		seenIds.add(flatNode.node.entry.id);
+	};
 
-  for (const flatNode of visibleNodes) {
-    pushNavButton(flatNode);
-  }
+	for (const flatNode of visibleNodes) {
+		pushNavButton(flatNode);
+	}
 
-  if (mode === "default" && buttons.length === 0) {
-    const fallbackCandidates = flattened
-      .map((flatNode, index) => ({ flatNode, index }))
-      .filter(({ flatNode }) => getNavButton(flatNode.node, leafId, mode) !== undefined)
-      .sort((left, right) => {
-        const leftDistance = Math.abs(left.index - focusIndex);
-        const rightDistance = Math.abs(right.index - focusIndex);
-        if (leftDistance !== rightDistance) {
-          return leftDistance - rightDistance;
-        }
-        return left.index - right.index;
-      });
+	if (mode === "default" && buttons.length === 0) {
+		const fallbackCandidates = flattened
+			.map((flatNode, index) => ({ flatNode, index }))
+			.filter(
+				({ flatNode }) =>
+					getNavButton(flatNode.node, leafId, mode) !== undefined,
+			)
+			.sort((left, right) => {
+				const leftDistance = Math.abs(left.index - focusIndex);
+				const rightDistance = Math.abs(right.index - focusIndex);
+				if (leftDistance !== rightDistance) {
+					return leftDistance - rightDistance;
+				}
+				return left.index - right.index;
+			});
 
-    for (const candidate of fallbackCandidates) {
-      if (buttons.length >= TREE_BUTTON_PAGE_LIMIT) {
-        break;
-      }
-      pushNavButton(candidate.flatNode);
-    }
-  }
+		for (const candidate of fallbackCandidates) {
+			if (buttons.length >= TREE_BUTTON_PAGE_LIMIT) {
+				break;
+			}
+			pushNavButton(candidate.flatNode);
+		}
+	}
 
-  if (totalPages > 1) {
-    if (page > 0) {
-      buttons.push({ label: "◀️ Prev", callbackData: `tree_page_${page - 1}` });
-    }
-    buttons.push({ label: `${page + 1}/${totalPages}`, callbackData: NOOP_PAGE_CALLBACK_DATA });
-    if (page < totalPages - 1) {
-      buttons.push({ label: "Next ▶️", callbackData: `tree_page_${page + 1}` });
-    }
-  }
+	if (totalPages > 1) {
+		if (page > 0) {
+			buttons.push({ label: "◀️ Prev", callbackData: `tree_page_${page - 1}` });
+		}
+		buttons.push({
+			label: `${page + 1}/${totalPages}`,
+			callbackData: NOOP_PAGE_CALLBACK_DATA,
+		});
+		if (page < totalPages - 1) {
+			buttons.push({ label: "Next ▶️", callbackData: `tree_page_${page + 1}` });
+		}
+	}
 
-  buttons.push(...buildFilterButtons(mode));
-  return buttons;
+	buttons.push(...buildFilterButtons(mode));
+	return buttons;
 }
 
-function getNavButton(node: SessionTreeNodeLike, leafId: string | null, mode: TreeFilterMode): TreeButton | undefined {
-  const shortId = node.entry.id.slice(0, 4);
-  const description = truncateText(cleanTextForButton(describeEntry(node.entry)), BUTTON_LABEL_DESCRIPTION_LIMIT);
+function getNavButton(
+	node: SessionTreeNodeLike,
+	leafId: string | null,
+	mode: TreeFilterMode,
+): TreeButton | undefined {
+	const shortId = node.entry.id.slice(0, 4);
+	const description = truncateText(
+		cleanTextForButton(describeEntry(node.entry)),
+		BUTTON_LABEL_DESCRIPTION_LIMIT,
+	);
 
-  if (mode === "all-with-buttons") {
-    return {
-      label: `🔀 ${shortId} · ${description}`,
-      callbackData: `tree_nav_${node.entry.id}`,
-    };
-  }
+	if (mode === "all-with-buttons") {
+		return {
+			label: `🔀 ${shortId} · ${description}`,
+			callbackData: `tree_nav_${node.entry.id}`,
+		};
+	}
 
-  if (mode === "user-only") {
-    return {
-      label: `👤 ${shortId} · ${description}`,
-      callbackData: `tree_nav_${node.entry.id}`,
-    };
-  }
+	if (mode === "user-only") {
+		return {
+			label: `👤 ${shortId} · ${description}`,
+			callbackData: `tree_nav_${node.entry.id}`,
+		};
+	}
 
-  if (node.children.length >= 2) {
-    return {
-      label: `🔀 ${shortId} · ${description}`,
-      callbackData: `tree_nav_${node.entry.id}`,
-    };
-  }
+	if (node.children.length >= 2) {
+		return {
+			label: `🔀 ${shortId} · ${description}`,
+			callbackData: `tree_nav_${node.entry.id}`,
+		};
+	}
 
-  if (node.label) {
-    return {
-      label: `🏷️ ${shortId} · ${truncateText(node.label, 14)}`,
-      callbackData: `tree_nav_${node.entry.id}`,
-    };
-  }
+	if (node.label) {
+		return {
+			label: `🏷️ ${shortId} · ${truncateText(node.label, 14)}`,
+			callbackData: `tree_nav_${node.entry.id}`,
+		};
+	}
 
-  if (node.children.length === 0 && node.entry.id !== leafId) {
-    return {
-      label: `🌿 ${shortId} · ${description}`,
-      callbackData: `tree_nav_${node.entry.id}`,
-    };
-  }
+	if (node.children.length === 0 && node.entry.id !== leafId) {
+		return {
+			label: `🌿 ${shortId} · ${description}`,
+			callbackData: `tree_nav_${node.entry.id}`,
+		};
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function buildFilterButtons(mode: TreeFilterMode): TreeButton[] {
-  const buttons: TreeButton[] = [];
+	const buttons: TreeButton[] = [];
 
-  if (mode !== "default") {
-    buttons.push({ label: "🌲 Default", callbackData: "tree_mode_default" });
-  }
+	if (mode !== "default") {
+		buttons.push({ label: "🌲 Default", callbackData: "tree_mode_default" });
+	}
 
-  if (mode !== "all-with-buttons") {
-    buttons.push({ label: "📄 All", callbackData: "tree_mode_all" });
-  }
+	if (mode !== "all-with-buttons") {
+		buttons.push({ label: "📄 All", callbackData: "tree_mode_all" });
+	}
 
-  if (mode !== "user-only") {
-    buttons.push({ label: "👤 User", callbackData: "tree_mode_user" });
-  }
+	if (mode !== "user-only") {
+		buttons.push({ label: "👤 User", callbackData: "tree_mode_user" });
+	}
 
-  return buttons;
+	return buttons;
 }
 
 function wrapTreeText(text: string): string {
-  return `<pre>${escapeHTML(text)}</pre>`;
+	return `<pre>${escapeHTML(text)}</pre>`;
 }
 
 function renderEntryRef(id: string): string {
-  return `<code>${escapeHTML(id.slice(0, 4))}</code>`;
+	return `<code>${escapeHTML(id.slice(0, 4))}</code>`;
 }
 
 function extractTextContent(content: unknown): string {
-  if (typeof content === "string") {
-    return normalizeWhitespace(content);
-  }
+	if (typeof content === "string") {
+		return normalizeWhitespace(content);
+	}
 
-  if (!Array.isArray(content)) {
-    return "";
-  }
+	if (!Array.isArray(content)) {
+		return "";
+	}
 
-  const text = content
-    .filter((item) => typeof item === "object" && item !== null && "type" in item && item.type === "text")
-    .map((item) => String((item as { text?: unknown }).text ?? ""))
-    .join(" ");
+	const text = content
+		.filter(
+			(item) =>
+				typeof item === "object" &&
+				item !== null &&
+				"type" in item &&
+				item.type === "text",
+		)
+		.map((item) => String((item as { text?: unknown }).text ?? ""))
+		.join(" ");
 
-  return normalizeWhitespace(text);
+	return normalizeWhitespace(text);
 }
 
 function extractToolCallName(content: unknown): string | undefined {
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
+	if (!Array.isArray(content)) {
+		return undefined;
+	}
 
-  for (const item of content) {
-    if (typeof item !== "object" || item === null || !("type" in item)) {
-      continue;
-    }
+	for (const item of content) {
+		if (typeof item !== "object" || item === null || !("type" in item)) {
+			continue;
+		}
 
-    if (item.type !== "toolCall") {
-      continue;
-    }
+		if (item.type !== "toolCall") {
+			continue;
+		}
 
-    const maybeName = (item as { name?: unknown }).name;
-    if (typeof maybeName === "string" && maybeName.trim()) {
-      return maybeName.trim();
-    }
-  }
+		const maybeName = (item as { name?: unknown }).name;
+		if (typeof maybeName === "string" && maybeName.trim()) {
+			return maybeName.trim();
+		}
+	}
 
-  return undefined;
+	return undefined;
 }
 
 function formatQuotedText(text: string): string {
-  return `"${truncateText(text || "", ENTRY_DESCRIPTION_LIMIT)}"`;
+	return `"${truncateText(text || "", ENTRY_DESCRIPTION_LIMIT)}"`;
 }
 
 function normalizeWhitespace(text: string): string {
-  return text.replace(/\s+/g, " ").trim();
+	return text.replace(/\s+/g, " ").trim();
 }
 
 function cleanTextForButton(text: string): string {
-  return text.replace(/[\[\]"]+/g, "").replace(/\s+/g, " ").trim();
+	return text
+		.replace(/[[\]"]+/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
 }

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -5,56 +5,58 @@ import path from "node:path";
 import { vi } from "vitest";
 
 vi.mock("@grammyjs/auto-retry", () => ({
-  autoRetry: () => (prev: any, method: string, payload: any, signal: any) =>
-    prev(method, payload, signal),
+	autoRetry: () => (prev: any, method: string, payload: any, signal: any) =>
+		prev(method, payload, signal),
 }));
 
 vi.mock("node:child_process", () => ({
-  spawnSync: vi.fn().mockReturnValue({ status: 0 }),
+	spawnSync: vi.fn().mockReturnValue({ status: 0 }),
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return {
-    ...actual,
-    readFile: vi.fn().mockResolvedValue(Buffer.from("image-bytes")),
-    writeFile: vi.fn().mockResolvedValue(undefined),
-    unlink: vi.fn().mockResolvedValue(undefined),
-  };
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		readFile: vi.fn().mockResolvedValue(Buffer.from("image-bytes")),
+		writeFile: vi.fn().mockResolvedValue(undefined),
+		unlink: vi.fn().mockResolvedValue(undefined),
+	};
 });
 
 vi.mock("../src/voice.js", () => ({
-  transcribeAudio: vi.fn().mockResolvedValue({
-    text: "transcribed text",
-    backend: "openai",
-    durationMs: 500,
-  }),
-  getAvailableBackends: vi.fn().mockResolvedValue(["openai"]),
-  getVoiceBackendStatus: vi.fn().mockResolvedValue({ backends: ["openai"], warning: undefined }),
-  _setImportHook: vi.fn(),
-  _resetImportHook: vi.fn(),
+	transcribeAudio: vi.fn().mockResolvedValue({
+		text: "transcribed text",
+		backend: "openai",
+		durationMs: 500,
+	}),
+	getAvailableBackends: vi.fn().mockResolvedValue(["openai"]),
+	getVoiceBackendStatus: vi
+		.fn()
+		.mockResolvedValue({ backends: ["openai"], warning: undefined }),
+	_setImportHook: vi.fn(),
+	_resetImportHook: vi.fn(),
 }));
 
 vi.mock("../src/bot/prompt-inbox.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/bot/prompt-inbox.js")>();
-  return {
-    ...actual,
-    startPromptInboxPolling: vi.fn(),
-  };
+	const actual =
+		await importOriginal<typeof import("../src/bot/prompt-inbox.js")>();
+	return {
+		...actual,
+		startPromptInboxPolling: vi.fn(),
+	};
 });
 
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
-
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
+import { startPromptInboxPolling } from "../src/bot/prompt-inbox.js";
+import { createBot, registerCommands } from "../src/bot.js";
 import type { TelePiConfig } from "../src/config.js";
 import type {
-  PiSessionCallbacks,
-  PiSessionContext,
-  PiSessionInfo,
-  PiSessionRegistry,
-  PiSessionService,
+	PiSessionCallbacks,
+	PiSessionContext,
+	PiSessionInfo,
+	PiSessionRegistry,
+	PiSessionService,
 } from "../src/pi-session.js";
-import { createBot, registerCommands } from "../src/bot.js";
-import { startPromptInboxPolling } from "../src/bot/prompt-inbox.js";
 import { getAvailableBackends, transcribeAudio } from "../src/voice.js";
 
 type SwitchResult = Awaited<ReturnType<PiSessionService["switchSession"]>>;
@@ -63,3851 +65,5132 @@ const ALLOWED_USER_ID = 123;
 const ALLOWED_CHAT_ID = 456;
 
 function makeTreeNode(
-  entry: Record<string, any>,
-  children: any[] = [],
-  label?: string,
+	entry: Record<string, any>,
+	children: any[] = [],
+	label?: string,
 ): { entry: Record<string, any>; children: any[]; label?: string } {
-  return { entry, children, label };
+	return { entry, children, label };
 }
 
 function makeMessageTreeNode(
-  id: string,
-  role: string,
-  content: string,
-  parentId: string | null = null,
-  children: any[] = [],
-  label?: string,
+	id: string,
+	role: string,
+	content: string,
+	parentId: string | null = null,
+	children: any[] = [],
+	label?: string,
 ): { entry: Record<string, any>; children: any[]; label?: string } {
-  return makeTreeNode(
-    {
-      type: "message",
-      id,
-      parentId,
-      timestamp: "2025-01-01T00:00:00Z",
-      message: { role, content },
-    },
-    children,
-    label,
-  );
+	return makeTreeNode(
+		{
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2025-01-01T00:00:00Z",
+			message: { role, content },
+		},
+		children,
+		label,
+	);
 }
 
 type SetupOptions = {
-  configOverrides?: Partial<TelePiConfig>;
-  piSessionOverrides?: Partial<PiSessionService>;
-  perContextSessionOverrides?: Record<string, Partial<PiSessionService>>;
+	configOverrides?: Partial<TelePiConfig>;
+	piSessionOverrides?: Partial<PiSessionService>;
+	perContextSessionOverrides?: Record<string, Partial<PiSessionService>>;
 };
 
 function createConfig(overrides: Partial<TelePiConfig> = {}): TelePiConfig {
-  return {
-    telegramBotToken: "bot-token",
-    telegramAllowedUserIds: [ALLOWED_USER_ID],
-    telegramAllowedUserIdSet: new Set([ALLOWED_USER_ID]),
-    workspace: "/workspace",
-    piSessionPath: undefined,
-    piModel: undefined,
-    toolVerbosity: "summary",
-    promptInboxDir: undefined,
-    promptInboxIntervalMs: 60000,
-    ...overrides,
-  };
+	return {
+		telegramBotToken: "bot-token",
+		telegramAllowedUserIds: [ALLOWED_USER_ID],
+		telegramAllowedUserIdSet: new Set([ALLOWED_USER_ID]),
+		workspace: "/workspace",
+		piSessionPath: undefined,
+		piModel: undefined,
+		toolVerbosity: "summary",
+		promptInboxDir: undefined,
+		promptInboxIntervalMs: 60000,
+		...overrides,
+	};
 }
 
-function makeContextKey(chatId: number | string = ALLOWED_CHAT_ID, messageThreadId?: number): string {
-  return `${String(chatId)}::${messageThreadId ?? "root"}`;
+function makeContextKey(
+	chatId: number | string = ALLOWED_CHAT_ID,
+	messageThreadId?: number,
+): string {
+	return `${String(chatId)}::${messageThreadId ?? "root"}`;
 }
 
-function makeSlashCommand(name: string, overrides: Record<string, any> = {}): Record<string, any> {
-  return {
-    name,
-    description: `${name} command`,
-    source: "extension",
-    sourceInfo: {
-      source: "extension",
-      scope: "project",
-      path: `/ext/${name}.ts`,
-    },
-    ...overrides,
-  };
+function makeSlashCommand(
+	name: string,
+	overrides: Record<string, any> = {},
+): Record<string, any> {
+	return {
+		name,
+		description: `${name} command`,
+		source: "extension",
+		sourceInfo: {
+			source: "extension",
+			scope: "project",
+			path: `/ext/${name}.ts`,
+		},
+		...overrides,
+	};
 }
 
 function makeTelepiBareNativeMenuSlashCommand(
-  name: string,
-  entries: Array<{ id: string; label: string; commandText: string }>,
-  overrides: Record<string, any> = {},
+	name: string,
+	entries: Array<{ id: string; label: string; commandText: string }>,
+	overrides: Record<string, any> = {},
 ): Record<string, any> {
-  return makeSlashCommand(name, {
-    integrations: {
-      telepi: {
-        bare: {
-          kind: "native-menu",
-          entries,
-        },
-      },
-    },
-    ...overrides,
-  });
+	return makeSlashCommand(name, {
+		integrations: {
+			telepi: {
+				bare: {
+					kind: "native-menu",
+					entries,
+				},
+			},
+		},
+		...overrides,
+	});
 }
 
 async function loadPiCronSlashCommands(): Promise<SlashCommandInfo[]> {
-  const piCronExtensionPath = path.resolve(process.cwd(), "../../PiCron/src/extension/index.ts");
-  if (!existsSync(piCronExtensionPath)) {
-    return [
-      makeTelepiBareNativeMenuSlashCommand("cron", [
-        { id: "picron.cron.list", label: "List schedules", commandText: "/cron list" },
-        { id: "picron.cron.status", label: "Show status", commandText: "/cron status" },
-        { id: "picron.cron.add", label: "Add schedule", commandText: "/cron add" },
-        { id: "picron.cron.manage", label: "Manage schedules", commandText: "/cron manage" },
-      ], { description: "Manage PiCron schedules" }) as SlashCommandInfo,
-    ];
-  }
+	const piCronExtensionPath = path.resolve(
+		process.cwd(),
+		"../../PiCron/src/extension/index.ts",
+	);
+	if (!existsSync(piCronExtensionPath)) {
+		return [
+			makeTelepiBareNativeMenuSlashCommand(
+				"cron",
+				[
+					{
+						id: "picron.cron.list",
+						label: "List schedules",
+						commandText: "/cron list",
+					},
+					{
+						id: "picron.cron.status",
+						label: "Show status",
+						commandText: "/cron status",
+					},
+					{
+						id: "picron.cron.add",
+						label: "Add schedule",
+						commandText: "/cron add",
+					},
+					{
+						id: "picron.cron.manage",
+						label: "Manage schedules",
+						commandText: "/cron manage",
+					},
+				],
+				{ description: "Manage PiCron schedules" },
+			) as SlashCommandInfo,
+		];
+	}
 
-  const { default: piCronExtension } = await import(piCronExtensionPath);
-  const slashCommands: SlashCommandInfo[] = [];
+	const { default: piCronExtension } = await import(piCronExtensionPath);
+	const slashCommands: SlashCommandInfo[] = [];
 
-  piCronExtension({
-    registerCommand: (name: string, options: Record<string, any>) => {
-      slashCommands.push({
-        name,
-        description: options.description,
-        integrations: options.integrations,
-        source: "extension",
-        sourceInfo: {
-          source: "extension",
-          scope: "project",
-          path: "../../PiCron/src/extension/index.ts",
-        } as any,
-      });
-    },
-  } as any);
+	piCronExtension({
+		registerCommand: (name: string, options: Record<string, any>) => {
+			slashCommands.push({
+				name,
+				description: options.description,
+				integrations: options.integrations,
+				source: "extension",
+				sourceInfo: {
+					source: "extension",
+					scope: "project",
+					path: "../../PiCron/src/extension/index.ts",
+				} as any,
+			});
+		},
+	} as any);
 
-  return slashCommands;
+	return slashCommands;
 }
 
 function createMockPiSession(overrides: Partial<PiSessionService> = {}) {
-  let callbacks: PiSessionCallbacks | undefined;
-  let extensionBindings: any;
+	let callbacks: PiSessionCallbacks | undefined;
+	let extensionBindings: any;
 
-  const defaultInfo: PiSessionInfo = {
-    sessionId: "test-id",
-    sessionFile: "/tmp/test.jsonl",
-    workspace: "/workspace",
-    model: "anthropic/claude-sonnet-4-5",
-    sessionName: undefined,
-    modelFallbackMessage: undefined,
-  };
+	const defaultInfo: PiSessionInfo = {
+		sessionId: "test-id",
+		sessionFile: "/tmp/test.jsonl",
+		workspace: "/workspace",
+		model: "anthropic/claude-sonnet-4-5",
+		sessionName: undefined,
+		modelFallbackMessage: undefined,
+	};
 
-  const defaultTree = [
-    makeMessageTreeNode(
-      "root1234",
-      "user",
-      "Start",
-      null,
-      [
-        makeMessageTreeNode(
-          "branch111",
-          "assistant",
-          "Pick a branch",
-          "root1234",
-          [
-            makeMessageTreeNode("leaf1234", "user", "Active leaf", "branch111"),
-            makeMessageTreeNode("leaf5678", "user", "Other leaf", "branch111", [], "saved"),
-          ],
-        ),
-      ],
-    ),
-  ];
+	const defaultTree = [
+		makeMessageTreeNode("root1234", "user", "Start", null, [
+			makeMessageTreeNode(
+				"branch111",
+				"assistant",
+				"Pick a branch",
+				"root1234",
+				[
+					makeMessageTreeNode("leaf1234", "user", "Active leaf", "branch111"),
+					makeMessageTreeNode(
+						"leaf5678",
+						"user",
+						"Other leaf",
+						"branch111",
+						[],
+						"saved",
+					),
+				],
+			),
+		]),
+	];
 
-  const session = {
-    getInfo: vi.fn().mockReturnValue(defaultInfo),
-    isStreaming: vi.fn().mockReturnValue(false),
-    hasActiveSession: vi.fn().mockReturnValue(true),
-    getCurrentWorkspace: vi.fn().mockReturnValue("/workspace"),
-    abort: vi.fn().mockResolvedValue(undefined),
-    newSession: vi.fn().mockResolvedValue({
-      info: {
-        sessionId: "new-id",
-        sessionFile: "/tmp/new.jsonl",
-        workspace: "/workspace",
-        model: "anthropic/claude-sonnet-4-5",
-      },
-      created: true,
-    }),
-    switchSession: vi.fn().mockResolvedValue({
-      sessionId: "switched-id",
-      sessionFile: "/tmp/switched.jsonl",
-      workspace: "/other",
-      model: "anthropic/claude-sonnet-4-5",
-      cancelled: false,
-    }),
-    handback: vi.fn().mockResolvedValue({
-      sessionFile: "/tmp/test.jsonl",
-      workspace: "/workspace",
-    }),
-    listAllSessions: vi.fn().mockResolvedValue([
-      {
-        id: "s1",
-        firstMessage: "Hello session",
-        path: "/s1.jsonl",
-        messageCount: 5,
-        cwd: "/workspace/A",
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-        name: undefined,
-      },
-      {
-        id: "s2",
-        firstMessage: "World session",
-        path: "/s2.jsonl",
-        messageCount: 3,
-        cwd: "/workspace/B",
-        modified: new Date("2025-01-01T00:00:00.000Z"),
-        name: undefined,
-      },
-    ]),
-    listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A", "/workspace/B"]),
-    listModels: vi.fn().mockResolvedValue([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-5",
-        name: "Claude Sonnet",
-        current: true,
-      },
-      {
-        provider: "openai",
-        id: "gpt-4o",
-        name: "GPT-4o",
-        current: false,
-      },
-    ]),
-    setModel: vi.fn().mockResolvedValue("openai/gpt-4o"),
-    getTree: vi.fn().mockReturnValue(defaultTree),
-    getLeafId: vi.fn().mockReturnValue("leaf1234"),
-    getEntry: vi.fn().mockImplementation((id: string) => {
-      const entries = [
-        defaultTree[0].entry,
-        defaultTree[0].children[0].entry,
-        defaultTree[0].children[0].children[0].entry,
-        defaultTree[0].children[0].children[1].entry,
-      ];
-      return entries.find((entry) => entry.id === id);
-    }),
-    getChildren: vi.fn().mockImplementation((id: string) => {
-      if (id === "branch111") {
-        return [defaultTree[0].children[0].children[0].entry, defaultTree[0].children[0].children[1].entry];
-      }
-      if (id === "root1234") {
-        return [defaultTree[0].children[0].entry];
-      }
-      return [];
-    }),
-    navigateTree: vi.fn().mockResolvedValue({ cancelled: false }),
-    setLabel: vi.fn(),
-    getLabels: vi.fn().mockReturnValue([{ id: "leaf5678", label: "saved", description: 'user: "Other leaf"' }]),
-    resolveSessionReference: vi.fn().mockImplementation(async (reference: string) => {
-      const sessions = await session.listAllSessions();
-      const pathMatch = sessions.find((savedSession: { path: string }) => savedSession.path === reference);
-      if (pathMatch) {
-        return {
-          id: pathMatch.id,
-          path: pathMatch.path,
-          cwd: pathMatch.cwd,
-          matchType: "path",
-        };
-      }
+	const session = {
+		getInfo: vi.fn().mockReturnValue(defaultInfo),
+		isStreaming: vi.fn().mockReturnValue(false),
+		hasActiveSession: vi.fn().mockReturnValue(true),
+		getCurrentWorkspace: vi.fn().mockReturnValue("/workspace"),
+		abort: vi.fn().mockResolvedValue(undefined),
+		newSession: vi.fn().mockResolvedValue({
+			info: {
+				sessionId: "new-id",
+				sessionFile: "/tmp/new.jsonl",
+				workspace: "/workspace",
+				model: "anthropic/claude-sonnet-4-5",
+			},
+			created: true,
+		}),
+		switchSession: vi.fn().mockResolvedValue({
+			sessionId: "switched-id",
+			sessionFile: "/tmp/switched.jsonl",
+			workspace: "/other",
+			model: "anthropic/claude-sonnet-4-5",
+			cancelled: false,
+		}),
+		handback: vi.fn().mockResolvedValue({
+			sessionFile: "/tmp/test.jsonl",
+			workspace: "/workspace",
+		}),
+		listAllSessions: vi.fn().mockResolvedValue([
+			{
+				id: "s1",
+				firstMessage: "Hello session",
+				path: "/s1.jsonl",
+				messageCount: 5,
+				cwd: "/workspace/A",
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+				name: undefined,
+			},
+			{
+				id: "s2",
+				firstMessage: "World session",
+				path: "/s2.jsonl",
+				messageCount: 3,
+				cwd: "/workspace/B",
+				modified: new Date("2025-01-01T00:00:00.000Z"),
+				name: undefined,
+			},
+		]),
+		listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A", "/workspace/B"]),
+		listModels: vi.fn().mockResolvedValue([
+			{
+				provider: "anthropic",
+				id: "claude-sonnet-4-5",
+				name: "Claude Sonnet",
+				current: true,
+			},
+			{
+				provider: "openai",
+				id: "gpt-4o",
+				name: "GPT-4o",
+				current: false,
+			},
+		]),
+		setModel: vi.fn().mockResolvedValue("openai/gpt-4o"),
+		getTree: vi.fn().mockReturnValue(defaultTree),
+		getLeafId: vi.fn().mockReturnValue("leaf1234"),
+		getEntry: vi.fn().mockImplementation((id: string) => {
+			const entries = [
+				defaultTree[0].entry,
+				defaultTree[0].children[0].entry,
+				defaultTree[0].children[0].children[0].entry,
+				defaultTree[0].children[0].children[1].entry,
+			];
+			return entries.find((entry) => entry.id === id);
+		}),
+		getChildren: vi.fn().mockImplementation((id: string) => {
+			if (id === "branch111") {
+				return [
+					defaultTree[0].children[0].children[0].entry,
+					defaultTree[0].children[0].children[1].entry,
+				];
+			}
+			if (id === "root1234") {
+				return [defaultTree[0].children[0].entry];
+			}
+			return [];
+		}),
+		navigateTree: vi.fn().mockResolvedValue({ cancelled: false }),
+		setLabel: vi.fn(),
+		getLabels: vi
+			.fn()
+			.mockReturnValue([
+				{ id: "leaf5678", label: "saved", description: 'user: "Other leaf"' },
+			]),
+		resolveSessionReference: vi
+			.fn()
+			.mockImplementation(async (reference: string) => {
+				const sessions = await session.listAllSessions();
+				const pathMatch = sessions.find(
+					(savedSession: { path: string }) => savedSession.path === reference,
+				);
+				if (pathMatch) {
+					return {
+						id: pathMatch.id,
+						path: pathMatch.path,
+						cwd: pathMatch.cwd,
+						matchType: "path",
+					};
+				}
 
-      const idMatch = sessions.find((savedSession: { id: string }) => savedSession.id === reference);
-      if (idMatch) {
-        return {
-          id: idMatch.id,
-          path: idMatch.path,
-          cwd: idMatch.cwd,
-          matchType: "id",
-        };
-      }
+				const idMatch = sessions.find(
+					(savedSession: { id: string }) => savedSession.id === reference,
+				);
+				if (idMatch) {
+					return {
+						id: idMatch.id,
+						path: idMatch.path,
+						cwd: idMatch.cwd,
+						matchType: "id",
+					};
+				}
 
-      return { id: "s1", path: reference, cwd: "/workspace/A", matchType: "path" };
-    }),
-    resolveWorkspaceForSession: vi.fn().mockResolvedValue("/workspace/A"),
-    listSlashCommands: vi.fn().mockResolvedValue([]),
-    bindExtensions: vi.fn().mockImplementation(async (bindings: any) => {
-      extensionBindings = bindings;
-    }),
-    prompt: vi.fn().mockResolvedValue(undefined),
-    getSession: vi.fn().mockReturnValue({
-      agent: { waitForIdle: vi.fn().mockResolvedValue(undefined) },
-    }),
-    fork: vi.fn().mockResolvedValue({ cancelled: false }),
-    reload: vi.fn().mockResolvedValue(undefined),
-    subscribe: vi.fn().mockImplementation((nextCallbacks: PiSessionCallbacks) => {
-      callbacks = nextCallbacks;
-      return () => {
-        if (callbacks === nextCallbacks) {
-          callbacks = undefined;
-        }
-      };
-    }),
-    dispose: vi.fn(),
-    getContextUsage: vi.fn().mockReturnValue({
-      tokens: 4500,
-      contextWindow: 128000,
-      percent: 3.52,
-    }),
-    getSessionStats: vi.fn().mockReturnValue({
-      userMessages: 5,
-      assistantMessages: 5,
-      toolCalls: 12,
-      toolResults: 12,
-      totalMessages: 20,
-      tokens: {
-        input: 40000,
-        output: 8000,
-        cacheRead: 2000,
-        cacheWrite: 1000,
-        total: 50000,
-      },
-      cost: 0.05,
-      contextUsage: {
-        tokens: 4500,
-        contextWindow: 128000,
-        percent: 3.52,
-      },
-      sessionFile: "/tmp/test.jsonl",
-      sessionId: "test-id",
-    }),
-  } satisfies Partial<PiSessionService>;
+				return {
+					id: "s1",
+					path: reference,
+					cwd: "/workspace/A",
+					matchType: "path",
+				};
+			}),
+		resolveWorkspaceForSession: vi.fn().mockResolvedValue("/workspace/A"),
+		listSlashCommands: vi.fn().mockResolvedValue([]),
+		bindExtensions: vi.fn().mockImplementation(async (bindings: any) => {
+			extensionBindings = bindings;
+		}),
+		prompt: vi.fn().mockResolvedValue(undefined),
+		getSession: vi.fn().mockReturnValue({
+			agent: { waitForIdle: vi.fn().mockResolvedValue(undefined) },
+		}),
+		fork: vi.fn().mockResolvedValue({ cancelled: false }),
+		reload: vi.fn().mockResolvedValue(undefined),
+		subscribe: vi
+			.fn()
+			.mockImplementation((nextCallbacks: PiSessionCallbacks) => {
+				callbacks = nextCallbacks;
+				return () => {
+					if (callbacks === nextCallbacks) {
+						callbacks = undefined;
+					}
+				};
+			}),
+		dispose: vi.fn(),
+		getContextUsage: vi.fn().mockReturnValue({
+			tokens: 4500,
+			contextWindow: 128000,
+			percent: 3.52,
+		}),
+		getSessionStats: vi.fn().mockReturnValue({
+			userMessages: 5,
+			assistantMessages: 5,
+			toolCalls: 12,
+			toolResults: 12,
+			totalMessages: 20,
+			tokens: {
+				input: 40000,
+				output: 8000,
+				cacheRead: 2000,
+				cacheWrite: 1000,
+				total: 50000,
+			},
+			cost: 0.05,
+			contextUsage: {
+				tokens: 4500,
+				contextWindow: 128000,
+				percent: 3.52,
+			},
+			sessionFile: "/tmp/test.jsonl",
+			sessionId: "test-id",
+		}),
+	} satisfies Partial<PiSessionService>;
 
-  Object.assign(session, overrides);
+	Object.assign(session, overrides);
 
-  return {
-    service: session as unknown as PiSessionService,
-    getCallbacks: () => callbacks,
-    getExtensionBindings: () => extensionBindings,
-    emitTextDelta: (delta: string) => callbacks?.onTextDelta(delta),
-    emitToolStart: (toolName: string, toolCallId: string) => callbacks?.onToolStart(toolName, toolCallId),
-    emitToolUpdate: (toolCallId: string, partialResult: string) =>
-      callbacks?.onToolUpdate(toolCallId, partialResult),
-    emitToolEnd: (toolCallId: string, isError: boolean) => callbacks?.onToolEnd(toolCallId, isError),
-    emitAgentEnd: () => callbacks?.onAgentEnd(),
-  };
+	return {
+		service: session as unknown as PiSessionService,
+		getCallbacks: () => callbacks,
+		getExtensionBindings: () => extensionBindings,
+		emitTextDelta: (delta: string) => callbacks?.onTextDelta(delta),
+		emitToolStart: (toolName: string, toolCallId: string) =>
+			callbacks?.onToolStart(toolName, toolCallId),
+		emitToolUpdate: (toolCallId: string, partialResult: string) =>
+			callbacks?.onToolUpdate(toolCallId, partialResult),
+		emitToolEnd: (toolCallId: string, isError: boolean) =>
+			callbacks?.onToolEnd(toolCallId, isError),
+		emitAgentEnd: () => callbacks?.onAgentEnd(),
+	};
 }
 
 function createMockPiSessionRegistry(options: SetupOptions = {}) {
-  const services = new Map<string, ReturnType<typeof createMockPiSession>>();
-  const defaultKey = makeContextKey();
-  const buildSession = (context: PiSessionContext) => {
-    const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-    return createMockPiSession({
-      ...options.piSessionOverrides,
-      ...options.perContextSessionOverrides?.[contextKey],
-    });
-  };
+	const services = new Map<string, ReturnType<typeof createMockPiSession>>();
+	const defaultKey = makeContextKey();
+	const buildSession = (context: PiSessionContext) => {
+		const contextKey = makeContextKey(context.chatId, context.messageThreadId);
+		return createMockPiSession({
+			...options.piSessionOverrides,
+			...options.perContextSessionOverrides?.[contextKey],
+		});
+	};
 
-  services.set(defaultKey, buildSession({ chatId: ALLOWED_CHAT_ID }));
+	services.set(defaultKey, buildSession({ chatId: ALLOWED_CHAT_ID }));
 
-  const defaultInfo: PiSessionInfo = {
-    sessionId: "(no active session)",
-    sessionFile: undefined,
-    workspace: options.configOverrides?.workspace ?? "/workspace",
-    sessionName: undefined,
-    modelFallbackMessage: undefined,
-    model: undefined,
-  };
+	const defaultInfo: PiSessionInfo = {
+		sessionId: "(no active session)",
+		sessionFile: undefined,
+		workspace: options.configOverrides?.workspace ?? "/workspace",
+		sessionName: undefined,
+		modelFallbackMessage: undefined,
+		model: undefined,
+	};
 
-  const registry = {
-    getOrCreate: vi.fn(async (context: PiSessionContext) => {
-      const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-      let entry = services.get(contextKey);
-      if (!entry) {
-        entry = buildSession(context);
-        services.set(contextKey, entry);
-      }
-      return entry.service;
-    }),
-    get: vi.fn((context: PiSessionContext) => {
-      const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-      return services.get(contextKey)?.service;
-    }),
-    has: vi.fn((context: PiSessionContext) => {
-      const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-      return services.has(contextKey);
-    }),
-    getInfo: vi.fn((context: PiSessionContext) => {
-      const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-      return services.get(contextKey)?.service.getInfo() ?? defaultInfo;
-    }),
-    remove: vi.fn((context: PiSessionContext) => {
-      const contextKey = makeContextKey(context.chatId, context.messageThreadId);
-      services.get(contextKey)?.service.dispose();
-      services.delete(contextKey);
-    }),
-    dispose: vi.fn(),
-  } satisfies Partial<PiSessionRegistry>;
+	const registry = {
+		getOrCreate: vi.fn(async (context: PiSessionContext) => {
+			const contextKey = makeContextKey(
+				context.chatId,
+				context.messageThreadId,
+			);
+			let entry = services.get(contextKey);
+			if (!entry) {
+				entry = buildSession(context);
+				services.set(contextKey, entry);
+			}
+			return entry.service;
+		}),
+		get: vi.fn((context: PiSessionContext) => {
+			const contextKey = makeContextKey(
+				context.chatId,
+				context.messageThreadId,
+			);
+			return services.get(contextKey)?.service;
+		}),
+		has: vi.fn((context: PiSessionContext) => {
+			const contextKey = makeContextKey(
+				context.chatId,
+				context.messageThreadId,
+			);
+			return services.has(contextKey);
+		}),
+		getInfo: vi.fn((context: PiSessionContext) => {
+			const contextKey = makeContextKey(
+				context.chatId,
+				context.messageThreadId,
+			);
+			return services.get(contextKey)?.service.getInfo() ?? defaultInfo;
+		}),
+		remove: vi.fn((context: PiSessionContext) => {
+			const contextKey = makeContextKey(
+				context.chatId,
+				context.messageThreadId,
+			);
+			services.get(contextKey)?.service.dispose();
+			services.delete(contextKey);
+		}),
+		dispose: vi.fn(),
+	} satisfies Partial<PiSessionRegistry>;
 
-  return {
-    registry: registry as PiSessionRegistry,
-    getSession(chatId: number | string = ALLOWED_CHAT_ID, messageThreadId?: number) {
-      return services.get(makeContextKey(chatId, messageThreadId));
-    },
-  };
+	return {
+		registry: registry as PiSessionRegistry,
+		getSession(
+			chatId: number | string = ALLOWED_CHAT_ID,
+			messageThreadId?: number,
+		) {
+			return services.get(makeContextKey(chatId, messageThreadId));
+		},
+	};
 }
 
 function setupBot(options: SetupOptions = {}) {
-  const registry = createMockPiSessionRegistry(options);
-  const pi = registry.getSession()!;
-  const bot = createBot(createConfig(options.configOverrides), registry.registry);
-  let messageId = 0;
+	const registry = createMockPiSessionRegistry(options);
+	const pi = registry.getSession()!;
+	const bot = createBot(
+		createConfig(options.configOverrides),
+		registry.registry,
+	);
+	let messageId = 0;
 
-  const api = {
-    sendMessage: vi.fn().mockImplementation(async (chatId: number | string, text: string, opts?: any) => ({
-      message_id: ++messageId,
-      chat: { id: chatId },
-      text,
-      ...opts,
-    })),
-    editMessageText: vi.fn().mockResolvedValue(true),
-    editMessageReplyMarkup: vi.fn().mockResolvedValue(true),
-    sendChatAction: vi.fn().mockResolvedValue(true),
-    setMyCommands: vi.fn().mockResolvedValue(true),
-    answerCallbackQuery: vi.fn().mockResolvedValue(true),
-    getFile: vi.fn().mockImplementation(async (fileId: string) => ({
-      file_id: fileId,
-      file_path: "voice/file.ogg",
-    })),
-  };
+	const api = {
+		sendMessage: vi
+			.fn()
+			.mockImplementation(
+				async (chatId: number | string, text: string, opts?: any) => ({
+					message_id: ++messageId,
+					chat: { id: chatId },
+					text,
+					...opts,
+				}),
+			),
+		editMessageText: vi.fn().mockResolvedValue(true),
+		editMessageReplyMarkup: vi.fn().mockResolvedValue(true),
+		sendChatAction: vi.fn().mockResolvedValue(true),
+		setMyCommands: vi.fn().mockResolvedValue(true),
+		answerCallbackQuery: vi.fn().mockResolvedValue(true),
+		getFile: vi.fn().mockImplementation(async (fileId: string) => ({
+			file_id: fileId,
+			file_path: "voice/file.ogg",
+		})),
+	};
 
-  bot.api.config.use(async (_prev, method, payload) => {
-    switch (method) {
-      case "sendMessage":
-        return {
-          ok: true,
-          result: await api.sendMessage(payload.chat_id, payload.text, {
-            parse_mode: payload.parse_mode,
-            reply_markup: payload.reply_markup,
-            message_thread_id: payload.message_thread_id,
-          }),
-        };
-      case "editMessageText":
-        await api.editMessageText(payload.chat_id, payload.message_id, payload.text, {
-          parse_mode: payload.parse_mode,
-          reply_markup: payload.reply_markup,
-        });
-        return { ok: true, result: true };
-      case "editMessageReplyMarkup":
-        await api.editMessageReplyMarkup(payload.chat_id, payload.message_id, {
-          reply_markup: payload.reply_markup,
-        });
-        return { ok: true, result: true };
-      case "sendChatAction":
-        await api.sendChatAction(payload.chat_id, payload.action, payload.message_thread_id);
-        return { ok: true, result: true };
-      case "setMyCommands": {
-        const other = payload.scope || payload.language_code
-          ? {
-              scope: payload.scope,
-              language_code: payload.language_code,
-            }
-          : undefined;
-        await api.setMyCommands(payload.commands, other);
-        return { ok: true, result: true };
-      }
-      case "answerCallbackQuery":
-        await api.answerCallbackQuery(payload.callback_query_id, {
-          text: payload.text,
-        });
-        return { ok: true, result: true };
-      case "getFile":
-        return {
-          ok: true,
-          result: await api.getFile(payload.file_id),
-        };
-      default:
-        throw new Error(`Unexpected Telegram API method in test: ${method}`);
-    }
-  });
+	bot.api.config.use(async (_prev, method, payload) => {
+		switch (method) {
+			case "sendMessage":
+				return {
+					ok: true,
+					result: await api.sendMessage(payload.chat_id, payload.text, {
+						parse_mode: payload.parse_mode,
+						reply_markup: payload.reply_markup,
+						message_thread_id: payload.message_thread_id,
+					}),
+				};
+			case "editMessageText":
+				await api.editMessageText(
+					payload.chat_id,
+					payload.message_id,
+					payload.text,
+					{
+						parse_mode: payload.parse_mode,
+						reply_markup: payload.reply_markup,
+					},
+				);
+				return { ok: true, result: true };
+			case "editMessageReplyMarkup":
+				await api.editMessageReplyMarkup(payload.chat_id, payload.message_id, {
+					reply_markup: payload.reply_markup,
+				});
+				return { ok: true, result: true };
+			case "sendChatAction":
+				await api.sendChatAction(
+					payload.chat_id,
+					payload.action,
+					payload.message_thread_id,
+				);
+				return { ok: true, result: true };
+			case "setMyCommands": {
+				const other =
+					payload.scope || payload.language_code
+						? {
+								scope: payload.scope,
+								language_code: payload.language_code,
+							}
+						: undefined;
+				await api.setMyCommands(payload.commands, other);
+				return { ok: true, result: true };
+			}
+			case "answerCallbackQuery":
+				await api.answerCallbackQuery(payload.callback_query_id, {
+					text: payload.text,
+				});
+				return { ok: true, result: true };
+			case "getFile":
+				return {
+					ok: true,
+					result: await api.getFile(payload.file_id),
+				};
+			default:
+				throw new Error(`Unexpected Telegram API method in test: ${method}`);
+		}
+	});
 
-  (bot as any).botInfo = {
-    id: 1,
-    is_bot: true,
-    first_name: "TelePi",
-    username: "telepi_test_bot",
-    can_join_groups: false,
-    can_read_all_group_messages: false,
-    supports_inline_queries: false,
-  };
+	(bot as any).botInfo = {
+		id: 1,
+		is_bot: true,
+		first_name: "TelePi",
+		username: "telepi_test_bot",
+		can_join_groups: false,
+		can_read_all_group_messages: false,
+		supports_inline_queries: false,
+	};
 
-  return { bot, pi, api, registry };
+	return { bot, pi, api, registry };
 }
 
 function createTestUpdate(overrides: Record<string, any> = {}): any {
-  const { message: messageOverrides = {}, ...updateOverrides } = overrides;
-  const update = {
-    update_id: Math.floor(Math.random() * 1_000_000),
-    ...updateOverrides,
-    message: {
-      message_id: 1,
-      date: Math.floor(Date.now() / 1000),
-      chat: { id: ALLOWED_CHAT_ID, type: "private" },
-      from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
-      text: "/start",
-      ...messageOverrides,
-    },
-  } as any;
+	const { message: messageOverrides = {}, ...updateOverrides } = overrides;
+	const update = {
+		update_id: Math.floor(Math.random() * 1_000_000),
+		...updateOverrides,
+		message: {
+			message_id: 1,
+			date: Math.floor(Date.now() / 1000),
+			chat: { id: ALLOWED_CHAT_ID, type: "private" },
+			from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
+			text: "/start",
+			...messageOverrides,
+		},
+	} as any;
 
-  const text = update.message?.text;
-  if (typeof text === "string" && text.startsWith("/") && !update.message.entities) {
-    const commandLength = text.split(/\s+/, 1)[0]?.length ?? text.length;
-    update.message.entities = [{ offset: 0, length: commandLength, type: "bot_command" }];
-  }
+	const text = update.message?.text;
+	if (
+		typeof text === "string" &&
+		text.startsWith("/") &&
+		!update.message.entities
+	) {
+		const commandLength = text.split(/\s+/, 1)[0]?.length ?? text.length;
+		update.message.entities = [
+			{ offset: 0, length: commandLength, type: "bot_command" },
+		];
+	}
 
-  return update;
+	return update;
 }
 
 function createVoiceUpdate(overrides: Record<string, any> = {}): any {
-  const { message: messageOverrides = {}, ...updateOverrides } = overrides;
-  return {
-    update_id: Math.floor(Math.random() * 1_000_000),
-    ...updateOverrides,
-    message: {
-      message_id: 1,
-      date: Math.floor(Date.now() / 1000),
-      chat: { id: ALLOWED_CHAT_ID, type: "private" },
-      from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
-      voice: {
-        file_id: "voice-file-id",
-        file_unique_id: "voice-unique",
-        duration: 5,
-      },
-      ...messageOverrides,
-    },
-  };
+	const { message: messageOverrides = {}, ...updateOverrides } = overrides;
+	return {
+		update_id: Math.floor(Math.random() * 1_000_000),
+		...updateOverrides,
+		message: {
+			message_id: 1,
+			date: Math.floor(Date.now() / 1000),
+			chat: { id: ALLOWED_CHAT_ID, type: "private" },
+			from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
+			voice: {
+				file_id: "voice-file-id",
+				file_unique_id: "voice-unique",
+				duration: 5,
+			},
+			...messageOverrides,
+		},
+	};
 }
 
 function createPhotoUpdate(overrides: Record<string, any> = {}): any {
-  const { message: messageOverrides = {}, ...updateOverrides } = overrides;
-  return {
-    update_id: Math.floor(Math.random() * 1_000_000),
-    ...updateOverrides,
-    message: {
-      message_id: 1,
-      date: Math.floor(Date.now() / 1000),
-      chat: { id: ALLOWED_CHAT_ID, type: "private" },
-      from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
-      caption: "Check this graph",
-      photo: [
-        { file_id: "photo-small", file_unique_id: "photo-small-unique", width: 100, height: 100, file_size: 1000 },
-        { file_id: "photo-big", file_unique_id: "photo-big-unique", width: 500, height: 500, file_size: 5000 },
-      ],
-      ...messageOverrides,
-    },
-  };
+	const { message: messageOverrides = {}, ...updateOverrides } = overrides;
+	return {
+		update_id: Math.floor(Math.random() * 1_000_000),
+		...updateOverrides,
+		message: {
+			message_id: 1,
+			date: Math.floor(Date.now() / 1000),
+			chat: { id: ALLOWED_CHAT_ID, type: "private" },
+			from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
+			caption: "Check this graph",
+			photo: [
+				{
+					file_id: "photo-small",
+					file_unique_id: "photo-small-unique",
+					width: 100,
+					height: 100,
+					file_size: 1000,
+				},
+				{
+					file_id: "photo-big",
+					file_unique_id: "photo-big-unique",
+					width: 500,
+					height: 500,
+					file_size: 5000,
+				},
+			],
+			...messageOverrides,
+		},
+	};
 }
 
 function createDocumentUpdate(overrides: Record<string, any> = {}): any {
-  const { message: messageOverrides = {}, ...updateOverrides } = overrides;
-  return {
-    update_id: Math.floor(Math.random() * 1_000_000),
-    ...updateOverrides,
-    message: {
-      message_id: 1,
-      date: Math.floor(Date.now() / 1000),
-      chat: { id: ALLOWED_CHAT_ID, type: "private" },
-      from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
-      document: {
-        file_id: "document-image-id",
-        file_unique_id: "document-image-unique",
-        file_name: "diagram.png",
-        mime_type: "image/png",
-        file_size: 2048,
-      },
-      ...messageOverrides,
-    },
-  };
+	const { message: messageOverrides = {}, ...updateOverrides } = overrides;
+	return {
+		update_id: Math.floor(Math.random() * 1_000_000),
+		...updateOverrides,
+		message: {
+			message_id: 1,
+			date: Math.floor(Date.now() / 1000),
+			chat: { id: ALLOWED_CHAT_ID, type: "private" },
+			from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
+			document: {
+				file_id: "document-image-id",
+				file_unique_id: "document-image-unique",
+				file_name: "diagram.png",
+				mime_type: "image/png",
+				file_size: 2048,
+			},
+			...messageOverrides,
+		},
+	};
 }
 
-function createCallbackUpdate(data: string, overrides: Record<string, any> = {}): any {
-  const { callback_query: callbackQueryOverrides = {}, ...updateOverrides } = overrides;
-  const { message: callbackMessageOverrides = {}, ...callbackQueryRest } = callbackQueryOverrides;
+function createCallbackUpdate(
+	data: string,
+	overrides: Record<string, any> = {},
+): any {
+	const { callback_query: callbackQueryOverrides = {}, ...updateOverrides } =
+		overrides;
+	const { message: callbackMessageOverrides = {}, ...callbackQueryRest } =
+		callbackQueryOverrides;
 
-  return {
-    update_id: Math.floor(Math.random() * 1_000_000),
-    ...updateOverrides,
-    callback_query: {
-      id: "cb_1",
-      chat_instance: "test",
-      from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
-      message: {
-        message_id: 1,
-        date: Math.floor(Date.now() / 1000),
-        chat: { id: ALLOWED_CHAT_ID, type: "private" },
-        from: { id: 1, is_bot: true, first_name: "TelePi" },
-        text: "Pick one",
-        ...callbackMessageOverrides,
-      },
-      data,
-      ...callbackQueryRest,
-    },
-  };
+	return {
+		update_id: Math.floor(Math.random() * 1_000_000),
+		...updateOverrides,
+		callback_query: {
+			id: "cb_1",
+			chat_instance: "test",
+			from: { id: ALLOWED_USER_ID, is_bot: false, first_name: "Test" },
+			message: {
+				message_id: 1,
+				date: Math.floor(Date.now() / 1000),
+				chat: { id: ALLOWED_CHAT_ID, type: "private" },
+				from: { id: 1, is_bot: true, first_name: "TelePi" },
+				text: "Pick one",
+				...callbackMessageOverrides,
+			},
+			data,
+			...callbackQueryRest,
+		},
+	};
 }
 
 async function nextTick(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-function getReplyMarkupData(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
-  const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
-  return markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [];
+function getReplyMarkupData(
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
+): string[] {
+	const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
+	return (
+		markup?.inline_keyboard
+			?.flat()
+			.map((button: any) => button.callback_data) ?? []
+	);
 }
 
-function getReplyMarkupTexts(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
-  const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
-  return markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? [];
+function getReplyMarkupTexts(
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
+): string[] {
+	const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
+	return (
+		markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? []
+	);
 }
 
 function getReplyMarkupButtons(
-  api: ReturnType<typeof setupBot>["api"],
-  callIndex = 0,
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
 ): Array<{ text: string; callback_data: string }> {
-  const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
-  return markup?.inline_keyboard?.flat() ?? [];
+	const markup = api.sendMessage.mock.calls[callIndex]?.[2]?.reply_markup;
+	return markup?.inline_keyboard?.flat() ?? [];
 }
 
-function getEditedReplyMarkupData(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
-  const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
-  return markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [];
+function getEditedReplyMarkupData(
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
+): string[] {
+	const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
+	return (
+		markup?.inline_keyboard
+			?.flat()
+			.map((button: any) => button.callback_data) ?? []
+	);
 }
 
-function getEditedReplyMarkupTexts(api: ReturnType<typeof setupBot>["api"], callIndex = 0): string[] {
-  const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
-  return markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? [];
+function getEditedReplyMarkupTexts(
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
+): string[] {
+	const markup = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
+	return (
+		markup?.inline_keyboard?.flat().map((button: any) => button.text) ?? []
+	);
 }
 
 function getEditedReplyMarkupButtons(
-  api: ReturnType<typeof setupBot>["api"],
-  callIndex = 0,
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
 ): Array<{ text: string; callback_data: string }> {
-  const replyMarkupFromText = api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
-  if (replyMarkupFromText) {
-    return replyMarkupFromText.inline_keyboard?.flat() ?? [];
-  }
+	const replyMarkupFromText =
+		api.editMessageText.mock.calls[callIndex]?.[3]?.reply_markup;
+	if (replyMarkupFromText) {
+		return replyMarkupFromText.inline_keyboard?.flat() ?? [];
+	}
 
-  const replyMarkupFromMarkup = api.editMessageReplyMarkup.mock.calls[callIndex]?.[2]?.reply_markup;
-  return replyMarkupFromMarkup?.inline_keyboard?.flat() ?? [];
+	const replyMarkupFromMarkup =
+		api.editMessageReplyMarkup.mock.calls[callIndex]?.[2]?.reply_markup;
+	return replyMarkupFromMarkup?.inline_keyboard?.flat() ?? [];
 }
 
-function getSetMyCommandsCall(api: ReturnType<typeof setupBot>["api"], callIndex = 0): {
-  commands: Array<{ command: string; description: string }>;
-  scope?: { type: string; chat_id?: number | string };
-  language_code?: string;
-} | undefined {
-  const [commands, other] = api.setMyCommands.mock.calls[callIndex] ?? [];
-  if (!commands) {
-    return undefined;
-  }
+function getSetMyCommandsCall(
+	api: ReturnType<typeof setupBot>["api"],
+	callIndex = 0,
+):
+	| {
+			commands: Array<{ command: string; description: string }>;
+			scope?: { type: string; chat_id?: number | string };
+			language_code?: string;
+	  }
+	| undefined {
+	const [commands, other] = api.setMyCommands.mock.calls[callIndex] ?? [];
+	if (!commands) {
+		return undefined;
+	}
 
-  return {
-    commands,
-    scope: other?.scope,
-    language_code: other?.language_code,
-  };
+	return {
+		commands,
+		scope: other?.scope,
+		language_code: other?.language_code,
+	};
 }
 
 function generateMockSessions(count: number) {
-  return Array.from({ length: count }, (_, i) => ({
-    id: `s${i}`,
-    firstMessage: `Session ${i}`,
-    path: `/s${i}.jsonl`,
-    messageCount: i + 1,
-    cwd: `/workspace/${i % 2 === 0 ? "A" : "B"}`,
-    modified: new Date(`2025-01-${String((count - i) % 28 || 28).padStart(2, "0")}T00:00:00.000Z`),
-    name: undefined,
-  }));
+	return Array.from({ length: count }, (_, i) => ({
+		id: `s${i}`,
+		firstMessage: `Session ${i}`,
+		path: `/s${i}.jsonl`,
+		messageCount: i + 1,
+		cwd: `/workspace/${i % 2 === 0 ? "A" : "B"}`,
+		modified: new Date(
+			`2025-01-${String((count - i) % 28 || 28).padStart(2, "0")}T00:00:00.000Z`,
+		),
+		name: undefined,
+	}));
 }
 
 function generateMockModels(count: number) {
-  return Array.from({ length: count }, (_, i) => ({
-    provider: `provider${i}`,
-    id: `model-${i}`,
-    name: `Model ${i}`,
-    current: i === 0,
-  }));
+	return Array.from({ length: count }, (_, i) => ({
+		provider: `provider${i}`,
+		id: `model-${i}`,
+		name: `Model ${i}`,
+		current: i === 0,
+	}));
 }
 
 function generateMockWorkspaces(count: number): string[] {
-  return Array.from({ length: count }, (_, i) => `/workspace/W${i}`);
+	return Array.from({ length: count }, (_, i) => `/workspace/W${i}`);
 }
 
 function generatePagedTree(totalEntries: number) {
-  const makeBranch = (index: number) =>
-    makeMessageTreeNode(`node${index.toString().padStart(4, "0")}`, "user", `Tree node ${index}`, "root0000");
+	const makeBranch = (index: number) =>
+		makeMessageTreeNode(
+			`node${index.toString().padStart(4, "0")}`,
+			"user",
+			`Tree node ${index}`,
+			"root0000",
+		);
 
-  return [
-    makeMessageTreeNode(
-      "root0000",
-      "user",
-      "Root",
-      null,
-      Array.from({ length: totalEntries - 1 }, (_, i) => makeBranch(i + 1)),
-    ),
-  ];
+	return [
+		makeMessageTreeNode(
+			"root0000",
+			"user",
+			"Root",
+			null,
+			Array.from({ length: totalEntries - 1 }, (_, i) => makeBranch(i + 1)),
+		),
+	];
 }
 
 describe("createBot", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-    vi.unstubAllGlobals();
-    vi.mocked(getAvailableBackends).mockResolvedValue(["openai"]);
-    vi.mocked(transcribeAudio).mockResolvedValue({
-      text: "transcribed text",
-      backend: "openai",
-      durationMs: 500,
-    });
-    vi.mocked(readFile).mockResolvedValue(Buffer.from("image-bytes"));
-    vi.mocked(writeFile).mockResolvedValue(undefined);
-    vi.mocked(unlink).mockResolvedValue(undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(100)),
-      }),
-    );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("starts prompt inbox polling when configured", () => {
-    setupBot({
-      configOverrides: {
-        promptInboxDir: "/tmp/telepi-inbox",
-        promptInboxIntervalMs: 15000,
-      },
-    });
-
-    expect(startPromptInboxPolling).toHaveBeenCalledWith(expect.objectContaining({
-      inboxDir: "/tmp/telepi-inbox",
-      intervalMs: 15000,
-      target: { chatId: ALLOWED_USER_ID },
-    }));
-  });
-
-  it("stops prompt inbox polling when the bot stops", () => {
-    const stopPolling = vi.fn();
-    vi.mocked(startPromptInboxPolling).mockReturnValue(stopPolling);
-    const { bot } = setupBot({
-      configOverrides: {
-        promptInboxDir: "/tmp/telepi-inbox",
-      },
-    });
-
-    bot.stop();
-
-    expect(stopPolling).toHaveBeenCalledTimes(1);
-  });
-
-  it("allows authorized users through the middleware and handles /start", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/start" } }));
-
-    expect(api.sendMessage).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("TelePi is ready.");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Session ID");
-  });
-
-  it("handles /help and /retry flows", async () => {
-    const { bot, pi, api } = setupBot();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/help" } }));
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("/retry");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Each Telegram chat/topic has its own Pi session");
-
-    api.sendMessage.mockClear();
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Nothing to retry yet");
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.emitTextDelta("Retried response");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "retry me" } }));
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-
-    expect(pi.service.prompt).toHaveBeenNthCalledWith(1, "retry me");
-    expect(pi.service.prompt).toHaveBeenNthCalledWith(2, "retry me");
-  });
-
-  it("keeps /retry state isolated per topic", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "topic one retry",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 101,
-        },
-      }),
-    );
-
-    api.sendMessage.mockClear();
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/retry",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 202,
-        },
-      }),
-    );
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Nothing to retry yet in this chat/topic.");
-  });
-
-  it("clears /retry memory after creating a new session or switching sessions", async () => {
-    const fresh = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-      },
-    });
-    await fresh.bot.handleUpdate(createTestUpdate({ message: { text: "retry me later" } }));
-    await fresh.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-
-    fresh.api.sendMessage.mockClear();
-    await fresh.bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-    expect(fresh.api.sendMessage.mock.calls[0]?.[1]).toContain("Nothing to retry yet");
-
-    const switched = setupBot();
-    await switched.bot.handleUpdate(createTestUpdate({ message: { text: "switch clears retry" } }));
-    await switched.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-
-    switched.api.sendMessage.mockClear();
-    await switched.bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-    expect(switched.api.sendMessage.mock.calls[0]?.[1]).toContain("Nothing to retry yet");
-  });
-
-  it("can retry failed prompts and prompts started from voice transcription", async () => {
-    const failing = setupBot();
-    const failingPrompt = failing.pi.service.prompt as ReturnType<typeof vi.fn>;
-    failingPrompt
-      .mockRejectedValueOnce(new Error("boom"))
-      .mockResolvedValueOnce(undefined);
-
-    await failing.bot.handleUpdate(createTestUpdate({ message: { text: "retry failed prompt" } }));
-    await failing.bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-
-    expect(failing.pi.service.prompt).toHaveBeenNthCalledWith(1, "retry failed prompt");
-    expect(failing.pi.service.prompt).toHaveBeenNthCalledWith(2, "retry failed prompt");
-
-    const voice = setupBot();
-    const voicePrompt = voice.pi.service.prompt as ReturnType<typeof vi.fn>;
-    voicePrompt.mockImplementation(async () => {
-      voice.pi.emitTextDelta("Voice response");
-      voice.pi.emitAgentEnd();
-    });
-
-    await voice.bot.handleUpdate(createVoiceUpdate());
-    await voice.bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
-
-    expect(voice.pi.service.prompt).toHaveBeenNthCalledWith(1, "transcribed text");
-    expect(voice.pi.service.prompt).toHaveBeenNthCalledWith(2, "transcribed text");
-  });
-
-  it("rejects unauthorized message senders", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(
-      createTestUpdate({ message: { from: { id: 999, is_bot: false, first_name: "Eve" } } }),
-    );
-
-    expect(api.sendMessage).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls[0]?.[1]).toBe("Unauthorized");
-  });
-
-  it("rejects unauthorized callback queries without sending a chat message", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(
-      createCallbackUpdate("switch_0", {
-        callback_query: { from: { id: 999, is_bot: false, first_name: "Eve" } },
-      }),
-    );
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Unauthorized" });
-    expect(api.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("rejects unauthorized tree commands", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: { text: "/tree", from: { id: 999, is_bot: false, first_name: "Eve" } },
-      }),
-    );
-
-    expect(api.sendMessage).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls[0]?.[1]).toBe("Unauthorized");
-  });
-
-  it("handles /session", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/session" } }));
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Session ID");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("/tmp/test.jsonl");
-  });
-
-  it("shows fallback /session info for untouched contexts without creating a session", async () => {
-    const { bot, api, registry } = setupBot();
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/session",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 909,
-        },
-      }),
-    );
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("(no active session)");
-    expect((registry.registry.getOrCreate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalledWith({
-      chatId: ALLOWED_CHAT_ID,
-      messageThreadId: 909,
-    });
-    expect(registry.getSession(ALLOWED_CHAT_ID, 909)).toBeUndefined();
-  });
-
-  it("handles /abort success and failure", async () => {
-    const ok = setupBot();
-    await ok.bot.handleUpdate(createTestUpdate({ message: { text: "/abort" } }));
-    expect(ok.pi.service.abort).toHaveBeenCalledTimes(1);
-    expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("Aborted current operation");
-
-    const failure = setupBot({
-      piSessionOverrides: {
-        abort: vi.fn().mockRejectedValue(new Error("abort failed")),
-      },
-    });
-    await failure.bot.handleUpdate(createTestUpdate({ message: { text: "/abort" } }));
-    expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
-    expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("abort failed");
-  });
-
-  it("does not create a fresh session for /abort in an untouched context", async () => {
-    const { bot, api, registry } = setupBot();
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/abort",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 910,
-        },
-      }),
-    );
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("No active session to abort.");
-    expect((registry.registry.getOrCreate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalledWith({
-      chatId: ALLOWED_CHAT_ID,
-      messageThreadId: 910,
-    });
-    expect(registry.getSession(ALLOWED_CHAT_ID, 910)).toBeUndefined();
-  });
-
-  it("shows a compact session picker with inline switch buttons", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Select a session to switch");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("(2 found)");
-    expect(api.sendMessage.mock.calls[0]?.[1]).not.toContain("📁 A");
-    expect(api.sendMessage.mock.calls[0]?.[1]).not.toContain("📁 B");
-    expect(getReplyMarkupButtons(api).slice(0, 2).map((button) => button.text)).toEqual([
-      "📁 A · Hello session",
-      "📁 B · World session",
-    ]);
-    expect(getReplyMarkupData(api)).toEqual(["switch_0", "switch_1"]);
-  });
-
-  it("paginates session pickers and keeps selections working across pages", async () => {
-    const sessions = generateMockSessions(8).map((session) => ({ ...session, cwd: "/workspace/A" }));
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listAllSessions: vi.fn().mockResolvedValue(sessions),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-
-    expect(getReplyMarkupData(api)).toEqual([
-      "switch_0",
-      "switch_1",
-      "switch_2",
-      "switch_3",
-      "switch_4",
-      "switch_5",
-      "noop_page",
-      "switch_page_1",
-    ]);
-    expect(getReplyMarkupButtons(api).at(-2)?.text).toBe("1/2");
-    expect(getReplyMarkupButtons(api).at(-1)?.text).toBe("Next ▶️");
-
-    await bot.handleUpdate(createCallbackUpdate("switch_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: undefined });
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "switch_6",
-      "switch_7",
-      "switch_page_0",
-      "noop_page",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("switch_7"));
-    expect(pi.service.switchSession).toHaveBeenCalledWith("/s7.jsonl", "/workspace/A");
-  });
-
-  it("routes session pickers and prompts per topic", async () => {
-    const topicOneKey = makeContextKey(ALLOWED_CHAT_ID, 101);
-    const topicTwoKey = makeContextKey(ALLOWED_CHAT_ID, 202);
-    const { bot, api, registry } = setupBot({
-      perContextSessionOverrides: {
-        [topicOneKey]: {
-          listAllSessions: vi.fn().mockResolvedValue([
-            {
-              id: "topic-1",
-              firstMessage: "Topic one",
-              path: "/topic-one.jsonl",
-              messageCount: 2,
-              cwd: "/workspace/topic-one",
-              modified: new Date("2025-01-02T00:00:00.000Z"),
-              name: undefined,
-            },
-          ]),
-        },
-        [topicTwoKey]: {
-          listAllSessions: vi.fn().mockResolvedValue([
-            {
-              id: "topic-2",
-              firstMessage: "Topic two",
-              path: "/topic-two.jsonl",
-              messageCount: 4,
-              cwd: "/workspace/topic-two",
-              modified: new Date("2025-01-03T00:00:00.000Z"),
-              name: undefined,
-            },
-          ]),
-        },
-      },
-    });
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/sessions",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 101,
-        },
-      }),
-    );
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/sessions",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 202,
-        },
-      }),
-    );
-
-    expect(api.sendMessage.mock.calls[0]?.[2]?.message_thread_id).toBe(101);
-    expect(api.sendMessage.mock.calls[1]?.[2]?.message_thread_id).toBe(202);
-
-    await bot.handleUpdate(
-      createCallbackUpdate("switch_0", {
-        callback_query: {
-          message: {
-            chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-            message_thread_id: 101,
-          },
-        },
-      }),
-    );
-    await bot.handleUpdate(
-      createCallbackUpdate("switch_0", {
-        callback_query: {
-          message: {
-            chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-            message_thread_id: 202,
-          },
-        },
-      }),
-    );
-
-    expect(registry.getSession(ALLOWED_CHAT_ID, 101)?.service.switchSession).toHaveBeenCalledWith(
-      "/topic-one.jsonl",
-      "/workspace/topic-one",
-    );
-    expect(registry.getSession(ALLOWED_CHAT_ID, 202)?.service.switchSession).toHaveBeenCalledWith(
-      "/topic-two.jsonl",
-      "/workspace/topic-two",
-    );
-
-    const topicOneSession = registry.getSession(ALLOWED_CHAT_ID, 101)!;
-    const promptMock = topicOneSession.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      topicOneSession.emitTextDelta("Topic response");
-      topicOneSession.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "topic prompt",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 101,
-        },
-      }),
-    );
-
-    expect(api.sendChatAction).toHaveBeenCalledWith(ALLOWED_CHAT_ID, "typing", 101);
-  });
-
-  it("allows independent topics to process prompts concurrently", async () => {
-    let resolveTopicOne!: () => void;
-    const { bot, api, registry } = setupBot({
-      perContextSessionOverrides: {
-        [makeContextKey(ALLOWED_CHAT_ID, 101)]: {
-          prompt: vi.fn().mockImplementation(
-            () =>
-              new Promise<void>((resolve) => {
-                resolveTopicOne = resolve;
-              }),
-          ),
-        },
-        [makeContextKey(ALLOWED_CHAT_ID, 202)]: {
-          prompt: vi.fn().mockResolvedValue(undefined),
-        },
-      },
-    });
-
-    const topicOnePending = bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "topic one prompt",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 101,
-        },
-      }),
-    );
-    await nextTick();
-
-    await bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "topic two prompt",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 202,
-        },
-      }),
-    );
-
-    expect(registry.getSession(ALLOWED_CHAT_ID, 202)?.service.prompt).toHaveBeenCalledWith("topic two prompt");
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Still working on previous message..."))).toBe(false);
-
-    resolveTopicOne();
-    await topicOnePending;
-  });
-
-  it("switches directly via /sessions and /switch aliases and shows errors when switching fails", async () => {
-    const ok = setupBot();
-    await ok.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-    expect(ok.pi.service.resolveSessionReference).toHaveBeenCalledWith("/saved/session.jsonl");
-    expect(ok.pi.service.switchSession).toHaveBeenCalledWith(
-      "/saved/session.jsonl",
-      "/workspace/A",
-    );
-    expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("Switched session");
-
-    const alias = setupBot();
-    await alias.bot.handleUpdate(createTestUpdate({ message: { text: "/switch /saved/session.jsonl" } }));
-    expect(alias.pi.service.resolveSessionReference).toHaveBeenCalledWith("/saved/session.jsonl");
-    expect(alias.pi.service.switchSession).toHaveBeenCalledWith(
-      "/saved/session.jsonl",
-      "/workspace/A",
-    );
-    expect(alias.api.sendMessage.mock.calls[0]?.[1]).toContain("Switched session");
-
-    const cancelled = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockResolvedValue({
-          sessionId: "test-id",
-          sessionFile: "/tmp/test.jsonl",
-          workspace: "/workspace",
-          model: "anthropic/claude-sonnet-4-5",
-          cancelled: true,
-        }),
-      },
-    });
-    await cancelled.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-    expect(cancelled.api.sendMessage.mock.calls[0]?.[1]).toContain("Session switch was cancelled.");
-
-    const byId = setupBot({
-      piSessionOverrides: {
-        resolveSessionReference: vi.fn().mockResolvedValue({
-          id: "s1",
-          path: "/saved/session.jsonl",
-          cwd: "/workspace/A",
-          matchType: "prefix",
-        }),
-      },
-    });
-    await byId.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions s1" } }));
-    expect(byId.pi.service.resolveSessionReference).toHaveBeenCalledWith("s1");
-    expect(byId.pi.service.switchSession).toHaveBeenCalledWith(
-      "/saved/session.jsonl",
-      "/workspace/A",
-    );
-
-    const failure = setupBot({
-      piSessionOverrides: {
-        resolveSessionReference: vi.fn().mockRejectedValue(new Error("ambiguous session id")),
-      },
-    });
-    await failure.bot.handleUpdate(
-      createTestUpdate({ message: { text: "/sessions deadbeef" } }),
-    );
-    expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
-    expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("ambiguous session id");
-  });
-
-  it("handles switch callbacks, expired picks, and wait states", async () => {
-    const ready = setupBot();
-    await ready.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    await ready.bot.handleUpdate(createCallbackUpdate("switch_1"));
-
-    expect(ready.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Switching..." });
-    expect(ready.pi.service.resolveSessionReference).toHaveBeenCalledWith("/s2.jsonl");
-    expect(ready.pi.service.switchSession).toHaveBeenCalledWith("/s2.jsonl", "/workspace/B");
-    expect(ready.api.editMessageText).toHaveBeenCalled();
-
-    const cancelled = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockResolvedValue({
-          sessionId: "test-id",
-          sessionFile: "/tmp/test.jsonl",
-          workspace: "/workspace",
-          model: "anthropic/claude-sonnet-4-5",
-          cancelled: true,
-        }),
-      },
-    });
-    await cancelled.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    await cancelled.bot.handleUpdate(createCallbackUpdate("switch_0"));
-    expect(cancelled.api.editMessageText.mock.calls.at(-1)?.[2]).toContain("Session switch was cancelled.");
-
-    const expired = setupBot();
-    await expired.bot.handleUpdate(createCallbackUpdate("switch_0"));
-    expect(expired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Session expired, run /sessions again",
-    });
-
-    let resolvePrompt!: () => void;
-    const waiting = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () => new Promise<void>((resolve) => {
-            resolvePrompt = resolve;
-          }),
-        ),
-      },
-    });
-    await waiting.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    const firstPrompt = waiting.bot.handleUpdate(createTestUpdate({ message: { text: "hello" } }));
-    await nextTick();
-    await waiting.bot.handleUpdate(createCallbackUpdate("switch_0"));
-
-    expect(waiting.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Wait for the current prompt to finish",
-    });
-
-    resolvePrompt();
-    await firstPrompt;
-  });
-
-  it("surfaces startup diagnostics after successful direct session switches", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockResolvedValue({
-          sessionId: "switched-id",
-          sessionFile: "/tmp/switched.jsonl",
-          workspace: "/workspace/B",
-          model: "anthropic/claude-sonnet-4-5",
-          diagnostics: [
-            { type: "error", message: "Extension issue (/ext/rebound.ts): startup failed" },
-          ],
-          cancelled: false,
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(1);
-    expect(startupMessages[0]).toContain("Extension issue (/ext/rebound.ts): startup failed");
-  });
-
-  it("surfaces startup diagnostics after successful switch callbacks", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockResolvedValue({
-          sessionId: "switched-id",
-          sessionFile: "/tmp/switched.jsonl",
-          workspace: "/workspace/B",
-          model: "anthropic/claude-sonnet-4-5",
-          diagnostics: [
-            { type: "error", message: "Prompt issue (/prompts/deploy.md): invalid frontmatter" },
-          ],
-          cancelled: false,
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    await bot.handleUpdate(createCallbackUpdate("switch_1"));
-
-    expect(api.editMessageText).toHaveBeenCalled();
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(1);
-    expect(startupMessages[0]).toContain("Prompt issue (/prompts/deploy.md): invalid frontmatter");
-  });
-
-  it("shows a workspace picker for /new and creates directly when only one workspace exists", async () => {
-    const picker = setupBot();
-    await picker.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(picker.api.sendMessage.mock.calls[0]?.[1]).toContain("Select workspace for new session");
-    expect(getReplyMarkupData(picker.api)).toEqual(["newws_0", "newws_1"]);
-
-    const single = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-      },
-    });
-    await single.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(single.pi.service.newSession).toHaveBeenCalledWith();
-    expect(single.api.sendMessage.mock.calls[0]?.[1]).toContain("New session created.");
-  });
-
-  it("surfaces startup diagnostics after successful direct /new session creation", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-        newSession: vi.fn().mockResolvedValue({
-          info: {
-            sessionId: "new-id",
-            sessionFile: "/tmp/new.jsonl",
-            workspace: "/workspace/A",
-            model: "anthropic/claude-sonnet-4-5",
-            diagnostics: [
-              { type: "error", message: "Extension issue (/ext/new.ts): startup failed" },
-            ],
-          },
-          created: true,
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(1);
-    expect(startupMessages[0]).toContain("Extension issue (/ext/new.ts): startup failed");
-  });
-
-  it("handles new workspace selection callbacks", async () => {
-    const { bot, pi, api } = setupBot();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    await bot.handleUpdate(createCallbackUpdate("newws_1"));
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Creating session..." });
-    expect(pi.service.newSession).toHaveBeenCalledWith("/workspace/B");
-    expect(api.editMessageText).toHaveBeenCalled();
-  });
-
-  it("surfaces startup diagnostics after successful workspace-picker session creation", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        newSession: vi.fn().mockResolvedValue({
-          info: {
-            sessionId: "new-id",
-            sessionFile: "/tmp/new.jsonl",
-            workspace: "/workspace/B",
-            model: "anthropic/claude-sonnet-4-5",
-            diagnostics: [
-              { type: "error", message: "Prompt issue (/prompts/new.md): invalid frontmatter" },
-            ],
-          },
-          created: true,
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    await bot.handleUpdate(createCallbackUpdate("newws_1"));
-
-    expect(api.editMessageText).toHaveBeenCalled();
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(1);
-    expect(startupMessages[0]).toContain("Prompt issue (/prompts/new.md): invalid frontmatter");
-  });
-
-  it("paginates workspace pickers and creates the selected workspace session", async () => {
-    const workspaces = generateMockWorkspaces(8);
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(workspaces),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(getReplyMarkupData(api)).toEqual([
-      "newws_0",
-      "newws_1",
-      "newws_2",
-      "newws_3",
-      "newws_4",
-      "newws_5",
-      "noop_page",
-      "newws_page_1",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("newws_page_1"));
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "newws_6",
-      "newws_7",
-      "newws_page_0",
-      "noop_page",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("newws_7"));
-    expect(pi.service.newSession).toHaveBeenCalledWith("/workspace/W7");
-  });
-
-  it("handles /handback and blocks it when unavailable or busy", async () => {
-    const ok = setupBot();
-    await ok.bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-    expect(ok.pi.service.handback).toHaveBeenCalledTimes(1);
-    expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("pi --session");
-    expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("pi -c");
-    expect((ok.registry.registry.remove as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith({
-      chatId: ALLOWED_CHAT_ID,
-    });
-
-    const noActive = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-      },
-    });
-    await noActive.bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-    expect(noActive.api.sendMessage.mock.calls[0]?.[1]).toContain("No active session to hand back.");
-
-    let resolvePrompt!: () => void;
-    const busy = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () => new Promise<void>((resolve) => {
-            resolvePrompt = resolve;
-          }),
-        ),
-      },
-    });
-    const pending = busy.bot.handleUpdate(createTestUpdate({ message: { text: "hello" } }));
-    await nextTick();
-    await busy.bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-
-    expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
-      "Cannot hand back while a prompt is running. Use /abort first.",
-    );
-
-    resolvePrompt();
-    await pending;
-  });
-
-  it("shows scoped models by default, can expand to all models, and handles model selection", async () => {
-    const scopedModels = [
-      {
-        provider: "github-copilot",
-        id: "codex",
-        name: "Codex",
-        current: true,
-        thinkingLevel: "high",
-      },
-    ];
-    const allModels = [
-      {
-        provider: "openai",
-        id: "codex",
-        name: "Codex",
-        current: false,
-      },
-      ...scopedModels,
-    ];
-    const listModels = vi.fn().mockImplementation((showAll?: boolean) =>
-      Promise.resolve(showAll ? allModels : scopedModels),
-    );
-
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listModels,
-        setModel: vi.fn().mockResolvedValue("openai/codex"),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Select a model");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Showing the current Pi model scope.");
-    expect(getReplyMarkupData(api)).toEqual(["model_0", "model_show_all"]);
-    expect(getReplyMarkupTexts(api)).toEqual([
-      "✅ github-copilot/codex · Codex : high",
-      "Show all models",
-    ]);
-    expect(listModels).toHaveBeenNthCalledWith(1, false);
-    expect(listModels).toHaveBeenNthCalledWith(2, true);
-
-    await bot.handleUpdate(createCallbackUpdate("model_show_all"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Loading all models..." });
-    expect(getEditedReplyMarkupData(api)).toEqual(["model_0", "model_1"]);
-    expect(getEditedReplyMarkupTexts(api)).toEqual([
-      "openai/codex · Codex",
-      "✅ github-copilot/codex · Codex : high",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("model_0"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Switching model..." });
-    expect(pi.service.setModel).toHaveBeenCalledWith("openai", "codex", undefined);
-    expect(api.editMessageText).toHaveBeenCalled();
-  });
-
-  it("applies the scoped thinking-level override when selecting a scoped model", async () => {
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        listModels: vi.fn().mockResolvedValue([
-          {
-            provider: "github-copilot",
-            id: "codex",
-            name: "Codex",
-            current: true,
-            thinkingLevel: "high",
-          },
-        ]),
-        setModel: vi.fn().mockResolvedValue("github-copilot/codex"),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    await bot.handleUpdate(createCallbackUpdate("model_0"));
-
-    expect(pi.service.setModel).toHaveBeenCalledWith("github-copilot", "codex", "high");
-  });
-
-  it("keeps the show-all button while paging through scoped models", async () => {
-    const scopedModels = Array.from({ length: 7 }, (_, index) => ({
-      provider: "github-copilot",
-      id: `codex-${index}`,
-      name: `Codex ${index}`,
-      current: index === 0,
-    }));
-    const allModels = [
-      ...Array.from({ length: 2 }, (_, index) => ({
-        provider: "openai",
-        id: `gpt-${index}`,
-        name: `GPT ${index}`,
-        current: false,
-      })),
-      ...scopedModels,
-    ];
-    const listModels = vi.fn().mockImplementation((showAll?: boolean) =>
-      Promise.resolve(showAll ? allModels : scopedModels),
-    );
-
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listModels,
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    expect(getReplyMarkupData(api)).toEqual([
-      "model_0",
-      "model_1",
-      "model_2",
-      "model_3",
-      "model_4",
-      "model_5",
-      "noop_page",
-      "model_page_1",
-      "model_show_all",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("model_page_1"));
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "model_6",
-      "model_page_0",
-      "noop_page",
-      "model_show_all",
-    ]);
-  });
-
-  it("paginates model pickers across all available models", async () => {
-    const models = generateMockModels(21);
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listModels: vi.fn().mockImplementation((showAll?: boolean) =>
-          Promise.resolve(showAll ? models : models),
-        ),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    expect(getReplyMarkupData(api)).toEqual([
-      "model_0",
-      "model_1",
-      "model_2",
-      "model_3",
-      "model_4",
-      "model_5",
-      "noop_page",
-      "model_page_1",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("model_page_3"));
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "model_18",
-      "model_19",
-      "model_20",
-      "model_page_2",
-      "noop_page",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("model_20"));
-    expect(pi.service.setModel).toHaveBeenCalledWith("provider20", "model-20", undefined);
-  });
-
-  it("handles /tree command variants and missing sessions", async () => {
-    const empty = setupBot({
-      piSessionOverrides: {
-        getTree: vi.fn().mockReturnValue([]),
-      },
-    });
-    await empty.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    expect(empty.api.sendMessage.mock.calls[0]?.[1]).toContain("Session tree is empty.");
-
-    const branched = setupBot();
-    await branched.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    expect(branched.api.sendMessage.mock.calls[0]?.[1]).toContain("Start");
-    expect(getReplyMarkupData(branched.api)).toContain("tree_nav_branch111");
-    expect(getReplyMarkupData(branched.api)).toContain("tree_nav_leaf5678");
-
-    const userMode = setupBot();
-    await userMode.bot.handleUpdate(createTestUpdate({ message: { text: "/tree user" } }));
-    expect(userMode.api.sendMessage.mock.calls[0]?.[1]).toContain("Filter: user messages only.");
-
-    const allMode = setupBot();
-    await allMode.bot.handleUpdate(createTestUpdate({ message: { text: "/tree all" } }));
-    expect(allMode.api.sendMessage.mock.calls[0]?.[1]).toContain("Filter: all entries with navigation buttons.");
-
-    const noActive = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-      },
-    });
-    await noActive.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    expect(noActive.api.sendMessage.mock.calls[0]?.[1]).toContain("No active session");
-  });
-
-  it("paginates tree navigation buttons while keeping filter buttons visible", async () => {
-    const tree = generatePagedTree(8);
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        getTree: vi.fn().mockReturnValue(tree),
-        getLeafId: vi.fn().mockReturnValue("node0001"),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Page 1/2");
-    expect(getReplyMarkupData(api)).toEqual([
-      "tree_nav_root0000",
-      "tree_nav_node0002",
-      "tree_nav_node0003",
-      "tree_nav_node0004",
-      "tree_nav_node0005",
-      "tree_nav_node0006",
-      "noop_page",
-      "tree_page_1",
-      "tree_mode_all",
-      "tree_mode_user",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
-    expect(api.editMessageText.mock.calls[0]?.[2]).toContain("Page 2/2");
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "tree_nav_node0007",
-      "tree_page_0",
-      "noop_page",
-      "tree_mode_all",
-      "tree_mode_user",
-    ]);
-  });
-
-  it("keeps the selected tree mode when paging", async () => {
-    const tree = generatePagedTree(8);
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        getTree: vi.fn().mockReturnValue(tree),
-        getLeafId: vi.fn().mockReturnValue("node0001"),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/tree all" } }));
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Filter: all entries with navigation buttons.");
-    expect(getReplyMarkupData(api)).toEqual([
-      "tree_nav_root0000",
-      "tree_nav_node0001",
-      "tree_nav_node0002",
-      "tree_nav_node0003",
-      "tree_nav_node0004",
-      "tree_nav_node0005",
-      "noop_page",
-      "tree_page_1",
-      "tree_mode_default",
-      "tree_mode_user",
-    ]);
-
-    await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
-    expect(api.editMessageText.mock.calls[0]?.[2]).toContain("Filter: all entries with navigation buttons.");
-    expect(getEditedReplyMarkupButtons(api).map((button) => button.callback_data)).toEqual([
-      "tree_nav_node0006",
-      "tree_nav_node0007",
-      "tree_page_0",
-      "noop_page",
-      "tree_mode_default",
-      "tree_mode_user",
-    ]);
-  });
-
-  it("handles /branch command success and validation", async () => {
-    const usage = setupBot();
-    await usage.bot.handleUpdate(createTestUpdate({ message: { text: "/branch" } }));
-    expect(usage.api.sendMessage.mock.calls[0]?.[1]).toContain("Usage: /branch &lt;entry-id&gt;");
-
-    const missing = setupBot();
-    await missing.bot.handleUpdate(createTestUpdate({ message: { text: "/branch missing" } }));
-    expect(missing.api.sendMessage.mock.calls[0]?.[1]).toContain("Entry not found: missing");
-
-    const sameLeaf = setupBot();
-    await sameLeaf.bot.handleUpdate(createTestUpdate({ message: { text: "/branch leaf1234" } }));
-    expect(sameLeaf.api.sendMessage.mock.calls[0]?.[1]).toContain("already at this point");
-
-    const ok = setupBot();
-    await ok.bot.handleUpdate(createTestUpdate({ message: { text: "/branch branch111" } }));
-    expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("Navigate to this point?");
-    expect(getReplyMarkupData(ok.api)).toEqual(["tree_go_branch111", "tree_sum_branch111", "tree_cancel"]);
-  });
-
-  it("handles /label command flows", async () => {
-    const show = setupBot();
-    await show.bot.handleUpdate(createTestUpdate({ message: { text: "/label" } }));
-    expect(show.api.sendMessage.mock.calls[0]?.[1]).toContain("saved");
-
-    const current = setupBot();
-    await current.bot.handleUpdate(createTestUpdate({ message: { text: "/label checkpoint" } }));
-    expect(current.pi.service.setLabel).toHaveBeenCalledWith("leaf1234", "checkpoint");
-    expect(current.api.sendMessage.mock.calls[0]?.[1]).toContain("current leaf");
-
-    const specific = setupBot();
-    await specific.bot.handleUpdate(createTestUpdate({ message: { text: "/label branch111 origin" } }));
-    expect(specific.pi.service.setLabel).toHaveBeenCalledWith("branch111", "origin");
-    expect(specific.api.sendMessage.mock.calls[0]?.[1]).toContain("set on");
-
-    const clear = setupBot();
-    await clear.bot.handleUpdate(createTestUpdate({ message: { text: "/label clear branch111" } }));
-    expect(clear.pi.service.setLabel).toHaveBeenCalledWith("branch111", "");
-    expect(clear.api.sendMessage.mock.calls[0]?.[1]).toContain("Label cleared");
-
-    const unknown = setupBot({
-      piSessionOverrides: {
-        getEntry: vi.fn().mockReturnValue(undefined),
-      },
-    });
-    await unknown.bot.handleUpdate(createTestUpdate({ message: { text: "/label clear nope" } }));
-    expect(unknown.api.sendMessage.mock.calls[0]?.[1]).toContain("Entry not found: nope");
-  });
-
-  it("handles tree callback queries", async () => {
-    const nav = setupBot();
-    await nav.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    expect(nav.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Loading..." });
-    expect(nav.api.editMessageText.mock.calls[0]?.[2]).toContain("Navigate to this point?");
-
-    // tree_go_ requires prior tree_nav_ confirmation (pendingTreeNavs)
-    const go = setupBot();
-    // First trigger nav to set pending state
-    await go.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    go.api.answerCallbackQuery.mockClear();
-    go.api.editMessageText.mockClear();
-    // Now confirm navigate
-    await go.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
-    expect(go.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Navigating..." });
-    expect(go.pi.service.navigateTree).toHaveBeenCalledWith("branch111");
-    expect(go.api.editMessageText.mock.calls[0]?.[2]).toContain("✅ Navigated to");
-
-    // tree_go_ without prior nav shows "expired"
-    const goExpired = setupBot();
-    await goExpired.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
-    expect(goExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Confirmation expired. Use /branch again.",
-    });
-
-    // tree_go_ with navigation error
-    const goFail = setupBot({
-      piSessionOverrides: {
-        navigateTree: vi.fn().mockRejectedValue(new Error("nav failed")),
-      },
-    });
-    await goFail.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    goFail.api.editMessageText.mockClear();
-    await goFail.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
-    expect(goFail.api.editMessageText.mock.calls[0]?.[2]).toContain("nav failed");
-
-    // tree_sum_ requires prior tree_nav_ confirmation
-    const sum = setupBot();
-    await sum.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    sum.api.answerCallbackQuery.mockClear();
-    sum.api.editMessageText.mockClear();
-    await sum.bot.handleUpdate(createCallbackUpdate("tree_sum_branch111"));
-    expect(sum.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Navigating with summary...",
-    });
-    expect(sum.pi.service.navigateTree).toHaveBeenCalledWith("branch111", { summarize: true });
-    expect(sum.api.editMessageText.mock.calls[0]?.[2]).toContain("Branch summary saved");
-
-    // tree_sum_ without prior nav shows "expired"
-    const sumExpired = setupBot();
-    await sumExpired.bot.handleUpdate(createCallbackUpdate("tree_sum_branch111"));
-    expect(sumExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Confirmation expired. Use /branch again.",
-    });
-
-    // tree_go_ with cancelled navigation
-    const goCancelled = setupBot({
-      piSessionOverrides: {
-        navigateTree: vi.fn().mockResolvedValue({ cancelled: true }),
-      },
-    });
-    await goCancelled.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    goCancelled.api.editMessageText.mockClear();
-    await goCancelled.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
-    expect(goCancelled.api.editMessageText.mock.calls[0]?.[2]).toContain("Navigation cancelled.");
-
-    const cancel = setupBot();
-    await cancel.bot.handleUpdate(createCallbackUpdate("tree_cancel"));
-    expect(cancel.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Cancelled" });
-    expect(cancel.api.editMessageText.mock.calls[0]?.[2]).toContain("Navigation cancelled.");
-
-    const mode = setupBot();
-    await mode.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    mode.api.editMessageText.mockClear();
-    await mode.bot.handleUpdate(createCallbackUpdate("tree_mode_user"));
-    expect(mode.api.editMessageText.mock.calls[0]?.[2]).toContain("Filter: user messages only.");
-
-    const modeExpired = setupBot();
-    await modeExpired.bot.handleUpdate(createCallbackUpdate("tree_mode_user"));
-    expect(modeExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /tree again",
-    });
-  });
-
-  it("processes plain text messages and subscribes to Pi events", async () => {
-    const { bot, pi, api } = setupBot({
-      configOverrides: { toolVerbosity: "all" },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.emitTextDelta("Hello ");
-      pi.emitTextDelta("world");
-      pi.emitToolStart("bash", "tool-1");
-      pi.emitToolUpdate("tool-1", "stdout\nline");
-      pi.emitToolEnd("tool-1", false);
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "continue please" } }));
-
-    expect(pi.service.subscribe).toHaveBeenCalledTimes(1);
-    expect(pi.service.prompt).toHaveBeenCalledWith("continue please");
-    expect(api.sendChatAction).toHaveBeenCalled();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Hello"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Running:"))).toBe(true);
-    expect(
-      api.editMessageText.mock.calls.some((call) => String(call[2]).includes("Hello world")),
-    ).toBe(true);
-  });
-
-  it("bridges discovered Pi slash commands into the prompt flow", async () => {
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/compact focus recent work" } }));
-
-    expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
-    expect(pi.service.prompt).toHaveBeenCalledWith("/compact focus recent work");
-  });
-
-  it("bridges /cron status through TelePi and surfaces the extension notification", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("cron", [
-            { id: "list", label: "📋 /cron list", commandText: "/cron list" },
-            { id: "status", label: "📊 /cron status", commandText: "/cron status" },
-            { id: "add", label: "➕ /cron add", commandText: "/cron add" },
-            { id: "manage", label: "🛠️ /cron manage", commandText: "/cron manage" },
-          ], {
-            description: "Manage PiCron schedules",
-          }),
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.getExtensionBindings()?.uiContext?.notify("Daemon: running\nSchedules: 1\nEnabled: 1\nNext due: 2026-01-01T09:00:00.000Z", "info");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/cron status" } }));
-    await nextTick();
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("/cron status");
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Daemon: running"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Schedules: 1"))).toBe(true);
-  });
-
-  it("opens a native TelePi menu for bare slash commands declared via metadata", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("deploy", [
-            { id: "preview", label: "🧪 /deploy preview", commandText: "/deploy preview" },
-            { id: "status", label: "📊 /deploy status", commandText: "/deploy status" },
-            { id: "prod", label: "🚀 /deploy prod", commandText: "/deploy prod" },
-          ], {
-            description: "Deployment shortcuts",
-          }),
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
-
-    expect(pi.service.prompt).not.toHaveBeenCalled();
-    expect(api.sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(api.sendMessage.mock.calls[0]?.[1])).toContain("/deploy");
-    expect(getReplyMarkupTexts(api)).toEqual([
-      "🧪 /deploy preview",
-      "📊 /deploy status",
-      "🚀 /deploy prod",
-    ]);
-    expect(getReplyMarkupData(api).every((callbackData) => /^cmdm_[a-z0-9]+$/.test(callbackData))).toBe(true);
-    expect(new Set(getReplyMarkupData(api)).size).toBe(3);
-    expect(getReplyMarkupData(api).every((callbackData) => callbackData.length < 64)).toBe(true);
-  });
-
-  it("drives bare /cron native menus from real PiCron extension metadata across repos", async () => {
-    const slashCommands = await loadPiCronSlashCommands();
-    const cronCommand = slashCommands.find((command) => command.name === "cron");
-
-    expect(cronCommand).toMatchObject({
-      name: "cron",
-      description: "Manage PiCron schedules",
-      integrations: {
-        telepi: {
-          bare: {
-            kind: "native-menu",
-            entries: [
-              { id: "picron.cron.list", label: "List schedules", commandText: "/cron list" },
-              { id: "picron.cron.status", label: "Show status", commandText: "/cron status" },
-              { id: "picron.cron.add", label: "Add schedule", commandText: "/cron add" },
-              { id: "picron.cron.manage", label: "Manage schedules", commandText: "/cron manage" },
-            ],
-          },
-        },
-      },
-    });
-
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue(slashCommands),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/cron" } }));
-
-    expect(pi.service.prompt).not.toHaveBeenCalled();
-    expect(api.sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(api.sendMessage.mock.calls[0]?.[1])).toContain("/cron");
-
-    const labels = getReplyMarkupTexts(api);
-    expect(labels).toEqual([
-      "List schedules",
-      "Show status",
-      "Add schedule",
-      "Manage schedules",
-    ]);
-
-    const showStatusCallbackData = getReplyMarkupData(api)[labels.indexOf("Show status")];
-    expect(showStatusCallbackData).toMatch(/^cmdm_[a-z0-9]+$/);
-
-    await bot.handleUpdate(createCallbackUpdate(showStatusCallbackData!));
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Running /cron status" });
-    expect(pi.service.prompt).toHaveBeenCalledWith("/cron status");
-  });
-
-  it("dispatches generic command-menu callbacks through the normal prompt flow", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("deploy", [
-            { id: "preview", label: "🧪 /deploy preview", commandText: "/deploy preview" },
-            { id: "status", label: "📊 /deploy status", commandText: "/deploy status" },
-          ]),
-        ]),
-      },
-    });
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
-    const callbackData = getReplyMarkupData(api)[1]!;
-
-    promptMock.mockImplementation(async (promptText: string) => {
-      expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Running /deploy status" });
-      expect(promptText).toBe("/deploy status");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createCallbackUpdate(callbackData));
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Running /deploy status" });
-    expect(pi.service.prompt).toHaveBeenCalledWith("/deploy status");
-  });
-
-  it("detaches command-menu prompt callbacks so extension dialog callbacks stay responsive", async () => {
-    let resolvePrompt!: () => void;
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("deploy", [
-            { id: "manage", label: "🛠️ /deploy manage", commandText: "/deploy manage" },
-            { id: "status", label: "📊 /deploy status", commandText: "/deploy status" },
-          ]),
-        ]),
-      },
-    });
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-
-    promptMock.mockImplementation(async (promptText: string) => {
-      expect(promptText).toBe("/deploy manage");
-      const choice = await pi.getExtensionBindings()?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
-      pi.emitTextDelta(`picked ${choice}`);
-      await new Promise<void>((resolve) => {
-        resolvePrompt = resolve;
-      });
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
-    const callbackData = getReplyMarkupData(api)[0]!;
-
-    let callbackHandled = false;
-    const pendingCallback = bot.handleUpdate(createCallbackUpdate(callbackData));
-    void pendingCallback.then(() => {
-      callbackHandled = true;
-    });
-
-    await nextTick();
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Running /deploy manage" });
-    expect(pi.service.prompt).toHaveBeenCalledWith("/deploy manage");
-    expect(callbackHandled).toBe(true);
-
-    const selectCallback = api.sendMessage.mock.calls
-      .flatMap((call) => call[2]?.reply_markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [])
-      .find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
-    expect(selectCallback).toBeTruthy();
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(
-      createCallbackUpdate(selectCallback!, {
-        callback_query: {
-          message: {
-            message_id: 2,
-          },
-        },
-      }),
-    );
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Selected Beta" });
-    expect(api.editMessageText.mock.calls.some((call) => String(call[2]).includes("Selected: Beta"))).toBe(true);
-
-    resolvePrompt();
-    await nextTick();
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("picked Beta"))).toBe(true);
-  });
-
-  it("detaches text prompt handling from the Telegram update lifetime", async () => {
-    let resolvePrompt!: () => void;
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () =>
-            new Promise<void>((resolve) => {
-              resolvePrompt = resolve;
-            }),
-        ),
-      },
-    });
-
-    let updateHandled = false;
-    const pendingUpdate = bot.handleUpdate(createTestUpdate({ message: { text: "hello" } }));
-    void pendingUpdate.then(() => {
-      updateHandled = true;
-    });
-
-    await nextTick();
-
-    expect(updateHandled).toBe(true);
-    expect(pi.service.prompt).toHaveBeenCalledWith("hello");
-
-    resolvePrompt();
-    await nextTick();
-  });
-
-  it("fails fast for generic command-menu callbacks while a prompt is already in flight", async () => {
-    let resolvePrompt!: () => void;
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("deploy", [
-            { id: "preview", label: "🧪 /deploy preview", commandText: "/deploy preview" },
-            { id: "status", label: "📊 /deploy status", commandText: "/deploy status" },
-          ]),
-        ]),
-        prompt: vi.fn().mockImplementation(
-          () =>
-            new Promise<void>((resolve) => {
-              resolvePrompt = resolve;
-            }),
-        ),
-      },
-    });
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
-    const callbackData = getReplyMarkupData(api)[0]!;
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "hello" } }));
-    await nextTick();
-
-    expect(promptMock).toHaveBeenCalledTimes(1);
-
-    api.answerCallbackQuery.mockClear();
-    const sendMessageCalls = api.sendMessage.mock.calls.length;
-
-    await bot.handleUpdate(createCallbackUpdate(callbackData));
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Wait for the current prompt to finish",
-    });
-    expect(api.answerCallbackQuery).not.toHaveBeenCalledWith("cb_1", { text: "Running /deploy preview" });
-    expect(api.sendMessage).toHaveBeenCalledTimes(sendMessageCalls);
-    expect(promptMock).toHaveBeenCalledTimes(1);
-
-    resolvePrompt();
-    await pending;
-  });
-
-  it("falls back to forwarding bare slash commands when native menu metadata is missing or invalid", async () => {
-    for (const slashCommands of [
-      [makeSlashCommand("deploy", { description: "Deploy app" })],
-      [
-        makeTelepiBareNativeMenuSlashCommand("deploy", [
-          { id: "preview", label: "", commandText: "/deploy preview" },
-        ]),
-      ],
-    ]) {
-      const { bot, pi } = setupBot({
-        piSessionOverrides: {
-          listSlashCommands: vi.fn().mockResolvedValue(slashCommands),
-        },
-      });
-
-      await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
-
-      expect(pi.service.prompt).toHaveBeenCalledWith("/deploy");
-    }
-  });
-
-  it("passes schedule-like plain text through unchanged instead of applying cron-specific rewrites", async () => {
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          makeTelepiBareNativeMenuSlashCommand("cron", [
-            { id: "picron.cron.list", label: "List schedules", commandText: "/cron list" },
-            { id: "picron.cron.status", label: "Show status", commandText: "/cron status" },
-          ], {
-            description: "Manage PiCron schedules",
-          }),
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "list schedules" } }));
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("list schedules");
-  });
-
-  it("drives a /cron add style multi-step extension dialog flow through TelePi replies", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "cron", description: "Manage PiCron schedules", source: "extension", path: "/ext/picron.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const ui = pi.getExtensionBindings()?.uiContext;
-      const name = await ui?.input("Schedule name", "Daily review");
-      const cron = await ui?.input("Cron expression", "0 9 * * *");
-      const timezone = await ui?.input("Timezone", "UTC");
-      const prompt = await ui?.input("Prompt", "Review the repo");
-      const cwd = await ui?.input("Target cwd (optional)", "/workspace/current");
-      const sessionFile = await ui?.input("Target session file (optional)", "session.jsonl");
-      ui?.notify(`Created schedule ${name} (${cron}, ${timezone}, ${prompt}, ${cwd}, ${sessionFile}).`, "info");
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/cron add" } }));
-    await nextTick();
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Schedule name"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "Daily review" } }));
-    await nextTick();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Cron expression"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "0 9 * * *" } }));
-    await nextTick();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Timezone"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "UTC" } }));
-    await nextTick();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Prompt"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "Review the repo" } }));
-    await nextTick();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Target cwd (optional)"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/workspace/current" } }));
-    await nextTick();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Target session file (optional)"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "session.jsonl" } }));
-    await pending;
-    await nextTick();
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("/cron add");
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Created schedule Daily review"))).toBe(true);
-  });
-
-  it("normalizes bot-addressed Pi slash commands before bridging them", async () => {
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/compact@telepi_test_bot focus recent work" } }));
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("/compact focus recent work");
-  });
-
-  it("ignores slash commands addressed to another bot", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/compact@another_bot focus recent work" } }));
-
-    expect(pi.service.prompt).not.toHaveBeenCalled();
-    expect(api.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it("does not bridge unknown slash commands and shows a helpful reply", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/ignored" } }));
-
-    expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
-    expect(pi.service.prompt).not.toHaveBeenCalled();
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Unknown command"))).toBe(true);
-  });
-
-  it("shows /commands as a paginated picker with TelePi and Pi filters", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-          { name: "review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-          { name: "skill:browser-tools", description: "Browser automation", source: "skill", path: "/skills/browser.md" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-
-    expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Command picker"))).toBe(true);
-    expect(getReplyMarkupData(api)).toContain("cmd_page_1");
-    expect(getReplyMarkupData(api)).toContain("cmd_filter_all");
-    expect(getReplyMarkupData(api)).toContain("cmd_filter_telepi");
-    expect(getReplyMarkupData(api)).toContain("cmd_filter_pi");
-
-    await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
-
-    expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain("/compact");
-    expect(getEditedReplyMarkupTexts(api, 0)).toContain("🧩 /compact");
-    expect(getEditedReplyMarkupTexts(api, 0)).toContain("📝 /review");
-    expect(getEditedReplyMarkupTexts(api, 0)).toContain("🧰 /skill:browser-tools");
-
-    await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
-
-    expect(String(api.editMessageText.mock.calls[1]?.[2])).toContain("/compact");
-    expect(getEditedReplyMarkupTexts(api, 1)).toContain("🧩 /compact");
-    expect(getEditedReplyMarkupTexts(api, 1)).toContain("📝 /review");
-    expect(getEditedReplyMarkupTexts(api, 1)).toContain("🧰 /skill:browser-tools");
-    expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_all");
-    expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_telepi");
-    expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_pi");
-  });
-
-  it("runs TelePi commands from the /commands picker", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    const helpButton = getReplyMarkupButtons(api).find((button) => button.text.includes("/help"));
-
-    expect(helpButton).toBeDefined();
-
-    await bot.handleUpdate(createCallbackUpdate(helpButton!.callback_data));
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Each Telegram chat/topic has its own Pi session and retry history."))).toBe(true);
-  });
-
-  it("runs Pi commands from the /commands picker", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
-    const compactButton = getEditedReplyMarkupButtons(api, 0).find((button) => button.text.includes("/compact"));
-
-    expect(compactButton).toBeDefined();
-
-    await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("/compact");
-  });
-
-  it("shows prompt argument hints in /commands without changing Pi command dispatch", async () => {
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-command-picker-"));
-    const promptPath = path.join(tempDir, "review.md");
-    writeFileSync(
-      promptPath,
-      [
-        "---",
-        "description: Review staged changes",
-        'argument-hint: "<PR-URL>"',
-        "---",
-        "Review changes.",
-        "",
-      ].join("\n"),
-    );
-
-    try {
-      const { bot, pi, api } = setupBot({
-        piSessionOverrides: {
-          listSlashCommands: vi.fn().mockResolvedValue([
-            {
-              name: "review",
-              description: "Review staged changes",
-              source: "prompt",
-              sourceInfo: { path: promptPath, source: "local", scope: "project", origin: "top-level" },
-            },
-          ]),
-        },
-      });
-
-      await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-      await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
-
-      expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain("/review &lt;PR-URL&gt;");
-      expect(getEditedReplyMarkupTexts(api, 0)).toContain("📝 /review <PR-URL>");
-
-      const reviewButton = getEditedReplyMarkupButtons(api, 0).find((button) => button.text.includes("/review <PR-URL>"));
-      expect(reviewButton).toBeDefined();
-
-      await bot.handleUpdate(createCallbackUpdate(reviewButton!.callback_data));
-
-      expect(pi.service.prompt).toHaveBeenCalledWith("/review");
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps the /commands picker active when a Pi command is tapped while busy", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        isStreaming: vi.fn().mockReturnValueOnce(true).mockReturnValue(false),
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
-    const compactButton = getEditedReplyMarkupButtons(api, 0).find((button) => button.text.includes("/compact"));
-
-    expect(compactButton).toBeDefined();
-
-    await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Wait for the current prompt to finish" });
-    expect(pi.service.prompt).not.toHaveBeenCalled();
-
-    await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
-    expect(pi.service.prompt).toHaveBeenCalledWith("/compact");
-  });
-
-  it("shows an empty-state Pi filter when no Pi commands are discovered", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
-
-    expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain("No Pi commands found in this session.");
-    expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_all");
-    expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_telepi");
-    expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_pi");
-  });
-
-  it("surfaces /commands discovery failures", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockRejectedValue(new Error("extensions unavailable")),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Failed to load commands"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("extensions unavailable"))).toBe(true);
-  });
-
-  it("syncs chat-scoped Telegram commands for registerable Pi slash commands", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-          { name: "review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-          { name: "skill:browser-tools", description: "Browser automation", source: "skill", path: "/skills/browser.md" },
-          { name: "switch", description: "Should not override TelePi switch", source: "extension", path: "/ext/switch.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-
-    const scoped = getSetMyCommandsCall(api, 0);
-    expect(scoped?.scope).toEqual({ type: "chat", chat_id: ALLOWED_CHAT_ID });
-    expect(scoped?.commands.some((command) => command.command === "compact")).toBe(true);
-    expect(scoped?.commands.some((command) => command.command === "review")).toBe(true);
-    expect(scoped?.commands.some((command) => command.command === "skill:browser-tools")).toBe(false);
-    expect(scoped?.commands.some((command) => command.command === "switch" && command.description.startsWith("Pi:"))).toBe(false);
-  });
-
-  it("avoids redundant scoped Telegram command sync when the command set is unchanged", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-
-    expect(api.setMyCommands).toHaveBeenCalledTimes(1);
-  });
-
-  it("replaces chat-scoped Telegram commands when the discovered Pi commands change", async () => {
-    const listSlashCommands = vi.fn()
-      .mockResolvedValueOnce([
-        { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-      ])
-      .mockResolvedValueOnce([]);
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands,
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/commands" } }));
-
-    expect(api.setMyCommands).toHaveBeenCalledTimes(2);
-    expect(getSetMyCommandsCall(api, 0)?.commands.some((command) => command.command === "compact")).toBe(true);
-    expect(getSetMyCommandsCall(api, 1)?.commands.some((command) => command.command === "compact")).toBe(false);
-  });
-
-  it("forwards runtime-backed new-session options from extension command actions", async () => {
-    const { bot, pi } = setupBot();
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      await pi.getExtensionBindings()?.commandContextActions?.newSession({
-        parentSession: "/tmp/handoff-parent.jsonl",
-        withSession,
-      });
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "prepare a handoff" } }));
-
-    expect(pi.service.newSession).toHaveBeenCalledWith({
-      parentSession: "/tmp/handoff-parent.jsonl",
-      withSession,
-    });
-  });
-
-  it("forwards runtime-backed fork options from extension command actions", async () => {
-    const { bot, pi } = setupBot();
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      await pi.getExtensionBindings()?.commandContextActions?.fork("leaf1234", {
-        position: "before",
-        withSession,
-      });
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "fork from extension" } }));
-
-    expect(pi.service.fork).toHaveBeenCalledWith("leaf1234", {
-      position: "before",
-      withSession,
-    });
-  });
-
-  it("bubbles cancelled switch-session results from extension command actions", async () => {
-    const { bot, pi } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockResolvedValue({
-          sessionId: "test-id",
-          sessionFile: "/tmp/test.jsonl",
-          workspace: "/workspace",
-          model: "anthropic/claude-sonnet-4-5",
-          cancelled: true,
-        }),
-      },
-    });
-    const withSession = vi.fn().mockResolvedValue(undefined);
-    let switchResult: { cancelled: boolean } | undefined;
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      switchResult = await pi.getExtensionBindings()?.commandContextActions?.switchSession("/tmp/other.jsonl", {
-        withSession,
-      });
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "switch from extension" } }));
-
-    expect(pi.service.switchSession).toHaveBeenCalledWith("/tmp/other.jsonl", { withSession });
-    expect(switchResult).toEqual({ cancelled: true });
-  });
-
-  it("surfaces extension command notifications in Telegram", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.getExtensionBindings()?.uiContext?.notify("No conversation to compact", "error");
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/compact" } }));
-    await nextTick();
-
-    expect(pi.service.bindExtensions).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("No conversation to compact"))).toBe(true);
-  });
-
-  it("surfaces extension command errors in Telegram", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "compact", description: "Compact context", source: "extension", path: "/ext/compact.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.getExtensionBindings()?.onError?.({
-        extensionPath: "command:compact",
-        event: "command",
-        error: "boom",
-      });
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/compact" } }));
-    await nextTick();
-
-    expect(pi.service.bindExtensions).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("/compact failed"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("boom"))).toBe(true);
-  });
-
-  it("supports extension select dialogs through Telegram callbacks", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "pick", description: "Pick an option", source: "extension", path: "/ext/pick.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const choice = await pi.getExtensionBindings()?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
-      pi.emitTextDelta(`picked ${choice}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/pick" } }));
-    await nextTick();
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Pick one"))).toBe(true);
-    const selectCallback = getReplyMarkupData(api, 0).find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
-    expect(selectCallback).toBeTruthy();
-
-    await bot.handleUpdate(createCallbackUpdate(selectCallback!));
-    await pending;
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("picked Beta"))).toBe(true);
-  });
-
-  it("supports extension select dialogs when forum callbacks omit the topic thread id", async () => {
-    const topicKey = makeContextKey(ALLOWED_CHAT_ID, 101);
-    const { bot, api, registry } = setupBot({
-      perContextSessionOverrides: {
-        [topicKey]: {
-          listSlashCommands: vi.fn().mockResolvedValue([
-            { name: "pick", description: "Pick an option", source: "extension", path: "/ext/pick.ts" },
-          ]),
-        },
-      },
-    });
-
-    await registry.registry.getOrCreate({ chatId: ALLOWED_CHAT_ID, messageThreadId: 101 });
-    const topicPi = registry.getSession(ALLOWED_CHAT_ID, 101)!;
-    const promptMock = topicPi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const choice = await topicPi.getExtensionBindings()?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
-      topicPi.emitTextDelta(`picked ${choice}`);
-      topicPi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(
-      createTestUpdate({
-        message: {
-          text: "/pick",
-          chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          message_thread_id: 101,
-        },
-      }),
-    );
-    await nextTick();
-
-    const selectCallback = api.sendMessage.mock.calls
-      .flatMap((call) => call[2]?.reply_markup?.inline_keyboard?.flat().map((button: any) => button.callback_data) ?? [])
-      .find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
-    expect(selectCallback).toBeTruthy();
-
-    await bot.handleUpdate(
-      createCallbackUpdate(selectCallback!, {
-        callback_query: {
-          message: {
-            chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-          },
-        },
-      }),
-    );
-    await pending;
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Selected Beta" });
-    expect(api.sendMessage.mock.calls.some(
-      (call) => String(call[1]).includes("picked Beta") && call[2]?.message_thread_id === 101,
-    )).toBe(true);
-  });
-
-  it("still resolves extension dialog callbacks when Telegram rejects answerCallbackQuery", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "pick", description: "Pick an option", source: "extension", path: "/ext/pick.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const choice = await pi.getExtensionBindings()?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
-      pi.emitTextDelta(`picked ${choice}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/pick" } }));
-    await nextTick();
-
-    const selectCallback = getReplyMarkupData(api, 0).find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
-    expect(selectCallback).toBeTruthy();
-
-    api.answerCallbackQuery.mockRejectedValueOnce(new Error("query too old"));
-    await bot.handleUpdate(createCallbackUpdate(selectCallback!));
-    await pending;
-
-    expect(api.editMessageText.mock.calls.some((call) => String(call[2]).includes("Selected: Beta"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("picked Beta"))).toBe(true);
-  });
-
-  it("supports extension confirm dialogs through Telegram callbacks", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "confirm", description: "Confirm action", source: "extension", path: "/ext/confirm.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const confirmed = await pi.getExtensionBindings()?.uiContext?.confirm("Confirm deploy", "Ship it?");
-      pi.emitTextDelta(`confirmed ${confirmed}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/confirm" } }));
-    await nextTick();
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Confirm deploy"))).toBe(true);
-    const confirmCallback = getReplyMarkupData(api, 0).find((data) => data?.endsWith("_yes"));
-    expect(confirmCallback).toBeTruthy();
-
-    await bot.handleUpdate(createCallbackUpdate(confirmCallback!));
-    await pending;
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("confirmed true"))).toBe(true);
-  });
-
-  it("supports extension confirm dialogs when Telegram omits callback message ids", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "confirm", description: "Confirm action", source: "extension", path: "/ext/confirm.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const confirmed = await pi.getExtensionBindings()?.uiContext?.confirm("Confirm deploy", "Ship it?");
-      pi.emitTextDelta(`confirmed ${confirmed}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/confirm" } }));
-    await nextTick();
-
-    const confirmCallback = getReplyMarkupData(api, 0).find((data) => data?.endsWith("_yes"));
-    expect(confirmCallback).toBeTruthy();
-
-    await bot.handleUpdate(
-      createCallbackUpdate(confirmCallback!, {
-        callback_query: {
-          message: {
-            message_id: undefined,
-          },
-        },
-      }),
-    );
-    await pending;
-
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Confirmed" });
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("confirmed true"))).toBe(true);
-  });
-
-  it("supports extension input dialogs through Telegram replies", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "ask", description: "Ask for input", source: "extension", path: "/ext/ask.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const value = await pi.getExtensionBindings()?.uiContext?.input("Name", "Your name");
-      pi.emitTextDelta(`hello ${value}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/ask" } }));
-    await nextTick();
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Name"))).toBe(true);
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "Bene" } }));
-    await pending;
-
-    expect(pi.service.prompt).toHaveBeenCalledTimes(1);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("hello Bene"))).toBe(true);
-  });
-
-  it("times out pending extension dialogs and finalizes them in Telegram", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "pick", description: "Pick an option", source: "extension", path: "/ext/pick.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const choice = await pi.getExtensionBindings()?.uiContext?.select("Pick one", ["Alpha", "Beta"], { timeout: 5 });
-      pi.emitTextDelta(`picked ${choice}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/pick" } }));
-    await nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    await pending;
-
-    expect(api.editMessageText.mock.calls.some((call) => String(call[2]).includes("Dialog timed out."))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("picked undefined"))).toBe(true);
-  });
-
-  it("cancels pending extension dialogs via /abort and still aborts the session", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "confirm", description: "Confirm action", source: "extension", path: "/ext/confirm.ts" },
-        ]),
-      },
-    });
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      const confirmed = await pi.getExtensionBindings()?.uiContext?.confirm("Confirm deploy", "Ship it?");
-      pi.emitTextDelta(`confirmed ${confirmed}`);
-      pi.emitAgentEnd();
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/confirm" } }));
-    await nextTick();
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/abort" } }));
-    await pending;
-
-    expect(pi.service.abort).toHaveBeenCalledTimes(1);
-    expect(api.editMessageText.mock.calls.some((call) => String(call[2]).includes("Dialog cancelled."))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("confirmed false"))).toBe(true);
-  });
-
-  it("blocks voice messages while an extension input dialog is pending", async () => {
-    const { bot, pi, api } = setupBot({
-      piSessionOverrides: {
-        listSlashCommands: vi.fn().mockResolvedValue([
-          { name: "ask", description: "Ask for input", source: "extension", path: "/ext/ask.ts" },
-        ]),
-      },
-    });
-
-    let resolveInput!: (value: void | PromiseLike<void>) => void;
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      await new Promise<void>(async (resolve) => {
-        resolveInput = resolve;
-        const value = await pi.getExtensionBindings()?.uiContext?.input("Name", "Your name");
-        pi.emitTextDelta(`hello ${value}`);
-        pi.emitAgentEnd();
-        resolve();
-      });
-    });
-
-    const pending = bot.handleUpdate(createTestUpdate({ message: { text: "/ask" } }));
-    await nextTick();
-    await bot.handleUpdate(createVoiceUpdate());
-
-    expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain("Please answer the pending prompt above or use /abort.");
-    expect(transcribeAudio).not.toHaveBeenCalled();
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "Bene" } }));
-    resolveInput();
-    await pending;
-  });
-
-  it("transcribes voice messages and feeds the transcript into the prompt flow", async () => {
-    const { bot, pi, api } = setupBot();
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.emitTextDelta("Voice response");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createVoiceUpdate());
-
-    expect(api.getFile).toHaveBeenCalledWith("voice-file-id");
-    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
-      "https://api.telegram.org/file/botbot-token/voice/file.ogg",
-    );
-    expect(transcribeAudio).toHaveBeenCalledTimes(1);
-    expect(pi.service.prompt).toHaveBeenCalledWith("transcribed text");
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("🎤 transcribed text"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Voice response"))).toBe(true);
-    expect(writeFile).toHaveBeenCalledTimes(1);
-    expect(unlink).toHaveBeenCalledTimes(1);
-  });
-
-  it("handles photo messages by sending caption + image input to Pi", async () => {
-    const { bot, pi, api } = setupBot();
-    api.getFile.mockImplementation(async (fileId: string) => ({
-      file_id: fileId,
-      file_path: fileId === "photo-big" ? "images/photo-big.jpg" : "images/photo-small.jpg",
-    }));
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.emitTextDelta("Image response");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createPhotoUpdate());
-
-    expect(api.getFile).toHaveBeenCalledWith("photo-big");
-    expect(pi.service.prompt).toHaveBeenCalledWith("Check this graph", [
-      {
-        type: "image",
-        data: Buffer.from("image-bytes").toString("base64"),
-        mimeType: "image/jpeg",
-      },
-    ]);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("🖼️ Check this graph"))).toBe(true);
-    expect(unlink).toHaveBeenCalledTimes(1);
-  });
-
-  it("handles image documents and ignores non-image documents", async () => {
-    const { bot, pi, api } = setupBot();
-    api.getFile.mockImplementation(async (fileId: string) => ({
-      file_id: fileId,
-      file_path: "docs/diagram.png",
-    }));
-
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      pi.emitTextDelta("Document image response");
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createDocumentUpdate({ message: { caption: undefined } }));
-
-    expect(pi.service.prompt).toHaveBeenCalledWith("Please analyze this image.", [
-      {
-        type: "image",
-        data: Buffer.from("image-bytes").toString("base64"),
-        mimeType: "image/png",
-      },
-    ]);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Please analyze this image."))).toBe(true);
-
-    await bot.handleUpdate(createDocumentUpdate({
-      message: {
-        document: {
-          file_id: "document-text-id",
-          file_unique_id: "document-text-unique",
-          file_name: "notes.txt",
-          mime_type: "text/plain",
-          file_size: 128,
-        },
-      },
-    }));
-
-    expect(api.getFile).not.toHaveBeenCalledWith("document-text-id");
-    expect(pi.service.prompt).toHaveBeenCalledTimes(1);
-  });
-
-  it("blocks voice messages while processing and reports transcription failures", async () => {
-    let resolvePrompt!: () => void;
-    const busy = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () =>
-            new Promise<void>((resolve) => {
-              resolvePrompt = resolve;
-            }),
-        ),
-      },
-    });
-
-    const pending = busy.bot.handleUpdate(createTestUpdate({ message: { text: "first" } }));
-    await nextTick();
-    await busy.bot.handleUpdate(createVoiceUpdate());
-
-    expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain("Still working on previous message...");
-    expect(transcribeAudio).not.toHaveBeenCalled();
-
-    resolvePrompt();
-    await pending;
-
-    vi.mocked(transcribeAudio).mockRejectedValueOnce(new Error("backend missing"));
-    const failure = setupBot();
-    await failure.bot.handleUpdate(createVoiceUpdate());
-
-    expect(failure.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Transcription failed:"))).toBe(
-      true,
-    );
-    expect(failure.pi.service.prompt).not.toHaveBeenCalled();
-    expect(unlink).toHaveBeenCalled();
-  });
-
-  it("auto-creates a session for audio files before prompting", async () => {
-    const noSession = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-      },
-    });
-    const promptMock = noSession.pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      noSession.pi.emitTextDelta("Audio response");
-      noSession.pi.emitAgentEnd();
-    });
-
-    await noSession.bot.handleUpdate(
-      createVoiceUpdate({
-        message: {
-          voice: undefined,
-          audio: {
-            file_id: "audio-file-id",
-            file_unique_id: "audio-unique",
-            duration: 6,
-            mime_type: "audio/ogg",
-            file_name: "clip.ogg",
-          },
-        },
-      }),
-    );
-
-    expect(noSession.api.getFile).toHaveBeenCalledWith("audio-file-id");
-    expect(noSession.pi.service.newSession).toHaveBeenCalledTimes(1);
-    expect(noSession.pi.service.prompt).toHaveBeenCalledWith("transcribed text");
-  });
-
-  it("blocks new messages while processing and auto-creates a session when needed", async () => {
-    let resolvePrompt!: () => void;
-    const busy = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () => new Promise<void>((resolve) => {
-            resolvePrompt = resolve;
-          }),
-        ),
-      },
-    });
-
-    const first = busy.bot.handleUpdate(createTestUpdate({ message: { text: "first" } }));
-    await nextTick();
-    await busy.bot.handleUpdate(createTestUpdate({ message: { text: "second" } }));
-
-    expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain("Still working on previous message...");
-
-    resolvePrompt();
-    await first;
-
-    const noSession = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-      },
-    });
-    const promptMock = noSession.pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      noSession.pi.emitTextDelta("Fresh session response");
-      noSession.pi.emitAgentEnd();
-    });
-
-    await noSession.bot.handleUpdate(createTestUpdate({ message: { text: "start over" } }));
-
-    expect(noSession.pi.service.newSession).toHaveBeenCalledTimes(1);
-    expect(noSession.pi.service.prompt).toHaveBeenCalledWith("start over");
-  });
-
-  it("blocks commands while switching sessions", async () => {
-    let resolveSwitch!: (info: SwitchResult) => void;
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockImplementation(
-          () =>
-            new Promise<SwitchResult>((resolve) => {
-              resolveSwitch = resolve;
-            }),
-        ),
-      },
-    });
-
-    const switching = bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-    await nextTick();
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-
-    expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
-      "Cannot create new session while a prompt is running.",
-    );
-
-    resolveSwitch({
-      sessionId: "switched-id",
-      sessionFile: "/tmp/switched.jsonl",
-      workspace: "/other",
-      model: "anthropic/claude-sonnet-4-5",
-      cancelled: false,
-    });
-    await switching;
-  });
-
-  it("blocks tree commands while processing or switching", async () => {
-    let resolvePrompt!: () => void;
-    const busy = setupBot({
-      piSessionOverrides: {
-        prompt: vi.fn().mockImplementation(
-          () =>
-            new Promise<void>((resolve) => {
-              resolvePrompt = resolve;
-            }),
-        ),
-      },
-    });
-
-    const pending = busy.bot.handleUpdate(createTestUpdate({ message: { text: "hello" } }));
-    await nextTick();
-    await busy.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    await busy.bot.handleUpdate(createTestUpdate({ message: { text: "/branch branch111" } }));
-    await busy.bot.handleUpdate(createTestUpdate({ message: { text: "/label mark" } }));
-    await busy.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-
-    expect(busy.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Cannot view tree while a prompt is running."))).toBe(true);
-    expect(busy.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Cannot navigate while a prompt is running."))).toBe(true);
-    expect(busy.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Cannot label entries while a prompt is running."))).toBe(true);
-    expect(busy.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Wait for the current prompt to finish",
-    });
-
-    resolvePrompt();
-    await pending;
-  });
-
-  it("surfaces startup error diagnostics once before the first prompt in a fresh context", async () => {
-    const topicKey = makeContextKey(ALLOWED_CHAT_ID, 909);
-    let registryRef: ReturnType<typeof createMockPiSessionRegistry> | undefined;
-    const prompt = vi.fn().mockImplementation(async () => {
-      const topicSession = registryRef?.getSession(ALLOWED_CHAT_ID, 909);
-      topicSession?.emitTextDelta("Fresh context response");
-      topicSession?.emitAgentEnd();
-    });
-    const harness = setupBot({
-      perContextSessionOverrides: {
-        [topicKey]: {
-          getInfo: vi.fn().mockReturnValue({
-            sessionId: "diagnostic-session",
-            sessionFile: "/tmp/diagnostic.jsonl",
-            workspace: "/workspace",
-            model: "anthropic/claude-sonnet-4-5",
-            diagnostics: [
-              { type: "error", message: 'Failed to load extension "/ext/bad.ts": boom' },
-              { type: "warning", message: "Theme issue (/themes/missing.json): theme path does not exist" },
-            ],
-          }),
-          prompt,
-        },
-      },
-    });
-    registryRef = harness.registry;
-    const { bot, api } = harness;
-
-    await bot.handleUpdate(createTestUpdate({
-      message: {
-        text: "first prompt",
-        chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-        message_thread_id: 909,
-      },
-    }));
-    await bot.handleUpdate(createTestUpdate({
-      message: {
-        text: "second prompt",
-        chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-        message_thread_id: 909,
-      },
-    }));
-
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(1);
-    expect(startupMessages[0]).toContain('Failed to load extension "/ext/bad.ts": boom');
-    expect(startupMessages[0]).not.toContain("Theme issue");
-  });
-
-  it("surfaces startup error diagnostics when /model creates a fresh session context", async () => {
-    const topicKey = makeContextKey(ALLOWED_CHAT_ID, 910);
-    const { bot, api } = setupBot({
-      perContextSessionOverrides: {
-        [topicKey]: {
-          getInfo: vi.fn().mockReturnValue({
-            sessionId: "model-diagnostic-session",
-            sessionFile: "/tmp/model-diagnostic.jsonl",
-            workspace: "/workspace",
-            model: "anthropic/claude-sonnet-4-5",
-            diagnostics: [
-              { type: "error", message: "Prompt issue (/prompts/deploy.md): invalid frontmatter" },
-            ],
-          }),
-        },
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({
-      message: {
-        text: "/model",
-        chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-        message_thread_id: 910,
-      },
-    }));
-
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Session startup issues"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Prompt issue (/prompts/deploy.md): invalid frontmatter"))).toBe(true);
-    expect(api.sendMessage.mock.calls.some((call) => String(call[1]).includes("Select a model"))).toBe(true);
-  });
-
-  it("re-surfaces startup diagnostics after /handback tears down the context", async () => {
-    const topicKey = makeContextKey(ALLOWED_CHAT_ID, 911);
-    let registryRef: ReturnType<typeof createMockPiSessionRegistry> | undefined;
-    const prompt = vi.fn().mockImplementation(async () => {
-      const session = registryRef?.getSession(ALLOWED_CHAT_ID, 911);
-      session?.emitTextDelta("Context rebuilt response");
-      session?.emitAgentEnd();
-    });
-    const harness = setupBot({
-      perContextSessionOverrides: {
-        [topicKey]: {
-          getInfo: vi.fn().mockReturnValue({
-            sessionId: "reused-diagnostic-session",
-            sessionFile: "/tmp/reused-diagnostic.jsonl",
-            workspace: "/workspace",
-            model: "anthropic/claude-sonnet-4-5",
-            diagnostics: [
-              { type: "error", message: "Extension issue (/ext/reload.ts): startup failed" },
-            ],
-          }),
-          prompt,
-        },
-      },
-    });
-    registryRef = harness.registry;
-    const { bot, api } = harness;
-    const topicMessage = (text: string) => createTestUpdate({
-      message: {
-        text,
-        chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
-        message_thread_id: 911,
-      },
-    });
-
-    await bot.handleUpdate(topicMessage("first prompt"));
-    await bot.handleUpdate(topicMessage("/handback"));
-    await bot.handleUpdate(topicMessage("second prompt"));
-
-    const startupMessages = api.sendMessage.mock.calls
-      .map((call) => String(call[1]))
-      .filter((text) => text.includes("Session startup issues"));
-    expect(startupMessages).toHaveLength(2);
-    expect(startupMessages[0]).toContain("Extension issue (/ext/reload.ts): startup failed");
-    expect(startupMessages[1]).toContain("Extension issue (/ext/reload.ts): startup failed");
-  });
-
-  it("covers additional command edge cases", async () => {
-    const noSessions = setupBot({
-      piSessionOverrides: {
-        listAllSessions: vi.fn().mockResolvedValue([]),
-      },
-    });
-    await noSessions.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    expect(noSessions.api.sendMessage.mock.calls[0]?.[1]).toContain("No saved sessions found.");
-
-    const cancelledNew = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-        newSession: vi.fn().mockResolvedValue({
-          info: {
-            sessionId: "cancelled",
-            sessionFile: "/tmp/cancelled.jsonl",
-            workspace: "/workspace/A",
-            model: "anthropic/claude-sonnet-4-5",
-          },
-          created: false,
-        }),
-      },
-    });
-    await cancelledNew.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(cancelledNew.api.sendMessage.mock.calls[0]?.[1]).toContain("New session was cancelled.");
-
-    const failedNew = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-        newSession: vi.fn().mockRejectedValue(new Error("new failed")),
-      },
-    });
-    await failedNew.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(failedNew.api.sendMessage.mock.calls[0]?.[1]).toContain("new failed");
-
-    const sameWorkspaceNewUnavailable = setupBot({
-      piSessionOverrides: {
-        listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
-        newSession: vi.fn().mockRejectedValue(
-          new Error("Starting a fresh session in the current workspace isn't available in this TelePi version yet."),
-        ),
-      },
-    });
-    await sameWorkspaceNewUnavailable.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(sameWorkspaceNewUnavailable.api.sendMessage.mock.calls[0]?.[1]).toContain(
-      "Starting a fresh session in the current workspace isn't available in this TelePi version yet.",
-    );
-    expect(sameWorkspaceNewUnavailable.api.sendMessage.mock.calls[0]?.[1]).not.toContain("AgentSessionRuntime migration");
-
-    const failedModelBootstrap = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-        newSession: vi.fn().mockRejectedValue(new Error("bootstrap failed")),
-      },
-    });
-    await failedModelBootstrap.bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    expect(failedModelBootstrap.api.sendMessage.mock.calls[0]?.[1]).toContain("Failed to create session");
-    expect(failedModelBootstrap.api.sendMessage.mock.calls[0]?.[1]).toContain("bootstrap failed");
-
-    const noModels = setupBot({
-      piSessionOverrides: {
-        listModels: vi.fn().mockResolvedValue([]),
-      },
-    });
-    await noModels.bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    expect(noModels.api.sendMessage.mock.calls[0]?.[1]).toContain("No models available.");
-  });
-
-  it("expires page callbacks when the original picker state is gone", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(createCallbackUpdate("switch_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /sessions again",
-    });
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(createCallbackUpdate("newws_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /new again",
-    });
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(createCallbackUpdate("model_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /model again",
-    });
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(createCallbackUpdate("model_show_all"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /model again",
-    });
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /tree again",
-    });
-
-    api.answerCallbackQuery.mockClear();
-    await bot.handleUpdate(createCallbackUpdate("branch_page_1"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /branch again",
-    });
-  });
-
-  it("handles noop_page callback without editing the message", async () => {
-    const { bot, api } = setupBot();
-
-    await bot.handleUpdate(createCallbackUpdate("noop_page"));
-    expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {});
-    expect(api.editMessageText).not.toHaveBeenCalled();
-    expect(api.editMessageReplyMarkup).not.toHaveBeenCalled();
-  });
-
-  it("handles callback edge cases and the abort button", async () => {
-    const abortCallback = setupBot();
-    await abortCallback.bot.handleUpdate(createCallbackUpdate("pi_abort"));
-    expect(abortCallback.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", { text: "Aborting..." });
-    expect(abortCallback.pi.service.abort).toHaveBeenCalledTimes(1);
-
-    const expiredWorkspace = setupBot();
-    await expiredWorkspace.bot.handleUpdate(createCallbackUpdate("newws_0"));
-    expect(expiredWorkspace.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /new again",
-    });
-
-    const cancelledWorkspace = setupBot({
-      piSessionOverrides: {
-        newSession: vi.fn().mockResolvedValue({
-          info: {
-            sessionId: "cancelled",
-            sessionFile: "/tmp/cancelled.jsonl",
-            workspace: "/workspace/B",
-            model: "anthropic/claude-sonnet-4-5",
-          },
-          created: false,
-        }),
-      },
-    });
-    await cancelledWorkspace.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    await cancelledWorkspace.bot.handleUpdate(createCallbackUpdate("newws_1"));
-    expect(cancelledWorkspace.api.editMessageText.mock.calls.at(-1)?.[2]).toContain(
-      "New session was cancelled.",
-    );
-
-    const expiredModel = setupBot();
-    await expiredModel.bot.handleUpdate(createCallbackUpdate("model_0"));
-    expect(expiredModel.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Expired, run /model again",
-    });
-
-    const failedModel = setupBot({
-      piSessionOverrides: {
-        setModel: vi.fn().mockRejectedValue(new Error("model failed")),
-      },
-    });
-    await failedModel.bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    await failedModel.bot.handleUpdate(createCallbackUpdate("model_1"));
-    expect(failedModel.api.editMessageText.mock.calls.at(-1)?.[2]).toContain("model failed");
-  });
-
-  it("summarizes tool usage, reports tool errors, and handles prompt failures", async () => {
-    const summary = setupBot();
-    const summaryPrompt = summary.pi.service.prompt as ReturnType<typeof vi.fn>;
-    summaryPrompt.mockImplementation(async () => {
-      summary.pi.emitTextDelta("Finished response");
-      summary.pi.emitToolStart("bash", "tool-1");
-      summary.pi.emitToolStart("read", "tool-2");
-      summary.pi.emitToolStart("bash", "tool-3");
-      summary.pi.emitAgentEnd();
-    });
-    await summary.bot.handleUpdate(createTestUpdate({ message: { text: "summarize" } }));
-    expect(summary.api.editMessageText.mock.calls.some((call) => String(call[2]).includes("bash ×2, read"))).toBe(
-      true,
-    );
-
-    const errorsOnly = setupBot({
-      configOverrides: { toolVerbosity: "errors-only" },
-    });
-    const errorsOnlyPrompt = errorsOnly.pi.service.prompt as ReturnType<typeof vi.fn>;
-    errorsOnlyPrompt.mockImplementation(async () => {
-      errorsOnly.pi.emitTextDelta("Answer");
-      errorsOnly.pi.emitToolStart("bash", "tool-1");
-      errorsOnly.pi.emitToolUpdate("tool-1", "stderr");
-      errorsOnly.pi.emitToolEnd("tool-1", true);
-      errorsOnly.pi.emitAgentEnd();
-    });
-    await errorsOnly.bot.handleUpdate(createTestUpdate({ message: { text: "show tool error" } }));
-    expect(errorsOnly.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("❌"))).toBe(true);
-
-    const failure = setupBot();
-    const failurePrompt = failure.pi.service.prompt as ReturnType<typeof vi.fn>;
-    failurePrompt.mockImplementation(async () => {
-      failure.pi.emitTextDelta("Partial output");
-      throw new Error("prompt failed");
-    });
-    await failure.bot.handleUpdate(createTestUpdate({ message: { text: "break" } }));
-    expect(failure.api.editMessageText.mock.calls.some((call) => String(call[2]).includes("⚠️ prompt failed"))).toBe(
-      true,
-    );
-
-    const aborted = setupBot();
-    const abortedPrompt = aborted.pi.service.prompt as ReturnType<typeof vi.fn>;
-    abortedPrompt.mockImplementation(async () => {
-      aborted.pi.emitTextDelta("Partial output");
-      throw new Error("Abort requested");
-    });
-    await aborted.bot.handleUpdate(createTestUpdate({ message: { text: "stop" } }));
-    expect(aborted.api.editMessageText.mock.calls.some((call) => String(call[2]).includes("⏹ Aborted"))).toBe(
-      true,
-    );
-  });
-
-  it("handles Telegram parse fallbacks and long streaming responses", async () => {
-    const sendFallback = setupBot();
-    sendFallback.api.sendMessage
-      .mockRejectedValueOnce(new Error("can't parse entities"))
-      .mockImplementation(async (chatId: number | string, text: string, opts?: any) => ({
-        message_id: 99,
-        chat: { id: chatId },
-        text,
-        ...opts,
-      }));
-    await sendFallback.bot.handleUpdate(createTestUpdate({ message: { text: "/start" } }));
-    expect(sendFallback.api.sendMessage).toHaveBeenCalledTimes(2);
-    expect(sendFallback.api.sendMessage.mock.calls[1]?.[2]?.parse_mode).toBeUndefined();
-
-    const editFallback = setupBot();
-    editFallback.api.editMessageText
-      .mockRejectedValueOnce(new Error("unsupported start tag"))
-      .mockResolvedValue(true);
-    await editFallback.bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    await editFallback.bot.handleUpdate(createCallbackUpdate("model_1"));
-    expect(editFallback.api.editMessageText).toHaveBeenCalledTimes(2);
-    expect(editFallback.api.editMessageText.mock.calls[1]?.[3]?.parse_mode).toBeUndefined();
-
-    const notModified = setupBot();
-    notModified.api.editMessageText.mockRejectedValueOnce(new Error("message is not modified"));
-    await notModified.bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
-    await notModified.bot.handleUpdate(createCallbackUpdate("model_1"));
-    expect(notModified.api.editMessageText).toHaveBeenCalledTimes(1);
-
-    const longResponse = setupBot();
-    const longPrompt = longResponse.pi.service.prompt as ReturnType<typeof vi.fn>;
-    const longChunk = "word ".repeat(900);
-    longPrompt.mockImplementation(async () => {
-      longResponse.pi.emitTextDelta(`${longChunk}${longChunk}`);
-      longResponse.pi.emitTextDelta(`${longChunk}${longChunk}`);
-      longResponse.pi.emitAgentEnd();
-    });
-    await longResponse.bot.handleUpdate(createTestUpdate({ message: { text: "long reply" } }));
-    expect(longResponse.api.sendMessage.mock.calls.some((call) => String(call[1]).includes("preview truncated"))).toBe(
-      true,
-    );
-    expect(longResponse.api.sendMessage.mock.calls.length).toBeGreaterThan(1);
-  });
-
-  it("registers bot commands", async () => {
-    const { bot, api } = setupBot();
-
-    await registerCommands(bot);
-
-    expect(api.setMyCommands).toHaveBeenCalledWith([
-      { command: "start", description: "Welcome and session info" },
-      { command: "help", description: "Show commands and usage tips" },
-      { command: "commands", description: "Browse TelePi and Pi commands" },
-      { command: "new", description: "Start a new session" },
-      { command: "retry", description: "Retry the last prompt in this chat/topic" },
-      { command: "handback", description: "Hand session back to Pi CLI" },
-      { command: "abort", description: "Cancel current operation" },
-      { command: "session", description: "Current session details" },
-      { command: "sessions", description: "List and switch sessions (or /sessions <path|id>)" },
-      { command: "context", description: "Show context usage and session stats" },
-      { command: "model", description: "Switch AI model" },
-      { command: "tree", description: "View and navigate the session tree" },
-      { command: "branch", description: "Navigate to a tree entry (/branch <id>)" },
-      { command: "label", description: "Label an entry (/label [name] or /label <id> <name>)" },
-    ], undefined);
-  });
-
-  it("blocks commands when piSession.isStreaming() returns true", async () => {
-    const streaming = setupBot({
-      piSessionOverrides: {
-        isStreaming: vi.fn().mockReturnValue(true),
-      },
-    });
-
-    // /sessions should be blocked
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    expect(streaming.api.sendMessage.mock.calls[0]?.[1]).toContain("Cannot switch sessions while a prompt is running.");
-
-    // /new should be blocked
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    expect(streaming.api.sendMessage.mock.calls[1]?.[1]).toContain("Cannot create new session while a prompt is running.");
-
-    // /handback should be blocked
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-    expect(streaming.api.sendMessage.mock.calls[2]?.[1]).toContain("Cannot hand back while a prompt is running.");
-
-    // tree commands should be blocked
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
-    expect(streaming.api.sendMessage.mock.calls[3]?.[1]).toContain("Cannot view tree while a prompt is running.");
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/branch branch111" } }));
-    expect(streaming.api.sendMessage.mock.calls[4]?.[1]).toContain("Cannot navigate while a prompt is running.");
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "/label saved" } }));
-    expect(streaming.api.sendMessage.mock.calls[5]?.[1]).toContain("Cannot label entries while a prompt is running.");
-
-    // text messages should be blocked
-    await streaming.bot.handleUpdate(createTestUpdate({ message: { text: "hello there" } }));
-    expect(streaming.api.sendMessage.mock.calls[6]?.[1]).toContain("Still working on previous message...");
-
-    await streaming.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
-    expect(streaming.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
-      text: "Wait for the current prompt to finish",
-    });
-  });
-
-  it("sends '✅ Done' when agent ends with no text output", async () => {
-    const { bot, pi, api } = setupBot();
-    const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
-    promptMock.mockImplementation(async () => {
-      // Agent ends without emitting any text deltas
-      pi.emitAgentEnd();
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "do something silent" } }));
-
-    const allSentTexts = api.sendMessage.mock.calls.map((call) => String(call[1]));
-    expect(allSentTexts.some((text) => text.includes("✅ Done"))).toBe(true);
-  });
-
-  it("handles in-memory handback (no sessionFile)", async () => {
-    const { bot, api, registry } = setupBot({
-      piSessionOverrides: {
-        handback: vi.fn().mockResolvedValue({
-          sessionFile: undefined,
-          workspace: "/workspace",
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Session was in-memory");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("No file to resume");
-    expect((registry.registry.remove as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith({
-      chatId: ALLOWED_CHAT_ID,
-    });
-  });
-
-  it("handles handback error", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        handback: vi.fn().mockRejectedValue(new Error("dispose exploded")),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/handback" } }));
-
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
-    expect(api.sendMessage.mock.calls[0]?.[1]).toContain("dispose exploded");
-  });
-
-  it("blocks text messages when isSwitching is active", async () => {
-    let resolveSwitch!: (info: SwitchResult) => void;
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockImplementation(
-          () =>
-            new Promise<SwitchResult>((resolve) => {
-              resolveSwitch = resolve;
-            }),
-        ),
-      },
-    });
-
-    // Start a switch via /sessions <path>
-    const switching = bot.handleUpdate(createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }));
-    await nextTick();
-
-    // Try to send a text message — should be blocked
-    await bot.handleUpdate(createTestUpdate({ message: { text: "hello there" } }));
-    expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain("Still working on previous message...");
-
-    resolveSwitch({
-      sessionId: "switched-id",
-      sessionFile: "/tmp/switched.jsonl",
-      workspace: "/other",
-      model: "anthropic/claude-sonnet-4-5",
-      cancelled: false,
-    });
-    await switching;
-  });
-
-  it("handles switch callback error", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        switchSession: vi.fn().mockRejectedValue(new Error("switch exploded")),
-      },
-    });
-
-    // Set up picks first
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/sessions" } }));
-    // Now click a switch button
-    await bot.handleUpdate(createCallbackUpdate("switch_0"));
-
-    expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("Failed:");
-    expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("switch exploded");
-  });
-
-  it("handles newws callback error", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        newSession: vi.fn().mockRejectedValue(new Error("create exploded")),
-      },
-    });
-
-    // Set up workspace picks
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
-    // Click a workspace button
-    await bot.handleUpdate(createCallbackUpdate("newws_0"));
-
-    expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("Failed:");
-    expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("create exploded");
-  });
-
-  it("shows context usage with /context command", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        getContextUsage: vi.fn().mockReturnValue({
-          tokens: 15000,
-          contextWindow: 128000,
-          percent: 11.72,
-        }),
-        getSessionStats: vi.fn().mockReturnValue({
-          userMessages: 10,
-          assistantMessages: 10,
-          toolCalls: 25,
-          toolResults: 25,
-          totalMessages: 40,
-          tokens: {
-            input: 120000,
-            output: 30000,
-            cacheRead: 5000,
-            cacheWrite: 2000,
-            total: 157000,
-          },
-          cost: 0.12,
-          contextUsage: {
-            tokens: 15000,
-            contextWindow: 128000,
-            percent: 11.72,
-          },
-          sessionFile: "/tmp/session.jsonl",
-          sessionId: "test-session",
-        }),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/context" } }));
-
-    const sentText = String(api.sendMessage.mock.calls[0]?.[1]);
-    expect(sentText).toContain("Context Usage");
-    expect(sentText).toContain("15,000");
-    expect(sentText).toContain("128,000");
-    expect(sentText).toContain("11.72%");
-    expect(sentText).toContain("Session Stats");
-    expect(sentText).toContain("10");
-    expect(sentText).toContain("user");
-    expect(sentText).toContain("25");
-    expect(sentText).toContain("$0.1200");
-  });
-
-  it("shows 'no active session' with /context when session is missing", async () => {
-    const { bot, api } = setupBot({
-      piSessionOverrides: {
-        hasActiveSession: vi.fn().mockReturnValue(false),
-        getContextUsage: vi.fn().mockReturnValue(undefined),
-        getSessionStats: vi.fn().mockReturnValue(undefined),
-      },
-    });
-
-    await bot.handleUpdate(createTestUpdate({ message: { text: "/context" } }));
-
-    const sentText = String(api.sendMessage.mock.calls[0]?.[1]);
-    expect(sentText).toContain("No active session");
-  });
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+		vi.mocked(getAvailableBackends).mockResolvedValue(["openai"]);
+		vi.mocked(transcribeAudio).mockResolvedValue({
+			text: "transcribed text",
+			backend: "openai",
+			durationMs: 500,
+		});
+		vi.mocked(readFile).mockResolvedValue(Buffer.from("image-bytes"));
+		vi.mocked(writeFile).mockResolvedValue(undefined);
+		vi.mocked(unlink).mockResolvedValue(undefined);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: () => Promise.resolve(new ArrayBuffer(100)),
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("starts prompt inbox polling when configured", () => {
+		setupBot({
+			configOverrides: {
+				promptInboxDir: "/tmp/telepi-inbox",
+				promptInboxIntervalMs: 15000,
+			},
+		});
+
+		expect(startPromptInboxPolling).toHaveBeenCalledWith(
+			expect.objectContaining({
+				inboxDir: "/tmp/telepi-inbox",
+				intervalMs: 15000,
+				target: { chatId: ALLOWED_USER_ID },
+			}),
+		);
+	});
+
+	it("stops prompt inbox polling when the bot stops", () => {
+		const stopPolling = vi.fn();
+		vi.mocked(startPromptInboxPolling).mockReturnValue(stopPolling);
+		const { bot } = setupBot({
+			configOverrides: {
+				promptInboxDir: "/tmp/telepi-inbox",
+			},
+		});
+
+		bot.stop();
+
+		expect(stopPolling).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows authorized users through the middleware and handles /start", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/start" } }));
+
+		expect(api.sendMessage).toHaveBeenCalledTimes(1);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("TelePi is ready.");
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Session ID");
+	});
+
+	it("handles /help and /retry flows", async () => {
+		const { bot, pi, api } = setupBot();
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/help" } }));
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("/retry");
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Each Telegram chat/topic has its own Pi session",
+		);
+
+		api.sendMessage.mockClear();
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Nothing to retry yet",
+		);
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.emitTextDelta("Retried response");
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "retry me" } }));
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/retry" } }));
+
+		expect(pi.service.prompt).toHaveBeenNthCalledWith(1, "retry me");
+		expect(pi.service.prompt).toHaveBeenNthCalledWith(2, "retry me");
+	});
+
+	it("keeps /retry state isolated per topic", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "topic one retry",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 101,
+				},
+			}),
+		);
+
+		api.sendMessage.mockClear();
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/retry",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 202,
+				},
+			}),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Nothing to retry yet in this chat/topic.",
+		);
+	});
+
+	it("clears /retry memory after creating a new session or switching sessions", async () => {
+		const fresh = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+			},
+		});
+		await fresh.bot.handleUpdate(
+			createTestUpdate({ message: { text: "retry me later" } }),
+		);
+		await fresh.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+
+		fresh.api.sendMessage.mockClear();
+		await fresh.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/retry" } }),
+		);
+		expect(fresh.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Nothing to retry yet",
+		);
+
+		const switched = setupBot();
+		await switched.bot.handleUpdate(
+			createTestUpdate({ message: { text: "switch clears retry" } }),
+		);
+		await switched.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+
+		switched.api.sendMessage.mockClear();
+		await switched.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/retry" } }),
+		);
+		expect(switched.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Nothing to retry yet",
+		);
+	});
+
+	it("can retry failed prompts and prompts started from voice transcription", async () => {
+		const failing = setupBot();
+		const failingPrompt = failing.pi.service.prompt as ReturnType<typeof vi.fn>;
+		failingPrompt
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValueOnce(undefined);
+
+		await failing.bot.handleUpdate(
+			createTestUpdate({ message: { text: "retry failed prompt" } }),
+		);
+		await failing.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/retry" } }),
+		);
+
+		expect(failing.pi.service.prompt).toHaveBeenNthCalledWith(
+			1,
+			"retry failed prompt",
+		);
+		expect(failing.pi.service.prompt).toHaveBeenNthCalledWith(
+			2,
+			"retry failed prompt",
+		);
+
+		const voice = setupBot();
+		const voicePrompt = voice.pi.service.prompt as ReturnType<typeof vi.fn>;
+		voicePrompt.mockImplementation(async () => {
+			voice.pi.emitTextDelta("Voice response");
+			voice.pi.emitAgentEnd();
+		});
+
+		await voice.bot.handleUpdate(createVoiceUpdate());
+		await voice.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/retry" } }),
+		);
+
+		expect(voice.pi.service.prompt).toHaveBeenNthCalledWith(
+			1,
+			"transcribed text",
+		);
+		expect(voice.pi.service.prompt).toHaveBeenNthCalledWith(
+			2,
+			"transcribed text",
+		);
+	});
+
+	it("rejects unauthorized message senders", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: { from: { id: 999, is_bot: false, first_name: "Eve" } },
+			}),
+		);
+
+		expect(api.sendMessage).toHaveBeenCalledTimes(1);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toBe("Unauthorized");
+	});
+
+	it("rejects unauthorized callback queries without sending a chat message", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(
+			createCallbackUpdate("switch_0", {
+				callback_query: { from: { id: 999, is_bot: false, first_name: "Eve" } },
+			}),
+		);
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Unauthorized",
+		});
+		expect(api.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("rejects unauthorized tree commands", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/tree",
+					from: { id: 999, is_bot: false, first_name: "Eve" },
+				},
+			}),
+		);
+
+		expect(api.sendMessage).toHaveBeenCalledTimes(1);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toBe("Unauthorized");
+	});
+
+	it("handles /session", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/session" } }));
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Session ID");
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("/tmp/test.jsonl");
+	});
+
+	it("shows fallback /session info for untouched contexts without creating a session", async () => {
+		const { bot, api, registry } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/session",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 909,
+				},
+			}),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("(no active session)");
+		expect(
+			registry.registry.getOrCreate as ReturnType<typeof vi.fn>,
+		).not.toHaveBeenCalledWith({
+			chatId: ALLOWED_CHAT_ID,
+			messageThreadId: 909,
+		});
+		expect(registry.getSession(ALLOWED_CHAT_ID, 909)).toBeUndefined();
+	});
+
+	it("handles /abort success and failure", async () => {
+		const ok = setupBot();
+		await ok.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/abort" } }),
+		);
+		expect(ok.pi.service.abort).toHaveBeenCalledTimes(1);
+		expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Aborted current operation",
+		);
+
+		const failure = setupBot({
+			piSessionOverrides: {
+				abort: vi.fn().mockRejectedValue(new Error("abort failed")),
+			},
+		});
+		await failure.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/abort" } }),
+		);
+		expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
+		expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"abort failed",
+		);
+	});
+
+	it("does not create a fresh session for /abort in an untouched context", async () => {
+		const { bot, api, registry } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/abort",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 910,
+				},
+			}),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"No active session to abort.",
+		);
+		expect(
+			registry.registry.getOrCreate as ReturnType<typeof vi.fn>,
+		).not.toHaveBeenCalledWith({
+			chatId: ALLOWED_CHAT_ID,
+			messageThreadId: 910,
+		});
+		expect(registry.getSession(ALLOWED_CHAT_ID, 910)).toBeUndefined();
+	});
+
+	it("shows a compact session picker with inline switch buttons", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Select a session to switch",
+		);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("(2 found)");
+		expect(api.sendMessage.mock.calls[0]?.[1]).not.toContain("📁 A");
+		expect(api.sendMessage.mock.calls[0]?.[1]).not.toContain("📁 B");
+		expect(
+			getReplyMarkupButtons(api)
+				.slice(0, 2)
+				.map((button) => button.text),
+		).toEqual(["📁 A · Hello session", "📁 B · World session"]);
+		expect(getReplyMarkupData(api)).toEqual(["switch_0", "switch_1"]);
+	});
+
+	it("paginates session pickers and keeps selections working across pages", async () => {
+		const sessions = generateMockSessions(8).map((session) => ({
+			...session,
+			cwd: "/workspace/A",
+		}));
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listAllSessions: vi.fn().mockResolvedValue(sessions),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+
+		expect(getReplyMarkupData(api)).toEqual([
+			"switch_0",
+			"switch_1",
+			"switch_2",
+			"switch_3",
+			"switch_4",
+			"switch_5",
+			"noop_page",
+			"switch_page_1",
+		]);
+		expect(getReplyMarkupButtons(api).at(-2)?.text).toBe("1/2");
+		expect(getReplyMarkupButtons(api).at(-1)?.text).toBe("Next ▶️");
+
+		await bot.handleUpdate(createCallbackUpdate("switch_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: undefined,
+		});
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual(["switch_6", "switch_7", "switch_page_0", "noop_page"]);
+
+		await bot.handleUpdate(createCallbackUpdate("switch_7"));
+		expect(pi.service.switchSession).toHaveBeenCalledWith(
+			"/s7.jsonl",
+			"/workspace/A",
+		);
+	});
+
+	it("routes session pickers and prompts per topic", async () => {
+		const topicOneKey = makeContextKey(ALLOWED_CHAT_ID, 101);
+		const topicTwoKey = makeContextKey(ALLOWED_CHAT_ID, 202);
+		const { bot, api, registry } = setupBot({
+			perContextSessionOverrides: {
+				[topicOneKey]: {
+					listAllSessions: vi.fn().mockResolvedValue([
+						{
+							id: "topic-1",
+							firstMessage: "Topic one",
+							path: "/topic-one.jsonl",
+							messageCount: 2,
+							cwd: "/workspace/topic-one",
+							modified: new Date("2025-01-02T00:00:00.000Z"),
+							name: undefined,
+						},
+					]),
+				},
+				[topicTwoKey]: {
+					listAllSessions: vi.fn().mockResolvedValue([
+						{
+							id: "topic-2",
+							firstMessage: "Topic two",
+							path: "/topic-two.jsonl",
+							messageCount: 4,
+							cwd: "/workspace/topic-two",
+							modified: new Date("2025-01-03T00:00:00.000Z"),
+							name: undefined,
+						},
+					]),
+				},
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/sessions",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 101,
+				},
+			}),
+		);
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/sessions",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 202,
+				},
+			}),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[2]?.message_thread_id).toBe(101);
+		expect(api.sendMessage.mock.calls[1]?.[2]?.message_thread_id).toBe(202);
+
+		await bot.handleUpdate(
+			createCallbackUpdate("switch_0", {
+				callback_query: {
+					message: {
+						chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+						message_thread_id: 101,
+					},
+				},
+			}),
+		);
+		await bot.handleUpdate(
+			createCallbackUpdate("switch_0", {
+				callback_query: {
+					message: {
+						chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+						message_thread_id: 202,
+					},
+				},
+			}),
+		);
+
+		expect(
+			registry.getSession(ALLOWED_CHAT_ID, 101)?.service.switchSession,
+		).toHaveBeenCalledWith("/topic-one.jsonl", "/workspace/topic-one");
+		expect(
+			registry.getSession(ALLOWED_CHAT_ID, 202)?.service.switchSession,
+		).toHaveBeenCalledWith("/topic-two.jsonl", "/workspace/topic-two");
+
+		const topicOneSession = registry.getSession(ALLOWED_CHAT_ID, 101)!;
+		const promptMock = topicOneSession.service.prompt as ReturnType<
+			typeof vi.fn
+		>;
+		promptMock.mockImplementation(async () => {
+			topicOneSession.emitTextDelta("Topic response");
+			topicOneSession.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "topic prompt",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 101,
+				},
+			}),
+		);
+
+		expect(api.sendChatAction).toHaveBeenCalledWith(
+			ALLOWED_CHAT_ID,
+			"typing",
+			101,
+		);
+	});
+
+	it("allows independent topics to process prompts concurrently", async () => {
+		let resolveTopicOne!: () => void;
+		const { bot, api, registry } = setupBot({
+			perContextSessionOverrides: {
+				[makeContextKey(ALLOWED_CHAT_ID, 101)]: {
+					prompt: vi.fn().mockImplementation(
+						() =>
+							new Promise<void>((resolve) => {
+								resolveTopicOne = resolve;
+							}),
+					),
+				},
+				[makeContextKey(ALLOWED_CHAT_ID, 202)]: {
+					prompt: vi.fn().mockResolvedValue(undefined),
+				},
+			},
+		});
+
+		const topicOnePending = bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "topic one prompt",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 101,
+				},
+			}),
+		);
+		await nextTick();
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "topic two prompt",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 202,
+				},
+			}),
+		);
+
+		expect(
+			registry.getSession(ALLOWED_CHAT_ID, 202)?.service.prompt,
+		).toHaveBeenCalledWith("topic two prompt");
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Still working on previous message..."),
+			),
+		).toBe(false);
+
+		resolveTopicOne();
+		await topicOnePending;
+	});
+
+	it("switches directly via /sessions and /switch aliases and shows errors when switching fails", async () => {
+		const ok = setupBot();
+		await ok.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+		expect(ok.pi.service.resolveSessionReference).toHaveBeenCalledWith(
+			"/saved/session.jsonl",
+		);
+		expect(ok.pi.service.switchSession).toHaveBeenCalledWith(
+			"/saved/session.jsonl",
+			"/workspace/A",
+		);
+		expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("Switched session");
+
+		const alias = setupBot();
+		await alias.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/switch /saved/session.jsonl" } }),
+		);
+		expect(alias.pi.service.resolveSessionReference).toHaveBeenCalledWith(
+			"/saved/session.jsonl",
+		);
+		expect(alias.pi.service.switchSession).toHaveBeenCalledWith(
+			"/saved/session.jsonl",
+			"/workspace/A",
+		);
+		expect(alias.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Switched session",
+		);
+
+		const cancelled = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockResolvedValue({
+					sessionId: "test-id",
+					sessionFile: "/tmp/test.jsonl",
+					workspace: "/workspace",
+					model: "anthropic/claude-sonnet-4-5",
+					cancelled: true,
+				}),
+			},
+		});
+		await cancelled.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+		expect(cancelled.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Session switch was cancelled.",
+		);
+
+		const byId = setupBot({
+			piSessionOverrides: {
+				resolveSessionReference: vi.fn().mockResolvedValue({
+					id: "s1",
+					path: "/saved/session.jsonl",
+					cwd: "/workspace/A",
+					matchType: "prefix",
+				}),
+			},
+		});
+		await byId.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions s1" } }),
+		);
+		expect(byId.pi.service.resolveSessionReference).toHaveBeenCalledWith("s1");
+		expect(byId.pi.service.switchSession).toHaveBeenCalledWith(
+			"/saved/session.jsonl",
+			"/workspace/A",
+		);
+
+		const failure = setupBot({
+			piSessionOverrides: {
+				resolveSessionReference: vi
+					.fn()
+					.mockRejectedValue(new Error("ambiguous session id")),
+			},
+		});
+		await failure.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions deadbeef" } }),
+		);
+		expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
+		expect(failure.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"ambiguous session id",
+		);
+	});
+
+	it("handles switch callbacks, expired picks, and wait states", async () => {
+		const ready = setupBot();
+		await ready.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		await ready.bot.handleUpdate(createCallbackUpdate("switch_1"));
+
+		expect(ready.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Switching...",
+		});
+		expect(ready.pi.service.resolveSessionReference).toHaveBeenCalledWith(
+			"/s2.jsonl",
+		);
+		expect(ready.pi.service.switchSession).toHaveBeenCalledWith(
+			"/s2.jsonl",
+			"/workspace/B",
+		);
+		expect(ready.api.editMessageText).toHaveBeenCalled();
+
+		const cancelled = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockResolvedValue({
+					sessionId: "test-id",
+					sessionFile: "/tmp/test.jsonl",
+					workspace: "/workspace",
+					model: "anthropic/claude-sonnet-4-5",
+					cancelled: true,
+				}),
+			},
+		});
+		await cancelled.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		await cancelled.bot.handleUpdate(createCallbackUpdate("switch_0"));
+		expect(cancelled.api.editMessageText.mock.calls.at(-1)?.[2]).toContain(
+			"Session switch was cancelled.",
+		);
+
+		const expired = setupBot();
+		await expired.bot.handleUpdate(createCallbackUpdate("switch_0"));
+		expect(expired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Session expired, run /sessions again",
+		});
+
+		let resolvePrompt!: () => void;
+		const waiting = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+		await waiting.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		const firstPrompt = waiting.bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello" } }),
+		);
+		await nextTick();
+		await waiting.bot.handleUpdate(createCallbackUpdate("switch_0"));
+
+		expect(waiting.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Wait for the current prompt to finish",
+		});
+
+		resolvePrompt();
+		await firstPrompt;
+	});
+
+	it("surfaces startup diagnostics after successful direct session switches", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockResolvedValue({
+					sessionId: "switched-id",
+					sessionFile: "/tmp/switched.jsonl",
+					workspace: "/workspace/B",
+					model: "anthropic/claude-sonnet-4-5",
+					diagnostics: [
+						{
+							type: "error",
+							message: "Extension issue (/ext/rebound.ts): startup failed",
+						},
+					],
+					cancelled: false,
+				}),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(1);
+		expect(startupMessages[0]).toContain(
+			"Extension issue (/ext/rebound.ts): startup failed",
+		);
+	});
+
+	it("surfaces startup diagnostics after successful switch callbacks", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockResolvedValue({
+					sessionId: "switched-id",
+					sessionFile: "/tmp/switched.jsonl",
+					workspace: "/workspace/B",
+					model: "anthropic/claude-sonnet-4-5",
+					diagnostics: [
+						{
+							type: "error",
+							message: "Prompt issue (/prompts/deploy.md): invalid frontmatter",
+						},
+					],
+					cancelled: false,
+				}),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		await bot.handleUpdate(createCallbackUpdate("switch_1"));
+
+		expect(api.editMessageText).toHaveBeenCalled();
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(1);
+		expect(startupMessages[0]).toContain(
+			"Prompt issue (/prompts/deploy.md): invalid frontmatter",
+		);
+	});
+
+	it("shows a workspace picker for /new and creates directly when only one workspace exists", async () => {
+		const picker = setupBot();
+		await picker.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(picker.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Select workspace for new session",
+		);
+		expect(getReplyMarkupData(picker.api)).toEqual(["newws_0", "newws_1"]);
+
+		const single = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+			},
+		});
+		await single.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(single.pi.service.newSession).toHaveBeenCalledWith();
+		expect(single.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"New session created.",
+		);
+	});
+
+	it("surfaces startup diagnostics after successful direct /new session creation", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+				newSession: vi.fn().mockResolvedValue({
+					info: {
+						sessionId: "new-id",
+						sessionFile: "/tmp/new.jsonl",
+						workspace: "/workspace/A",
+						model: "anthropic/claude-sonnet-4-5",
+						diagnostics: [
+							{
+								type: "error",
+								message: "Extension issue (/ext/new.ts): startup failed",
+							},
+						],
+					},
+					created: true,
+				}),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(1);
+		expect(startupMessages[0]).toContain(
+			"Extension issue (/ext/new.ts): startup failed",
+		);
+	});
+
+	it("handles new workspace selection callbacks", async () => {
+		const { bot, pi, api } = setupBot();
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+		await bot.handleUpdate(createCallbackUpdate("newws_1"));
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Creating session...",
+		});
+		expect(pi.service.newSession).toHaveBeenCalledWith("/workspace/B");
+		expect(api.editMessageText).toHaveBeenCalled();
+	});
+
+	it("surfaces startup diagnostics after successful workspace-picker session creation", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				newSession: vi.fn().mockResolvedValue({
+					info: {
+						sessionId: "new-id",
+						sessionFile: "/tmp/new.jsonl",
+						workspace: "/workspace/B",
+						model: "anthropic/claude-sonnet-4-5",
+						diagnostics: [
+							{
+								type: "error",
+								message: "Prompt issue (/prompts/new.md): invalid frontmatter",
+							},
+						],
+					},
+					created: true,
+				}),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+		await bot.handleUpdate(createCallbackUpdate("newws_1"));
+
+		expect(api.editMessageText).toHaveBeenCalled();
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(1);
+		expect(startupMessages[0]).toContain(
+			"Prompt issue (/prompts/new.md): invalid frontmatter",
+		);
+	});
+
+	it("paginates workspace pickers and creates the selected workspace session", async () => {
+		const workspaces = generateMockWorkspaces(8);
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(workspaces),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+		expect(getReplyMarkupData(api)).toEqual([
+			"newws_0",
+			"newws_1",
+			"newws_2",
+			"newws_3",
+			"newws_4",
+			"newws_5",
+			"noop_page",
+			"newws_page_1",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("newws_page_1"));
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual(["newws_6", "newws_7", "newws_page_0", "noop_page"]);
+
+		await bot.handleUpdate(createCallbackUpdate("newws_7"));
+		expect(pi.service.newSession).toHaveBeenCalledWith("/workspace/W7");
+	});
+
+	it("handles /handback and blocks it when unavailable or busy", async () => {
+		const ok = setupBot();
+		await ok.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+		expect(ok.pi.service.handback).toHaveBeenCalledTimes(1);
+		expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("pi --session");
+		expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain("pi -c");
+		expect(
+			ok.registry.registry.remove as ReturnType<typeof vi.fn>,
+		).toHaveBeenCalledWith({
+			chatId: ALLOWED_CHAT_ID,
+		});
+
+		const noActive = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+			},
+		});
+		await noActive.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+		expect(noActive.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"No active session to hand back.",
+		);
+
+		let resolvePrompt!: () => void;
+		const busy = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+		const pending = busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello" } }),
+		);
+		await nextTick();
+		await busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+
+		expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Cannot hand back while a prompt is running. Use /abort first.",
+		);
+
+		resolvePrompt();
+		await pending;
+	});
+
+	it("shows scoped models by default, can expand to all models, and handles model selection", async () => {
+		const scopedModels = [
+			{
+				provider: "github-copilot",
+				id: "codex",
+				name: "Codex",
+				current: true,
+				thinkingLevel: "high",
+			},
+		];
+		const allModels = [
+			{
+				provider: "openai",
+				id: "codex",
+				name: "Codex",
+				current: false,
+			},
+			...scopedModels,
+		];
+		const listModels = vi
+			.fn()
+			.mockImplementation((showAll?: boolean) =>
+				Promise.resolve(showAll ? allModels : scopedModels),
+			);
+
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listModels,
+				setModel: vi.fn().mockResolvedValue("openai/codex"),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Select a model");
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Showing the current Pi model scope.",
+		);
+		expect(getReplyMarkupData(api)).toEqual(["model_0", "model_show_all"]);
+		expect(getReplyMarkupTexts(api)).toEqual([
+			"✅ github-copilot/codex · Codex : high",
+			"Show all models",
+		]);
+		expect(listModels).toHaveBeenNthCalledWith(1, false);
+		expect(listModels).toHaveBeenNthCalledWith(2, true);
+
+		await bot.handleUpdate(createCallbackUpdate("model_show_all"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Loading all models...",
+		});
+		expect(getEditedReplyMarkupData(api)).toEqual(["model_0", "model_1"]);
+		expect(getEditedReplyMarkupTexts(api)).toEqual([
+			"openai/codex · Codex",
+			"✅ github-copilot/codex · Codex : high",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("model_0"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Switching model...",
+		});
+		expect(pi.service.setModel).toHaveBeenCalledWith(
+			"openai",
+			"codex",
+			undefined,
+		);
+		expect(api.editMessageText).toHaveBeenCalled();
+	});
+
+	it("applies the scoped thinking-level override when selecting a scoped model", async () => {
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				listModels: vi.fn().mockResolvedValue([
+					{
+						provider: "github-copilot",
+						id: "codex",
+						name: "Codex",
+						current: true,
+						thinkingLevel: "high",
+					},
+				]),
+				setModel: vi.fn().mockResolvedValue("github-copilot/codex"),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+		await bot.handleUpdate(createCallbackUpdate("model_0"));
+
+		expect(pi.service.setModel).toHaveBeenCalledWith(
+			"github-copilot",
+			"codex",
+			"high",
+		);
+	});
+
+	it("keeps the show-all button while paging through scoped models", async () => {
+		const scopedModels = Array.from({ length: 7 }, (_, index) => ({
+			provider: "github-copilot",
+			id: `codex-${index}`,
+			name: `Codex ${index}`,
+			current: index === 0,
+		}));
+		const allModels = [
+			...Array.from({ length: 2 }, (_, index) => ({
+				provider: "openai",
+				id: `gpt-${index}`,
+				name: `GPT ${index}`,
+				current: false,
+			})),
+			...scopedModels,
+		];
+		const listModels = vi
+			.fn()
+			.mockImplementation((showAll?: boolean) =>
+				Promise.resolve(showAll ? allModels : scopedModels),
+			);
+
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listModels,
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+		expect(getReplyMarkupData(api)).toEqual([
+			"model_0",
+			"model_1",
+			"model_2",
+			"model_3",
+			"model_4",
+			"model_5",
+			"noop_page",
+			"model_page_1",
+			"model_show_all",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("model_page_1"));
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual(["model_6", "model_page_0", "noop_page", "model_show_all"]);
+	});
+
+	it("paginates model pickers across all available models", async () => {
+		const models = generateMockModels(21);
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listModels: vi
+					.fn()
+					.mockImplementation((showAll?: boolean) =>
+						Promise.resolve(showAll ? models : models),
+					),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/model" } }));
+		expect(getReplyMarkupData(api)).toEqual([
+			"model_0",
+			"model_1",
+			"model_2",
+			"model_3",
+			"model_4",
+			"model_5",
+			"noop_page",
+			"model_page_1",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("model_page_3"));
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual([
+			"model_18",
+			"model_19",
+			"model_20",
+			"model_page_2",
+			"noop_page",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("model_20"));
+		expect(pi.service.setModel).toHaveBeenCalledWith(
+			"provider20",
+			"model-20",
+			undefined,
+		);
+	});
+
+	it("handles /tree command variants and missing sessions", async () => {
+		const empty = setupBot({
+			piSessionOverrides: {
+				getTree: vi.fn().mockReturnValue([]),
+			},
+		});
+		await empty.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		expect(empty.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Session tree is empty.",
+		);
+
+		const branched = setupBot();
+		await branched.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		expect(branched.api.sendMessage.mock.calls[0]?.[1]).toContain("Start");
+		expect(getReplyMarkupData(branched.api)).toContain("tree_nav_branch111");
+		expect(getReplyMarkupData(branched.api)).toContain("tree_nav_leaf5678");
+
+		const userMode = setupBot();
+		await userMode.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree user" } }),
+		);
+		expect(userMode.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Filter: user messages only.",
+		);
+
+		const allMode = setupBot();
+		await allMode.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree all" } }),
+		);
+		expect(allMode.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Filter: all entries with navigation buttons.",
+		);
+
+		const noActive = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+			},
+		});
+		await noActive.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		expect(noActive.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"No active session",
+		);
+	});
+
+	it("paginates tree navigation buttons while keeping filter buttons visible", async () => {
+		const tree = generatePagedTree(8);
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				getTree: vi.fn().mockReturnValue(tree),
+				getLeafId: vi.fn().mockReturnValue("node0001"),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/tree" } }));
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Page 1/2");
+		expect(getReplyMarkupData(api)).toEqual([
+			"tree_nav_root0000",
+			"tree_nav_node0002",
+			"tree_nav_node0003",
+			"tree_nav_node0004",
+			"tree_nav_node0005",
+			"tree_nav_node0006",
+			"noop_page",
+			"tree_page_1",
+			"tree_mode_all",
+			"tree_mode_user",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
+		expect(api.editMessageText.mock.calls[0]?.[2]).toContain("Page 2/2");
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual([
+			"tree_nav_node0007",
+			"tree_page_0",
+			"noop_page",
+			"tree_mode_all",
+			"tree_mode_user",
+		]);
+	});
+
+	it("keeps the selected tree mode when paging", async () => {
+		const tree = generatePagedTree(8);
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				getTree: vi.fn().mockReturnValue(tree),
+				getLeafId: vi.fn().mockReturnValue("node0001"),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree all" } }),
+		);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Filter: all entries with navigation buttons.",
+		);
+		expect(getReplyMarkupData(api)).toEqual([
+			"tree_nav_root0000",
+			"tree_nav_node0001",
+			"tree_nav_node0002",
+			"tree_nav_node0003",
+			"tree_nav_node0004",
+			"tree_nav_node0005",
+			"noop_page",
+			"tree_page_1",
+			"tree_mode_default",
+			"tree_mode_user",
+		]);
+
+		await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
+		expect(api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Filter: all entries with navigation buttons.",
+		);
+		expect(
+			getEditedReplyMarkupButtons(api).map((button) => button.callback_data),
+		).toEqual([
+			"tree_nav_node0006",
+			"tree_nav_node0007",
+			"tree_page_0",
+			"noop_page",
+			"tree_mode_default",
+			"tree_mode_user",
+		]);
+	});
+
+	it("handles /branch command success and validation", async () => {
+		const usage = setupBot();
+		await usage.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch" } }),
+		);
+		expect(usage.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Usage: /branch &lt;entry-id&gt;",
+		);
+
+		const missing = setupBot();
+		await missing.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch missing" } }),
+		);
+		expect(missing.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Entry not found: missing",
+		);
+
+		const sameLeaf = setupBot();
+		await sameLeaf.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch leaf1234" } }),
+		);
+		expect(sameLeaf.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"already at this point",
+		);
+
+		const ok = setupBot();
+		await ok.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch branch111" } }),
+		);
+		expect(ok.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Navigate to this point?",
+		);
+		expect(getReplyMarkupData(ok.api)).toEqual([
+			"tree_go_branch111",
+			"tree_sum_branch111",
+			"tree_cancel",
+		]);
+	});
+
+	it("handles /label command flows", async () => {
+		const show = setupBot();
+		await show.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label" } }),
+		);
+		expect(show.api.sendMessage.mock.calls[0]?.[1]).toContain("saved");
+
+		const current = setupBot();
+		await current.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label checkpoint" } }),
+		);
+		expect(current.pi.service.setLabel).toHaveBeenCalledWith(
+			"leaf1234",
+			"checkpoint",
+		);
+		expect(current.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"current leaf",
+		);
+
+		const specific = setupBot();
+		await specific.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label branch111 origin" } }),
+		);
+		expect(specific.pi.service.setLabel).toHaveBeenCalledWith(
+			"branch111",
+			"origin",
+		);
+		expect(specific.api.sendMessage.mock.calls[0]?.[1]).toContain("set on");
+
+		const clear = setupBot();
+		await clear.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label clear branch111" } }),
+		);
+		expect(clear.pi.service.setLabel).toHaveBeenCalledWith("branch111", "");
+		expect(clear.api.sendMessage.mock.calls[0]?.[1]).toContain("Label cleared");
+
+		const unknown = setupBot({
+			piSessionOverrides: {
+				getEntry: vi.fn().mockReturnValue(undefined),
+			},
+		});
+		await unknown.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label clear nope" } }),
+		);
+		expect(unknown.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Entry not found: nope",
+		);
+	});
+
+	it("handles tree callback queries", async () => {
+		const nav = setupBot();
+		await nav.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
+		expect(nav.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Loading...",
+		});
+		expect(nav.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Navigate to this point?",
+		);
+
+		// tree_go_ requires prior tree_nav_ confirmation (pendingTreeNavs)
+		const go = setupBot();
+		// First trigger nav to set pending state
+		await go.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
+		go.api.answerCallbackQuery.mockClear();
+		go.api.editMessageText.mockClear();
+		// Now confirm navigate
+		await go.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
+		expect(go.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Navigating...",
+		});
+		expect(go.pi.service.navigateTree).toHaveBeenCalledWith("branch111");
+		expect(go.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"✅ Navigated to",
+		);
+
+		// tree_go_ without prior nav shows "expired"
+		const goExpired = setupBot();
+		await goExpired.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
+		expect(goExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Confirmation expired. Use /branch again.",
+		});
+
+		// tree_go_ with navigation error
+		const goFail = setupBot({
+			piSessionOverrides: {
+				navigateTree: vi.fn().mockRejectedValue(new Error("nav failed")),
+			},
+		});
+		await goFail.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
+		goFail.api.editMessageText.mockClear();
+		await goFail.bot.handleUpdate(createCallbackUpdate("tree_go_branch111"));
+		expect(goFail.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"nav failed",
+		);
+
+		// tree_sum_ requires prior tree_nav_ confirmation
+		const sum = setupBot();
+		await sum.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
+		sum.api.answerCallbackQuery.mockClear();
+		sum.api.editMessageText.mockClear();
+		await sum.bot.handleUpdate(createCallbackUpdate("tree_sum_branch111"));
+		expect(sum.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Navigating with summary...",
+		});
+		expect(sum.pi.service.navigateTree).toHaveBeenCalledWith("branch111", {
+			summarize: true,
+		});
+		expect(sum.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Branch summary saved",
+		);
+
+		// tree_sum_ without prior nav shows "expired"
+		const sumExpired = setupBot();
+		await sumExpired.bot.handleUpdate(
+			createCallbackUpdate("tree_sum_branch111"),
+		);
+		expect(sumExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Confirmation expired. Use /branch again.",
+		});
+
+		// tree_go_ with cancelled navigation
+		const goCancelled = setupBot({
+			piSessionOverrides: {
+				navigateTree: vi.fn().mockResolvedValue({ cancelled: true }),
+			},
+		});
+		await goCancelled.bot.handleUpdate(
+			createCallbackUpdate("tree_nav_branch111"),
+		);
+		goCancelled.api.editMessageText.mockClear();
+		await goCancelled.bot.handleUpdate(
+			createCallbackUpdate("tree_go_branch111"),
+		);
+		expect(goCancelled.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Navigation cancelled.",
+		);
+
+		const cancel = setupBot();
+		await cancel.bot.handleUpdate(createCallbackUpdate("tree_cancel"));
+		expect(cancel.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Cancelled",
+		});
+		expect(cancel.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Navigation cancelled.",
+		);
+
+		const mode = setupBot();
+		await mode.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		mode.api.editMessageText.mockClear();
+		await mode.bot.handleUpdate(createCallbackUpdate("tree_mode_user"));
+		expect(mode.api.editMessageText.mock.calls[0]?.[2]).toContain(
+			"Filter: user messages only.",
+		);
+
+		const modeExpired = setupBot();
+		await modeExpired.bot.handleUpdate(createCallbackUpdate("tree_mode_user"));
+		expect(modeExpired.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /tree again",
+		});
+	});
+
+	it("processes plain text messages and subscribes to Pi events", async () => {
+		const { bot, pi, api } = setupBot({
+			configOverrides: { toolVerbosity: "all" },
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.emitTextDelta("Hello ");
+			pi.emitTextDelta("world");
+			pi.emitToolStart("bash", "tool-1");
+			pi.emitToolUpdate("tool-1", "stdout\nline");
+			pi.emitToolEnd("tool-1", false);
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "continue please" } }),
+		);
+
+		expect(pi.service.subscribe).toHaveBeenCalledTimes(1);
+		expect(pi.service.prompt).toHaveBeenCalledWith("continue please");
+		expect(api.sendChatAction).toHaveBeenCalled();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Hello"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Running:"),
+			),
+		).toBe(true);
+		expect(
+			api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("Hello world"),
+			),
+		).toBe(true);
+	});
+
+	it("bridges discovered Pi slash commands into the prompt flow", async () => {
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/compact focus recent work" } }),
+		);
+
+		expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
+		expect(pi.service.prompt).toHaveBeenCalledWith(
+			"/compact focus recent work",
+		);
+	});
+
+	it("bridges /cron status through TelePi and surfaces the extension notification", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand(
+						"cron",
+						[
+							{ id: "list", label: "📋 /cron list", commandText: "/cron list" },
+							{
+								id: "status",
+								label: "📊 /cron status",
+								commandText: "/cron status",
+							},
+							{ id: "add", label: "➕ /cron add", commandText: "/cron add" },
+							{
+								id: "manage",
+								label: "🛠️ /cron manage",
+								commandText: "/cron manage",
+							},
+						],
+						{
+							description: "Manage PiCron schedules",
+						},
+					),
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.getExtensionBindings()?.uiContext?.notify(
+				"Daemon: running\nSchedules: 1\nEnabled: 1\nNext due: 2026-01-01T09:00:00.000Z",
+				"info",
+			);
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/cron status" } }),
+		);
+		await nextTick();
+
+		expect(pi.service.prompt).toHaveBeenCalledWith("/cron status");
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Daemon: running"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Schedules: 1"),
+			),
+		).toBe(true);
+	});
+
+	it("opens a native TelePi menu for bare slash commands declared via metadata", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand(
+						"deploy",
+						[
+							{
+								id: "preview",
+								label: "🧪 /deploy preview",
+								commandText: "/deploy preview",
+							},
+							{
+								id: "status",
+								label: "📊 /deploy status",
+								commandText: "/deploy status",
+							},
+							{
+								id: "prod",
+								label: "🚀 /deploy prod",
+								commandText: "/deploy prod",
+							},
+						],
+						{
+							description: "Deployment shortcuts",
+						},
+					),
+				]),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
+
+		expect(pi.service.prompt).not.toHaveBeenCalled();
+		expect(api.sendMessage).toHaveBeenCalledTimes(1);
+		expect(String(api.sendMessage.mock.calls[0]?.[1])).toContain("/deploy");
+		expect(getReplyMarkupTexts(api)).toEqual([
+			"🧪 /deploy preview",
+			"📊 /deploy status",
+			"🚀 /deploy prod",
+		]);
+		expect(
+			getReplyMarkupData(api).every((callbackData) =>
+				/^cmdm_[a-z0-9]+$/.test(callbackData),
+			),
+		).toBe(true);
+		expect(new Set(getReplyMarkupData(api)).size).toBe(3);
+		expect(
+			getReplyMarkupData(api).every((callbackData) => callbackData.length < 64),
+		).toBe(true);
+	});
+
+	it("drives bare /cron native menus from real PiCron extension metadata across repos", async () => {
+		const slashCommands = await loadPiCronSlashCommands();
+		const cronCommand = slashCommands.find(
+			(command) => command.name === "cron",
+		);
+
+		expect(cronCommand).toMatchObject({
+			name: "cron",
+			description: "Manage PiCron schedules",
+			integrations: {
+				telepi: {
+					bare: {
+						kind: "native-menu",
+						entries: [
+							{
+								id: "picron.cron.list",
+								label: "List schedules",
+								commandText: "/cron list",
+							},
+							{
+								id: "picron.cron.status",
+								label: "Show status",
+								commandText: "/cron status",
+							},
+							{
+								id: "picron.cron.add",
+								label: "Add schedule",
+								commandText: "/cron add",
+							},
+							{
+								id: "picron.cron.manage",
+								label: "Manage schedules",
+								commandText: "/cron manage",
+							},
+						],
+					},
+				},
+			},
+		});
+
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue(slashCommands),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/cron" } }));
+
+		expect(pi.service.prompt).not.toHaveBeenCalled();
+		expect(api.sendMessage).toHaveBeenCalledTimes(1);
+		expect(String(api.sendMessage.mock.calls[0]?.[1])).toContain("/cron");
+
+		const labels = getReplyMarkupTexts(api);
+		expect(labels).toEqual([
+			"List schedules",
+			"Show status",
+			"Add schedule",
+			"Manage schedules",
+		]);
+
+		const showStatusCallbackData =
+			getReplyMarkupData(api)[labels.indexOf("Show status")];
+		expect(showStatusCallbackData).toMatch(/^cmdm_[a-z0-9]+$/);
+
+		await bot.handleUpdate(createCallbackUpdate(showStatusCallbackData!));
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Running /cron status",
+		});
+		expect(pi.service.prompt).toHaveBeenCalledWith("/cron status");
+	});
+
+	it("dispatches generic command-menu callbacks through the normal prompt flow", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand("deploy", [
+						{
+							id: "preview",
+							label: "🧪 /deploy preview",
+							commandText: "/deploy preview",
+						},
+						{
+							id: "status",
+							label: "📊 /deploy status",
+							commandText: "/deploy status",
+						},
+					]),
+				]),
+			},
+		});
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
+		const callbackData = getReplyMarkupData(api)[1]!;
+
+		promptMock.mockImplementation(async (promptText: string) => {
+			expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+				text: "Running /deploy status",
+			});
+			expect(promptText).toBe("/deploy status");
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(createCallbackUpdate(callbackData));
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Running /deploy status",
+		});
+		expect(pi.service.prompt).toHaveBeenCalledWith("/deploy status");
+	});
+
+	it("detaches command-menu prompt callbacks so extension dialog callbacks stay responsive", async () => {
+		let resolvePrompt!: () => void;
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand("deploy", [
+						{
+							id: "manage",
+							label: "🛠️ /deploy manage",
+							commandText: "/deploy manage",
+						},
+						{
+							id: "status",
+							label: "📊 /deploy status",
+							commandText: "/deploy status",
+						},
+					]),
+				]),
+			},
+		});
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+
+		promptMock.mockImplementation(async (promptText: string) => {
+			expect(promptText).toBe("/deploy manage");
+			const choice = await pi
+				.getExtensionBindings()
+				?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
+			pi.emitTextDelta(`picked ${choice}`);
+			await new Promise<void>((resolve) => {
+				resolvePrompt = resolve;
+			});
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
+		const callbackData = getReplyMarkupData(api)[0]!;
+
+		let callbackHandled = false;
+		const pendingCallback = bot.handleUpdate(
+			createCallbackUpdate(callbackData),
+		);
+		void pendingCallback.then(() => {
+			callbackHandled = true;
+		});
+
+		await nextTick();
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Running /deploy manage",
+		});
+		expect(pi.service.prompt).toHaveBeenCalledWith("/deploy manage");
+		expect(callbackHandled).toBe(true);
+
+		const selectCallback = api.sendMessage.mock.calls
+			.flatMap(
+				(call) =>
+					call[2]?.reply_markup?.inline_keyboard
+						?.flat()
+						.map((button: any) => button.callback_data) ?? [],
+			)
+			.find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
+		expect(selectCallback).toBeTruthy();
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(
+			createCallbackUpdate(selectCallback!, {
+				callback_query: {
+					message: {
+						message_id: 2,
+					},
+				},
+			}),
+		);
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Selected Beta",
+		});
+		expect(
+			api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("Selected: Beta"),
+			),
+		).toBe(true);
+
+		resolvePrompt();
+		await nextTick();
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("picked Beta"),
+			),
+		).toBe(true);
+	});
+
+	it("detaches text prompt handling from the Telegram update lifetime", async () => {
+		let resolvePrompt!: () => void;
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+
+		let updateHandled = false;
+		const pendingUpdate = bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello" } }),
+		);
+		void pendingUpdate.then(() => {
+			updateHandled = true;
+		});
+
+		await nextTick();
+
+		expect(updateHandled).toBe(true);
+		expect(pi.service.prompt).toHaveBeenCalledWith("hello");
+
+		resolvePrompt();
+		await nextTick();
+	});
+
+	it("fails fast for generic command-menu callbacks while a prompt is already in flight", async () => {
+		let resolvePrompt!: () => void;
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand("deploy", [
+						{
+							id: "preview",
+							label: "🧪 /deploy preview",
+							commandText: "/deploy preview",
+						},
+						{
+							id: "status",
+							label: "📊 /deploy status",
+							commandText: "/deploy status",
+						},
+					]),
+				]),
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/deploy" } }));
+		const callbackData = getReplyMarkupData(api)[0]!;
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello" } }),
+		);
+		await nextTick();
+
+		expect(promptMock).toHaveBeenCalledTimes(1);
+
+		api.answerCallbackQuery.mockClear();
+		const sendMessageCalls = api.sendMessage.mock.calls.length;
+
+		await bot.handleUpdate(createCallbackUpdate(callbackData));
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Wait for the current prompt to finish",
+		});
+		expect(api.answerCallbackQuery).not.toHaveBeenCalledWith("cb_1", {
+			text: "Running /deploy preview",
+		});
+		expect(api.sendMessage).toHaveBeenCalledTimes(sendMessageCalls);
+		expect(promptMock).toHaveBeenCalledTimes(1);
+
+		resolvePrompt();
+		await pending;
+	});
+
+	it("falls back to forwarding bare slash commands when native menu metadata is missing or invalid", async () => {
+		for (const slashCommands of [
+			[makeSlashCommand("deploy", { description: "Deploy app" })],
+			[
+				makeTelepiBareNativeMenuSlashCommand("deploy", [
+					{ id: "preview", label: "", commandText: "/deploy preview" },
+				]),
+			],
+		]) {
+			const { bot, pi } = setupBot({
+				piSessionOverrides: {
+					listSlashCommands: vi.fn().mockResolvedValue(slashCommands),
+				},
+			});
+
+			await bot.handleUpdate(
+				createTestUpdate({ message: { text: "/deploy" } }),
+			);
+
+			expect(pi.service.prompt).toHaveBeenCalledWith("/deploy");
+		}
+	});
+
+	it("passes schedule-like plain text through unchanged instead of applying cron-specific rewrites", async () => {
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					makeTelepiBareNativeMenuSlashCommand(
+						"cron",
+						[
+							{
+								id: "picron.cron.list",
+								label: "List schedules",
+								commandText: "/cron list",
+							},
+							{
+								id: "picron.cron.status",
+								label: "Show status",
+								commandText: "/cron status",
+							},
+						],
+						{
+							description: "Manage PiCron schedules",
+						},
+					),
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "list schedules" } }),
+		);
+
+		expect(pi.service.prompt).toHaveBeenCalledWith("list schedules");
+	});
+
+	it("drives a /cron add style multi-step extension dialog flow through TelePi replies", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "cron",
+						description: "Manage PiCron schedules",
+						source: "extension",
+						path: "/ext/picron.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const ui = pi.getExtensionBindings()?.uiContext;
+			const name = await ui?.input("Schedule name", "Daily review");
+			const cron = await ui?.input("Cron expression", "0 9 * * *");
+			const timezone = await ui?.input("Timezone", "UTC");
+			const prompt = await ui?.input("Prompt", "Review the repo");
+			const cwd = await ui?.input(
+				"Target cwd (optional)",
+				"/workspace/current",
+			);
+			const sessionFile = await ui?.input(
+				"Target session file (optional)",
+				"session.jsonl",
+			);
+			ui?.notify(
+				`Created schedule ${name} (${cron}, ${timezone}, ${prompt}, ${cwd}, ${sessionFile}).`,
+				"info",
+			);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/cron add" } }),
+		);
+		await nextTick();
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Schedule name"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "Daily review" } }),
+		);
+		await nextTick();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Cron expression"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "0 9 * * *" } }),
+		);
+		await nextTick();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Timezone"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "UTC" } }));
+		await nextTick();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Prompt"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "Review the repo" } }),
+		);
+		await nextTick();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Target cwd (optional)"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/workspace/current" } }),
+		);
+		await nextTick();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Target session file (optional)"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "session.jsonl" } }),
+		);
+		await pending;
+		await nextTick();
+
+		expect(pi.service.prompt).toHaveBeenCalledWith("/cron add");
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Created schedule Daily review"),
+			),
+		).toBe(true);
+	});
+
+	it("normalizes bot-addressed Pi slash commands before bridging them", async () => {
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: { text: "/compact@telepi_test_bot focus recent work" },
+			}),
+		);
+
+		expect(pi.service.prompt).toHaveBeenCalledWith(
+			"/compact focus recent work",
+		);
+	});
+
+	it("ignores slash commands addressed to another bot", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: { text: "/compact@another_bot focus recent work" },
+			}),
+		);
+
+		expect(pi.service.prompt).not.toHaveBeenCalled();
+		expect(api.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not bridge unknown slash commands and shows a helpful reply", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([]),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/ignored" } }));
+
+		expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
+		expect(pi.service.prompt).not.toHaveBeenCalled();
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Unknown command"),
+			),
+		).toBe(true);
+	});
+
+	it("shows /commands as a paginated picker with TelePi and Pi filters", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+					{
+						name: "review",
+						description: "Review staged changes",
+						source: "prompt",
+						path: "/prompts/review.md",
+					},
+					{
+						name: "skill:browser-tools",
+						description: "Browser automation",
+						source: "skill",
+						path: "/skills/browser.md",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+
+		expect(pi.service.listSlashCommands).toHaveBeenCalledTimes(1);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Command picker"),
+			),
+		).toBe(true);
+		expect(getReplyMarkupData(api)).toContain("cmd_page_1");
+		expect(getReplyMarkupData(api)).toContain("cmd_filter_all");
+		expect(getReplyMarkupData(api)).toContain("cmd_filter_telepi");
+		expect(getReplyMarkupData(api)).toContain("cmd_filter_pi");
+
+		await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
+
+		expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain(
+			"/compact",
+		);
+		expect(getEditedReplyMarkupTexts(api, 0)).toContain("🧩 /compact");
+		expect(getEditedReplyMarkupTexts(api, 0)).toContain("📝 /review");
+		expect(getEditedReplyMarkupTexts(api, 0)).toContain(
+			"🧰 /skill:browser-tools",
+		);
+
+		await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
+
+		expect(String(api.editMessageText.mock.calls[1]?.[2])).toContain(
+			"/compact",
+		);
+		expect(getEditedReplyMarkupTexts(api, 1)).toContain("🧩 /compact");
+		expect(getEditedReplyMarkupTexts(api, 1)).toContain("📝 /review");
+		expect(getEditedReplyMarkupTexts(api, 1)).toContain(
+			"🧰 /skill:browser-tools",
+		);
+		expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_all");
+		expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_telepi");
+		expect(getEditedReplyMarkupData(api, 1)).toContain("cmd_filter_pi");
+	});
+
+	it("runs TelePi commands from the /commands picker", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		const helpButton = getReplyMarkupButtons(api).find((button) =>
+			button.text.includes("/help"),
+		);
+
+		expect(helpButton).toBeDefined();
+
+		await bot.handleUpdate(createCallbackUpdate(helpButton!.callback_data));
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes(
+					"Each Telegram chat/topic has its own Pi session and retry history.",
+				),
+			),
+		).toBe(true);
+	});
+
+	it("runs Pi commands from the /commands picker", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
+		const compactButton = getEditedReplyMarkupButtons(api, 0).find((button) =>
+			button.text.includes("/compact"),
+		);
+
+		expect(compactButton).toBeDefined();
+
+		await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
+
+		expect(pi.service.prompt).toHaveBeenCalledWith("/compact");
+	});
+
+	it("shows prompt argument hints in /commands without changing Pi command dispatch", async () => {
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-command-picker-"));
+		const promptPath = path.join(tempDir, "review.md");
+		writeFileSync(
+			promptPath,
+			[
+				"---",
+				"description: Review staged changes",
+				'argument-hint: "<PR-URL>"',
+				"---",
+				"Review changes.",
+				"",
+			].join("\n"),
+		);
+
+		try {
+			const { bot, pi, api } = setupBot({
+				piSessionOverrides: {
+					listSlashCommands: vi.fn().mockResolvedValue([
+						{
+							name: "review",
+							description: "Review staged changes",
+							source: "prompt",
+							sourceInfo: {
+								path: promptPath,
+								source: "local",
+								scope: "project",
+								origin: "top-level",
+							},
+						},
+					]),
+				},
+			});
+
+			await bot.handleUpdate(
+				createTestUpdate({ message: { text: "/commands" } }),
+			);
+			await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
+
+			expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain(
+				"/review &lt;PR-URL&gt;",
+			);
+			expect(getEditedReplyMarkupTexts(api, 0)).toContain(
+				"📝 /review <PR-URL>",
+			);
+
+			const reviewButton = getEditedReplyMarkupButtons(api, 0).find((button) =>
+				button.text.includes("/review <PR-URL>"),
+			);
+			expect(reviewButton).toBeDefined();
+
+			await bot.handleUpdate(createCallbackUpdate(reviewButton!.callback_data));
+
+			expect(pi.service.prompt).toHaveBeenCalledWith("/review");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the /commands picker active when a Pi command is tapped while busy", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				isStreaming: vi.fn().mockReturnValueOnce(true).mockReturnValue(false),
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		await bot.handleUpdate(createCallbackUpdate("cmd_page_2"));
+		const compactButton = getEditedReplyMarkupButtons(api, 0).find((button) =>
+			button.text.includes("/compact"),
+		);
+
+		expect(compactButton).toBeDefined();
+
+		await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Wait for the current prompt to finish",
+		});
+		expect(pi.service.prompt).not.toHaveBeenCalled();
+
+		await bot.handleUpdate(createCallbackUpdate(compactButton!.callback_data));
+		expect(pi.service.prompt).toHaveBeenCalledWith("/compact");
+	});
+
+	it("shows an empty-state Pi filter when no Pi commands are discovered", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		await bot.handleUpdate(createCallbackUpdate("cmd_filter_pi"));
+
+		expect(String(api.editMessageText.mock.calls[0]?.[2])).toContain(
+			"No Pi commands found in this session.",
+		);
+		expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_all");
+		expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_telepi");
+		expect(getEditedReplyMarkupData(api, 0)).toContain("cmd_filter_pi");
+	});
+
+	it("surfaces /commands discovery failures", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi
+					.fn()
+					.mockRejectedValue(new Error("extensions unavailable")),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Failed to load commands"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("extensions unavailable"),
+			),
+		).toBe(true);
+	});
+
+	it("syncs chat-scoped Telegram commands for registerable Pi slash commands", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+					{
+						name: "review",
+						description: "Review staged changes",
+						source: "prompt",
+						path: "/prompts/review.md",
+					},
+					{
+						name: "skill:browser-tools",
+						description: "Browser automation",
+						source: "skill",
+						path: "/skills/browser.md",
+					},
+					{
+						name: "switch",
+						description: "Should not override TelePi switch",
+						source: "extension",
+						path: "/ext/switch.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+
+		const scoped = getSetMyCommandsCall(api, 0);
+		expect(scoped?.scope).toEqual({ type: "chat", chat_id: ALLOWED_CHAT_ID });
+		expect(
+			scoped?.commands.some((command) => command.command === "compact"),
+		).toBe(true);
+		expect(
+			scoped?.commands.some((command) => command.command === "review"),
+		).toBe(true);
+		expect(
+			scoped?.commands.some(
+				(command) => command.command === "skill:browser-tools",
+			),
+		).toBe(false);
+		expect(
+			scoped?.commands.some(
+				(command) =>
+					command.command === "switch" && command.description.startsWith("Pi:"),
+			),
+		).toBe(false);
+	});
+
+	it("avoids redundant scoped Telegram command sync when the command set is unchanged", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+
+		expect(api.setMyCommands).toHaveBeenCalledTimes(1);
+	});
+
+	it("replaces chat-scoped Telegram commands when the discovered Pi commands change", async () => {
+		const listSlashCommands = vi
+			.fn()
+			.mockResolvedValueOnce([
+				{
+					name: "compact",
+					description: "Compact context",
+					source: "extension",
+					path: "/ext/compact.ts",
+				},
+			])
+			.mockResolvedValueOnce([]);
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands,
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/commands" } }),
+		);
+
+		expect(api.setMyCommands).toHaveBeenCalledTimes(2);
+		expect(
+			getSetMyCommandsCall(api, 0)?.commands.some(
+				(command) => command.command === "compact",
+			),
+		).toBe(true);
+		expect(
+			getSetMyCommandsCall(api, 1)?.commands.some(
+				(command) => command.command === "compact",
+			),
+		).toBe(false);
+	});
+
+	it("forwards runtime-backed new-session options from extension command actions", async () => {
+		const { bot, pi } = setupBot();
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			await pi.getExtensionBindings()?.commandContextActions?.newSession({
+				parentSession: "/tmp/handoff-parent.jsonl",
+				withSession,
+			});
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "prepare a handoff" } }),
+		);
+
+		expect(pi.service.newSession).toHaveBeenCalledWith({
+			parentSession: "/tmp/handoff-parent.jsonl",
+			withSession,
+		});
+	});
+
+	it("forwards runtime-backed fork options from extension command actions", async () => {
+		const { bot, pi } = setupBot();
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			await pi.getExtensionBindings()?.commandContextActions?.fork("leaf1234", {
+				position: "before",
+				withSession,
+			});
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "fork from extension" } }),
+		);
+
+		expect(pi.service.fork).toHaveBeenCalledWith("leaf1234", {
+			position: "before",
+			withSession,
+		});
+	});
+
+	it("bubbles cancelled switch-session results from extension command actions", async () => {
+		const { bot, pi } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockResolvedValue({
+					sessionId: "test-id",
+					sessionFile: "/tmp/test.jsonl",
+					workspace: "/workspace",
+					model: "anthropic/claude-sonnet-4-5",
+					cancelled: true,
+				}),
+			},
+		});
+		const withSession = vi.fn().mockResolvedValue(undefined);
+		let switchResult: { cancelled: boolean } | undefined;
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			switchResult = await pi
+				.getExtensionBindings()
+				?.commandContextActions?.switchSession("/tmp/other.jsonl", {
+					withSession,
+				});
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "switch from extension" } }),
+		);
+
+		expect(pi.service.switchSession).toHaveBeenCalledWith("/tmp/other.jsonl", {
+			withSession,
+		});
+		expect(switchResult).toEqual({ cancelled: true });
+	});
+
+	it("surfaces extension command notifications in Telegram", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.getExtensionBindings()?.uiContext?.notify(
+				"No conversation to compact",
+				"error",
+			);
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/compact" } }));
+		await nextTick();
+
+		expect(pi.service.bindExtensions).toHaveBeenCalledTimes(1);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("No conversation to compact"),
+			),
+		).toBe(true);
+	});
+
+	it("surfaces extension command errors in Telegram", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "compact",
+						description: "Compact context",
+						source: "extension",
+						path: "/ext/compact.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.getExtensionBindings()?.onError?.({
+				extensionPath: "command:compact",
+				event: "command",
+				error: "boom",
+			});
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/compact" } }));
+		await nextTick();
+
+		expect(pi.service.bindExtensions).toHaveBeenCalledTimes(1);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("/compact failed"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("boom"),
+			),
+		).toBe(true);
+	});
+
+	it("supports extension select dialogs through Telegram callbacks", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "pick",
+						description: "Pick an option",
+						source: "extension",
+						path: "/ext/pick.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const choice = await pi
+				.getExtensionBindings()
+				?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
+			pi.emitTextDelta(`picked ${choice}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/pick" } }),
+		);
+		await nextTick();
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Pick one"),
+			),
+		).toBe(true);
+		const selectCallback = getReplyMarkupData(api, 0).find((data) =>
+			/^ui_sel_[a-z0-9]+_1$/.test(data ?? ""),
+		);
+		expect(selectCallback).toBeTruthy();
+
+		await bot.handleUpdate(createCallbackUpdate(selectCallback!));
+		await pending;
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("picked Beta"),
+			),
+		).toBe(true);
+	});
+
+	it("supports extension select dialogs when forum callbacks omit the topic thread id", async () => {
+		const topicKey = makeContextKey(ALLOWED_CHAT_ID, 101);
+		const { bot, api, registry } = setupBot({
+			perContextSessionOverrides: {
+				[topicKey]: {
+					listSlashCommands: vi.fn().mockResolvedValue([
+						{
+							name: "pick",
+							description: "Pick an option",
+							source: "extension",
+							path: "/ext/pick.ts",
+						},
+					]),
+				},
+			},
+		});
+
+		await registry.registry.getOrCreate({
+			chatId: ALLOWED_CHAT_ID,
+			messageThreadId: 101,
+		});
+		const topicPi = registry.getSession(ALLOWED_CHAT_ID, 101)!;
+		const promptMock = topicPi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const choice = await topicPi
+				.getExtensionBindings()
+				?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
+			topicPi.emitTextDelta(`picked ${choice}`);
+			topicPi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/pick",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 101,
+				},
+			}),
+		);
+		await nextTick();
+
+		const selectCallback = api.sendMessage.mock.calls
+			.flatMap(
+				(call) =>
+					call[2]?.reply_markup?.inline_keyboard
+						?.flat()
+						.map((button: any) => button.callback_data) ?? [],
+			)
+			.find((data) => /^ui_sel_[a-z0-9]+_1$/.test(data ?? ""));
+		expect(selectCallback).toBeTruthy();
+
+		await bot.handleUpdate(
+			createCallbackUpdate(selectCallback!, {
+				callback_query: {
+					message: {
+						chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					},
+				},
+			}),
+		);
+		await pending;
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Selected Beta",
+		});
+		expect(
+			api.sendMessage.mock.calls.some(
+				(call) =>
+					String(call[1]).includes("picked Beta") &&
+					call[2]?.message_thread_id === 101,
+			),
+		).toBe(true);
+	});
+
+	it("still resolves extension dialog callbacks when Telegram rejects answerCallbackQuery", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "pick",
+						description: "Pick an option",
+						source: "extension",
+						path: "/ext/pick.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const choice = await pi
+				.getExtensionBindings()
+				?.uiContext?.select("Pick one", ["Alpha", "Beta"]);
+			pi.emitTextDelta(`picked ${choice}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/pick" } }),
+		);
+		await nextTick();
+
+		const selectCallback = getReplyMarkupData(api, 0).find((data) =>
+			/^ui_sel_[a-z0-9]+_1$/.test(data ?? ""),
+		);
+		expect(selectCallback).toBeTruthy();
+
+		api.answerCallbackQuery.mockRejectedValueOnce(new Error("query too old"));
+		await bot.handleUpdate(createCallbackUpdate(selectCallback!));
+		await pending;
+
+		expect(
+			api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("Selected: Beta"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("picked Beta"),
+			),
+		).toBe(true);
+	});
+
+	it("supports extension confirm dialogs through Telegram callbacks", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "confirm",
+						description: "Confirm action",
+						source: "extension",
+						path: "/ext/confirm.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const confirmed = await pi
+				.getExtensionBindings()
+				?.uiContext?.confirm("Confirm deploy", "Ship it?");
+			pi.emitTextDelta(`confirmed ${confirmed}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/confirm" } }),
+		);
+		await nextTick();
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Confirm deploy"),
+			),
+		).toBe(true);
+		const confirmCallback = getReplyMarkupData(api, 0).find((data) =>
+			data?.endsWith("_yes"),
+		);
+		expect(confirmCallback).toBeTruthy();
+
+		await bot.handleUpdate(createCallbackUpdate(confirmCallback!));
+		await pending;
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("confirmed true"),
+			),
+		).toBe(true);
+	});
+
+	it("supports extension confirm dialogs when Telegram omits callback message ids", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "confirm",
+						description: "Confirm action",
+						source: "extension",
+						path: "/ext/confirm.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const confirmed = await pi
+				.getExtensionBindings()
+				?.uiContext?.confirm("Confirm deploy", "Ship it?");
+			pi.emitTextDelta(`confirmed ${confirmed}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/confirm" } }),
+		);
+		await nextTick();
+
+		const confirmCallback = getReplyMarkupData(api, 0).find((data) =>
+			data?.endsWith("_yes"),
+		);
+		expect(confirmCallback).toBeTruthy();
+
+		await bot.handleUpdate(
+			createCallbackUpdate(confirmCallback!, {
+				callback_query: {
+					message: {
+						message_id: undefined,
+					},
+				},
+			}),
+		);
+		await pending;
+
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Confirmed",
+		});
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("confirmed true"),
+			),
+		).toBe(true);
+	});
+
+	it("supports extension input dialogs through Telegram replies", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "ask",
+						description: "Ask for input",
+						source: "extension",
+						path: "/ext/ask.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const value = await pi
+				.getExtensionBindings()
+				?.uiContext?.input("Name", "Your name");
+			pi.emitTextDelta(`hello ${value}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/ask" } }),
+		);
+		await nextTick();
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Name"),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "Bene" } }));
+		await pending;
+
+		expect(pi.service.prompt).toHaveBeenCalledTimes(1);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("hello Bene"),
+			),
+		).toBe(true);
+	});
+
+	it("times out pending extension dialogs and finalizes them in Telegram", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "pick",
+						description: "Pick an option",
+						source: "extension",
+						path: "/ext/pick.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const choice = await pi
+				.getExtensionBindings()
+				?.uiContext?.select("Pick one", ["Alpha", "Beta"], { timeout: 5 });
+			pi.emitTextDelta(`picked ${choice}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/pick" } }),
+		);
+		await nextTick();
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		await pending;
+
+		expect(
+			api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("Dialog timed out."),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("picked undefined"),
+			),
+		).toBe(true);
+	});
+
+	it("cancels pending extension dialogs via /abort and still aborts the session", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "confirm",
+						description: "Confirm action",
+						source: "extension",
+						path: "/ext/confirm.ts",
+					},
+				]),
+			},
+		});
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			const confirmed = await pi
+				.getExtensionBindings()
+				?.uiContext?.confirm("Confirm deploy", "Ship it?");
+			pi.emitTextDelta(`confirmed ${confirmed}`);
+			pi.emitAgentEnd();
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/confirm" } }),
+		);
+		await nextTick();
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/abort" } }));
+		await pending;
+
+		expect(pi.service.abort).toHaveBeenCalledTimes(1);
+		expect(
+			api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("Dialog cancelled."),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("confirmed false"),
+			),
+		).toBe(true);
+	});
+
+	it("blocks voice messages while an extension input dialog is pending", async () => {
+		const { bot, pi, api } = setupBot({
+			piSessionOverrides: {
+				listSlashCommands: vi.fn().mockResolvedValue([
+					{
+						name: "ask",
+						description: "Ask for input",
+						source: "extension",
+						path: "/ext/ask.ts",
+					},
+				]),
+			},
+		});
+
+		let resolveInput!: (value: void | PromiseLike<void>) => void;
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			await new Promise<void>(async (resolve) => {
+				resolveInput = resolve;
+				const value = await pi
+					.getExtensionBindings()
+					?.uiContext?.input("Name", "Your name");
+				pi.emitTextDelta(`hello ${value}`);
+				pi.emitAgentEnd();
+				resolve();
+			});
+		});
+
+		const pending = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/ask" } }),
+		);
+		await nextTick();
+		await bot.handleUpdate(createVoiceUpdate());
+
+		expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Please answer the pending prompt above or use /abort.",
+		);
+		expect(transcribeAudio).not.toHaveBeenCalled();
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "Bene" } }));
+		resolveInput();
+		await pending;
+	});
+
+	it("transcribes voice messages and feeds the transcript into the prompt flow", async () => {
+		const { bot, pi, api } = setupBot();
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.emitTextDelta("Voice response");
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(createVoiceUpdate());
+
+		expect(api.getFile).toHaveBeenCalledWith("voice-file-id");
+		expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+			"https://api.telegram.org/file/botbot-token/voice/file.ogg",
+		);
+		expect(transcribeAudio).toHaveBeenCalledTimes(1);
+		expect(pi.service.prompt).toHaveBeenCalledWith("transcribed text");
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("🎤 transcribed text"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Voice response"),
+			),
+		).toBe(true);
+		expect(writeFile).toHaveBeenCalledTimes(1);
+		expect(unlink).toHaveBeenCalledTimes(1);
+	});
+
+	it("handles photo messages by sending caption + image input to Pi", async () => {
+		const { bot, pi, api } = setupBot();
+		api.getFile.mockImplementation(async (fileId: string) => ({
+			file_id: fileId,
+			file_path:
+				fileId === "photo-big"
+					? "images/photo-big.jpg"
+					: "images/photo-small.jpg",
+		}));
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.emitTextDelta("Image response");
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(createPhotoUpdate());
+
+		expect(api.getFile).toHaveBeenCalledWith("photo-big");
+		expect(pi.service.prompt).toHaveBeenCalledWith("Check this graph", [
+			{
+				type: "image",
+				data: Buffer.from("image-bytes").toString("base64"),
+				mimeType: "image/jpeg",
+			},
+		]);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("🖼️ Check this graph"),
+			),
+		).toBe(true);
+		expect(unlink).toHaveBeenCalledTimes(1);
+	});
+
+	it("handles image documents and ignores non-image documents", async () => {
+		const { bot, pi, api } = setupBot();
+		api.getFile.mockImplementation(async (fileId: string) => ({
+			file_id: fileId,
+			file_path: "docs/diagram.png",
+		}));
+
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			pi.emitTextDelta("Document image response");
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createDocumentUpdate({ message: { caption: undefined } }),
+		);
+
+		expect(pi.service.prompt).toHaveBeenCalledWith(
+			"Please analyze this image.",
+			[
+				{
+					type: "image",
+					data: Buffer.from("image-bytes").toString("base64"),
+					mimeType: "image/png",
+				},
+			],
+		);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Please analyze this image."),
+			),
+		).toBe(true);
+
+		await bot.handleUpdate(
+			createDocumentUpdate({
+				message: {
+					document: {
+						file_id: "document-text-id",
+						file_unique_id: "document-text-unique",
+						file_name: "notes.txt",
+						mime_type: "text/plain",
+						file_size: 128,
+					},
+				},
+			}),
+		);
+
+		expect(api.getFile).not.toHaveBeenCalledWith("document-text-id");
+		expect(pi.service.prompt).toHaveBeenCalledTimes(1);
+	});
+
+	it("blocks voice messages while processing and reports transcription failures", async () => {
+		let resolvePrompt!: () => void;
+		const busy = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+
+		const pending = busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "first" } }),
+		);
+		await nextTick();
+		await busy.bot.handleUpdate(createVoiceUpdate());
+
+		expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Still working on previous message...",
+		);
+		expect(transcribeAudio).not.toHaveBeenCalled();
+
+		resolvePrompt();
+		await pending;
+
+		vi.mocked(transcribeAudio).mockRejectedValueOnce(
+			new Error("backend missing"),
+		);
+		const failure = setupBot();
+		await failure.bot.handleUpdate(createVoiceUpdate());
+
+		expect(
+			failure.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Transcription failed:"),
+			),
+		).toBe(true);
+		expect(failure.pi.service.prompt).not.toHaveBeenCalled();
+		expect(unlink).toHaveBeenCalled();
+	});
+
+	it("auto-creates a session for audio files before prompting", async () => {
+		const noSession = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+			},
+		});
+		const promptMock = noSession.pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			noSession.pi.emitTextDelta("Audio response");
+			noSession.pi.emitAgentEnd();
+		});
+
+		await noSession.bot.handleUpdate(
+			createVoiceUpdate({
+				message: {
+					voice: undefined,
+					audio: {
+						file_id: "audio-file-id",
+						file_unique_id: "audio-unique",
+						duration: 6,
+						mime_type: "audio/ogg",
+						file_name: "clip.ogg",
+					},
+				},
+			}),
+		);
+
+		expect(noSession.api.getFile).toHaveBeenCalledWith("audio-file-id");
+		expect(noSession.pi.service.newSession).toHaveBeenCalledTimes(1);
+		expect(noSession.pi.service.prompt).toHaveBeenCalledWith(
+			"transcribed text",
+		);
+	});
+
+	it("blocks new messages while processing and auto-creates a session when needed", async () => {
+		let resolvePrompt!: () => void;
+		const busy = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+
+		const first = busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "first" } }),
+		);
+		await nextTick();
+		await busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "second" } }),
+		);
+
+		expect(busy.api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Still working on previous message...",
+		);
+
+		resolvePrompt();
+		await first;
+
+		const noSession = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+			},
+		});
+		const promptMock = noSession.pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			noSession.pi.emitTextDelta("Fresh session response");
+			noSession.pi.emitAgentEnd();
+		});
+
+		await noSession.bot.handleUpdate(
+			createTestUpdate({ message: { text: "start over" } }),
+		);
+
+		expect(noSession.pi.service.newSession).toHaveBeenCalledTimes(1);
+		expect(noSession.pi.service.prompt).toHaveBeenCalledWith("start over");
+	});
+
+	it("blocks commands while switching sessions", async () => {
+		let resolveSwitch!: (info: SwitchResult) => void;
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockImplementation(
+					() =>
+						new Promise<SwitchResult>((resolve) => {
+							resolveSwitch = resolve;
+						}),
+				),
+			},
+		});
+
+		const switching = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+		await nextTick();
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+
+		expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Cannot create new session while a prompt is running.",
+		);
+
+		resolveSwitch({
+			sessionId: "switched-id",
+			sessionFile: "/tmp/switched.jsonl",
+			workspace: "/other",
+			model: "anthropic/claude-sonnet-4-5",
+			cancelled: false,
+		});
+		await switching;
+	});
+
+	it("blocks tree commands while processing or switching", async () => {
+		let resolvePrompt!: () => void;
+		const busy = setupBot({
+			piSessionOverrides: {
+				prompt: vi.fn().mockImplementation(
+					() =>
+						new Promise<void>((resolve) => {
+							resolvePrompt = resolve;
+						}),
+				),
+			},
+		});
+
+		const pending = busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello" } }),
+		);
+		await nextTick();
+		await busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		await busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch branch111" } }),
+		);
+		await busy.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label mark" } }),
+		);
+		await busy.bot.handleUpdate(createCallbackUpdate("tree_nav_branch111"));
+
+		expect(
+			busy.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Cannot view tree while a prompt is running."),
+			),
+		).toBe(true);
+		expect(
+			busy.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Cannot navigate while a prompt is running."),
+			),
+		).toBe(true);
+		expect(
+			busy.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes(
+					"Cannot label entries while a prompt is running.",
+				),
+			),
+		).toBe(true);
+		expect(busy.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Wait for the current prompt to finish",
+		});
+
+		resolvePrompt();
+		await pending;
+	});
+
+	it("surfaces startup error diagnostics once before the first prompt in a fresh context", async () => {
+		const topicKey = makeContextKey(ALLOWED_CHAT_ID, 909);
+		let registryRef: ReturnType<typeof createMockPiSessionRegistry> | undefined;
+		const prompt = vi.fn().mockImplementation(async () => {
+			const topicSession = registryRef?.getSession(ALLOWED_CHAT_ID, 909);
+			topicSession?.emitTextDelta("Fresh context response");
+			topicSession?.emitAgentEnd();
+		});
+		const harness = setupBot({
+			perContextSessionOverrides: {
+				[topicKey]: {
+					getInfo: vi.fn().mockReturnValue({
+						sessionId: "diagnostic-session",
+						sessionFile: "/tmp/diagnostic.jsonl",
+						workspace: "/workspace",
+						model: "anthropic/claude-sonnet-4-5",
+						diagnostics: [
+							{
+								type: "error",
+								message: 'Failed to load extension "/ext/bad.ts": boom',
+							},
+							{
+								type: "warning",
+								message:
+									"Theme issue (/themes/missing.json): theme path does not exist",
+							},
+						],
+					}),
+					prompt,
+				},
+			},
+		});
+		registryRef = harness.registry;
+		const { bot, api } = harness;
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "first prompt",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 909,
+				},
+			}),
+		);
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "second prompt",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 909,
+				},
+			}),
+		);
+
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(1);
+		expect(startupMessages[0]).toContain(
+			'Failed to load extension "/ext/bad.ts": boom',
+		);
+		expect(startupMessages[0]).not.toContain("Theme issue");
+	});
+
+	it("surfaces startup error diagnostics when /model creates a fresh session context", async () => {
+		const topicKey = makeContextKey(ALLOWED_CHAT_ID, 910);
+		const { bot, api } = setupBot({
+			perContextSessionOverrides: {
+				[topicKey]: {
+					getInfo: vi.fn().mockReturnValue({
+						sessionId: "model-diagnostic-session",
+						sessionFile: "/tmp/model-diagnostic.jsonl",
+						workspace: "/workspace",
+						model: "anthropic/claude-sonnet-4-5",
+						diagnostics: [
+							{
+								type: "error",
+								message:
+									"Prompt issue (/prompts/deploy.md): invalid frontmatter",
+							},
+						],
+					}),
+				},
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({
+				message: {
+					text: "/model",
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 910,
+				},
+			}),
+		);
+
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Session startup issues"),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes(
+					"Prompt issue (/prompts/deploy.md): invalid frontmatter",
+				),
+			),
+		).toBe(true);
+		expect(
+			api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("Select a model"),
+			),
+		).toBe(true);
+	});
+
+	it("re-surfaces startup diagnostics after /handback tears down the context", async () => {
+		const topicKey = makeContextKey(ALLOWED_CHAT_ID, 911);
+		let registryRef: ReturnType<typeof createMockPiSessionRegistry> | undefined;
+		const prompt = vi.fn().mockImplementation(async () => {
+			const session = registryRef?.getSession(ALLOWED_CHAT_ID, 911);
+			session?.emitTextDelta("Context rebuilt response");
+			session?.emitAgentEnd();
+		});
+		const harness = setupBot({
+			perContextSessionOverrides: {
+				[topicKey]: {
+					getInfo: vi.fn().mockReturnValue({
+						sessionId: "reused-diagnostic-session",
+						sessionFile: "/tmp/reused-diagnostic.jsonl",
+						workspace: "/workspace",
+						model: "anthropic/claude-sonnet-4-5",
+						diagnostics: [
+							{
+								type: "error",
+								message: "Extension issue (/ext/reload.ts): startup failed",
+							},
+						],
+					}),
+					prompt,
+				},
+			},
+		});
+		registryRef = harness.registry;
+		const { bot, api } = harness;
+		const topicMessage = (text: string) =>
+			createTestUpdate({
+				message: {
+					text,
+					chat: { id: ALLOWED_CHAT_ID, type: "supergroup" },
+					message_thread_id: 911,
+				},
+			});
+
+		await bot.handleUpdate(topicMessage("first prompt"));
+		await bot.handleUpdate(topicMessage("/handback"));
+		await bot.handleUpdate(topicMessage("second prompt"));
+
+		const startupMessages = api.sendMessage.mock.calls
+			.map((call) => String(call[1]))
+			.filter((text) => text.includes("Session startup issues"));
+		expect(startupMessages).toHaveLength(2);
+		expect(startupMessages[0]).toContain(
+			"Extension issue (/ext/reload.ts): startup failed",
+		);
+		expect(startupMessages[1]).toContain(
+			"Extension issue (/ext/reload.ts): startup failed",
+		);
+	});
+
+	it("covers additional command edge cases", async () => {
+		const noSessions = setupBot({
+			piSessionOverrides: {
+				listAllSessions: vi.fn().mockResolvedValue([]),
+			},
+		});
+		await noSessions.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		expect(noSessions.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"No saved sessions found.",
+		);
+
+		const cancelledNew = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+				newSession: vi.fn().mockResolvedValue({
+					info: {
+						sessionId: "cancelled",
+						sessionFile: "/tmp/cancelled.jsonl",
+						workspace: "/workspace/A",
+						model: "anthropic/claude-sonnet-4-5",
+					},
+					created: false,
+				}),
+			},
+		});
+		await cancelledNew.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(cancelledNew.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"New session was cancelled.",
+		);
+
+		const failedNew = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+				newSession: vi.fn().mockRejectedValue(new Error("new failed")),
+			},
+		});
+		await failedNew.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(failedNew.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"new failed",
+		);
+
+		const sameWorkspaceNewUnavailable = setupBot({
+			piSessionOverrides: {
+				listWorkspaces: vi.fn().mockResolvedValue(["/workspace/A"]),
+				newSession: vi
+					.fn()
+					.mockRejectedValue(
+						new Error(
+							"Starting a fresh session in the current workspace isn't available in this TelePi version yet.",
+						),
+					),
+			},
+		});
+		await sameWorkspaceNewUnavailable.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(
+			sameWorkspaceNewUnavailable.api.sendMessage.mock.calls[0]?.[1],
+		).toContain(
+			"Starting a fresh session in the current workspace isn't available in this TelePi version yet.",
+		);
+		expect(
+			sameWorkspaceNewUnavailable.api.sendMessage.mock.calls[0]?.[1],
+		).not.toContain("AgentSessionRuntime migration");
+
+		const failedModelBootstrap = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+				newSession: vi.fn().mockRejectedValue(new Error("bootstrap failed")),
+			},
+		});
+		await failedModelBootstrap.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/model" } }),
+		);
+		expect(failedModelBootstrap.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Failed to create session",
+		);
+		expect(failedModelBootstrap.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"bootstrap failed",
+		);
+
+		const noModels = setupBot({
+			piSessionOverrides: {
+				listModels: vi.fn().mockResolvedValue([]),
+			},
+		});
+		await noModels.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/model" } }),
+		);
+		expect(noModels.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"No models available.",
+		);
+	});
+
+	it("expires page callbacks when the original picker state is gone", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(createCallbackUpdate("switch_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /sessions again",
+		});
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(createCallbackUpdate("newws_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /new again",
+		});
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(createCallbackUpdate("model_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /model again",
+		});
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(createCallbackUpdate("model_show_all"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /model again",
+		});
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(createCallbackUpdate("tree_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /tree again",
+		});
+
+		api.answerCallbackQuery.mockClear();
+		await bot.handleUpdate(createCallbackUpdate("branch_page_1"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /branch again",
+		});
+	});
+
+	it("handles noop_page callback without editing the message", async () => {
+		const { bot, api } = setupBot();
+
+		await bot.handleUpdate(createCallbackUpdate("noop_page"));
+		expect(api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {});
+		expect(api.editMessageText).not.toHaveBeenCalled();
+		expect(api.editMessageReplyMarkup).not.toHaveBeenCalled();
+	});
+
+	it("handles callback edge cases and the abort button", async () => {
+		const abortCallback = setupBot();
+		await abortCallback.bot.handleUpdate(createCallbackUpdate("pi_abort"));
+		expect(abortCallback.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Aborting...",
+		});
+		expect(abortCallback.pi.service.abort).toHaveBeenCalledTimes(1);
+
+		const expiredWorkspace = setupBot();
+		await expiredWorkspace.bot.handleUpdate(createCallbackUpdate("newws_0"));
+		expect(expiredWorkspace.api.answerCallbackQuery).toHaveBeenCalledWith(
+			"cb_1",
+			{
+				text: "Expired, run /new again",
+			},
+		);
+
+		const cancelledWorkspace = setupBot({
+			piSessionOverrides: {
+				newSession: vi.fn().mockResolvedValue({
+					info: {
+						sessionId: "cancelled",
+						sessionFile: "/tmp/cancelled.jsonl",
+						workspace: "/workspace/B",
+						model: "anthropic/claude-sonnet-4-5",
+					},
+					created: false,
+				}),
+			},
+		});
+		await cancelledWorkspace.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		await cancelledWorkspace.bot.handleUpdate(createCallbackUpdate("newws_1"));
+		expect(
+			cancelledWorkspace.api.editMessageText.mock.calls.at(-1)?.[2],
+		).toContain("New session was cancelled.");
+
+		const expiredModel = setupBot();
+		await expiredModel.bot.handleUpdate(createCallbackUpdate("model_0"));
+		expect(expiredModel.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Expired, run /model again",
+		});
+
+		const failedModel = setupBot({
+			piSessionOverrides: {
+				setModel: vi.fn().mockRejectedValue(new Error("model failed")),
+			},
+		});
+		await failedModel.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/model" } }),
+		);
+		await failedModel.bot.handleUpdate(createCallbackUpdate("model_1"));
+		expect(failedModel.api.editMessageText.mock.calls.at(-1)?.[2]).toContain(
+			"model failed",
+		);
+	});
+
+	it("summarizes tool usage, reports tool errors, and handles prompt failures", async () => {
+		const summary = setupBot();
+		const summaryPrompt = summary.pi.service.prompt as ReturnType<typeof vi.fn>;
+		summaryPrompt.mockImplementation(async () => {
+			summary.pi.emitTextDelta("Finished response");
+			summary.pi.emitToolStart("bash", "tool-1");
+			summary.pi.emitToolStart("read", "tool-2");
+			summary.pi.emitToolStart("bash", "tool-3");
+			summary.pi.emitAgentEnd();
+		});
+		await summary.bot.handleUpdate(
+			createTestUpdate({ message: { text: "summarize" } }),
+		);
+		expect(
+			summary.api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("bash ×2, read"),
+			),
+		).toBe(true);
+
+		const errorsOnly = setupBot({
+			configOverrides: { toolVerbosity: "errors-only" },
+		});
+		const errorsOnlyPrompt = errorsOnly.pi.service.prompt as ReturnType<
+			typeof vi.fn
+		>;
+		errorsOnlyPrompt.mockImplementation(async () => {
+			errorsOnly.pi.emitTextDelta("Answer");
+			errorsOnly.pi.emitToolStart("bash", "tool-1");
+			errorsOnly.pi.emitToolUpdate("tool-1", "stderr");
+			errorsOnly.pi.emitToolEnd("tool-1", true);
+			errorsOnly.pi.emitAgentEnd();
+		});
+		await errorsOnly.bot.handleUpdate(
+			createTestUpdate({ message: { text: "show tool error" } }),
+		);
+		expect(
+			errorsOnly.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("❌"),
+			),
+		).toBe(true);
+
+		const failure = setupBot();
+		const failurePrompt = failure.pi.service.prompt as ReturnType<typeof vi.fn>;
+		failurePrompt.mockImplementation(async () => {
+			failure.pi.emitTextDelta("Partial output");
+			throw new Error("prompt failed");
+		});
+		await failure.bot.handleUpdate(
+			createTestUpdate({ message: { text: "break" } }),
+		);
+		expect(
+			failure.api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("⚠️ prompt failed"),
+			),
+		).toBe(true);
+
+		const aborted = setupBot();
+		const abortedPrompt = aborted.pi.service.prompt as ReturnType<typeof vi.fn>;
+		abortedPrompt.mockImplementation(async () => {
+			aborted.pi.emitTextDelta("Partial output");
+			throw new Error("Abort requested");
+		});
+		await aborted.bot.handleUpdate(
+			createTestUpdate({ message: { text: "stop" } }),
+		);
+		expect(
+			aborted.api.editMessageText.mock.calls.some((call) =>
+				String(call[2]).includes("⏹ Aborted"),
+			),
+		).toBe(true);
+	});
+
+	it("handles Telegram parse fallbacks and long streaming responses", async () => {
+		const sendFallback = setupBot();
+		sendFallback.api.sendMessage
+			.mockRejectedValueOnce(new Error("can't parse entities"))
+			.mockImplementation(
+				async (chatId: number | string, text: string, opts?: any) => ({
+					message_id: 99,
+					chat: { id: chatId },
+					text,
+					...opts,
+				}),
+			);
+		await sendFallback.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/start" } }),
+		);
+		expect(sendFallback.api.sendMessage).toHaveBeenCalledTimes(2);
+		expect(
+			sendFallback.api.sendMessage.mock.calls[1]?.[2]?.parse_mode,
+		).toBeUndefined();
+
+		const editFallback = setupBot();
+		editFallback.api.editMessageText
+			.mockRejectedValueOnce(new Error("unsupported start tag"))
+			.mockResolvedValue(true);
+		await editFallback.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/model" } }),
+		);
+		await editFallback.bot.handleUpdate(createCallbackUpdate("model_1"));
+		expect(editFallback.api.editMessageText).toHaveBeenCalledTimes(2);
+		expect(
+			editFallback.api.editMessageText.mock.calls[1]?.[3]?.parse_mode,
+		).toBeUndefined();
+
+		const notModified = setupBot();
+		notModified.api.editMessageText.mockRejectedValueOnce(
+			new Error("message is not modified"),
+		);
+		await notModified.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/model" } }),
+		);
+		await notModified.bot.handleUpdate(createCallbackUpdate("model_1"));
+		expect(notModified.api.editMessageText).toHaveBeenCalledTimes(1);
+
+		const longResponse = setupBot();
+		const longPrompt = longResponse.pi.service.prompt as ReturnType<
+			typeof vi.fn
+		>;
+		const longChunk = "word ".repeat(900);
+		longPrompt.mockImplementation(async () => {
+			longResponse.pi.emitTextDelta(`${longChunk}${longChunk}`);
+			longResponse.pi.emitTextDelta(`${longChunk}${longChunk}`);
+			longResponse.pi.emitAgentEnd();
+		});
+		await longResponse.bot.handleUpdate(
+			createTestUpdate({ message: { text: "long reply" } }),
+		);
+		expect(
+			longResponse.api.sendMessage.mock.calls.some((call) =>
+				String(call[1]).includes("preview truncated"),
+			),
+		).toBe(true);
+		expect(longResponse.api.sendMessage.mock.calls.length).toBeGreaterThan(1);
+	});
+
+	it("registers bot commands", async () => {
+		const { bot, api } = setupBot();
+
+		await registerCommands(bot);
+
+		expect(api.setMyCommands).toHaveBeenCalledWith(
+			[
+				{ command: "start", description: "Welcome and session info" },
+				{ command: "help", description: "Show commands and usage tips" },
+				{ command: "commands", description: "Browse TelePi and Pi commands" },
+				{ command: "new", description: "Start a new session" },
+				{
+					command: "retry",
+					description: "Retry the last prompt in this chat/topic",
+				},
+				{ command: "handback", description: "Hand session back to Pi CLI" },
+				{ command: "abort", description: "Cancel current operation" },
+				{ command: "session", description: "Current session details" },
+				{
+					command: "sessions",
+					description: "List and switch sessions (or /sessions <path|id>)",
+				},
+				{
+					command: "context",
+					description: "Show context usage and session stats",
+				},
+				{ command: "model", description: "Switch AI model" },
+				{ command: "tree", description: "View and navigate the session tree" },
+				{
+					command: "branch",
+					description: "Navigate to a tree entry (/branch <id>)",
+				},
+				{
+					command: "label",
+					description: "Label an entry (/label [name] or /label <id> <name>)",
+				},
+			],
+			undefined,
+		);
+	});
+
+	it("blocks commands when piSession.isStreaming() returns true", async () => {
+		const streaming = setupBot({
+			piSessionOverrides: {
+				isStreaming: vi.fn().mockReturnValue(true),
+			},
+		});
+
+		// /sessions should be blocked
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Cannot switch sessions while a prompt is running.",
+		);
+
+		// /new should be blocked
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/new" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[1]?.[1]).toContain(
+			"Cannot create new session while a prompt is running.",
+		);
+
+		// /handback should be blocked
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[2]?.[1]).toContain(
+			"Cannot hand back while a prompt is running.",
+		);
+
+		// tree commands should be blocked
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/tree" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[3]?.[1]).toContain(
+			"Cannot view tree while a prompt is running.",
+		);
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/branch branch111" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[4]?.[1]).toContain(
+			"Cannot navigate while a prompt is running.",
+		);
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "/label saved" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[5]?.[1]).toContain(
+			"Cannot label entries while a prompt is running.",
+		);
+
+		// text messages should be blocked
+		await streaming.bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello there" } }),
+		);
+		expect(streaming.api.sendMessage.mock.calls[6]?.[1]).toContain(
+			"Still working on previous message...",
+		);
+
+		await streaming.bot.handleUpdate(
+			createCallbackUpdate("tree_nav_branch111"),
+		);
+		expect(streaming.api.answerCallbackQuery).toHaveBeenCalledWith("cb_1", {
+			text: "Wait for the current prompt to finish",
+		});
+	});
+
+	it("sends '✅ Done' when agent ends with no text output", async () => {
+		const { bot, pi, api } = setupBot();
+		const promptMock = pi.service.prompt as ReturnType<typeof vi.fn>;
+		promptMock.mockImplementation(async () => {
+			// Agent ends without emitting any text deltas
+			pi.emitAgentEnd();
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "do something silent" } }),
+		);
+
+		const allSentTexts = api.sendMessage.mock.calls.map((call) =>
+			String(call[1]),
+		);
+		expect(allSentTexts.some((text) => text.includes("✅ Done"))).toBe(true);
+	});
+
+	it("handles in-memory handback (no sessionFile)", async () => {
+		const { bot, api, registry } = setupBot({
+			piSessionOverrides: {
+				handback: vi.fn().mockResolvedValue({
+					sessionFile: undefined,
+					workspace: "/workspace",
+				}),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain(
+			"Session was in-memory",
+		);
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("No file to resume");
+		expect(
+			registry.registry.remove as ReturnType<typeof vi.fn>,
+		).toHaveBeenCalledWith({
+			chatId: ALLOWED_CHAT_ID,
+		});
+	});
+
+	it("handles handback error", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				handback: vi.fn().mockRejectedValue(new Error("dispose exploded")),
+			},
+		});
+
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/handback" } }),
+		);
+
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("Failed:");
+		expect(api.sendMessage.mock.calls[0]?.[1]).toContain("dispose exploded");
+	});
+
+	it("blocks text messages when isSwitching is active", async () => {
+		let resolveSwitch!: (info: SwitchResult) => void;
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockImplementation(
+					() =>
+						new Promise<SwitchResult>((resolve) => {
+							resolveSwitch = resolve;
+						}),
+				),
+			},
+		});
+
+		// Start a switch via /sessions <path>
+		const switching = bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions /saved/session.jsonl" } }),
+		);
+		await nextTick();
+
+		// Try to send a text message — should be blocked
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "hello there" } }),
+		);
+		expect(api.sendMessage.mock.calls.at(-1)?.[1]).toContain(
+			"Still working on previous message...",
+		);
+
+		resolveSwitch({
+			sessionId: "switched-id",
+			sessionFile: "/tmp/switched.jsonl",
+			workspace: "/other",
+			model: "anthropic/claude-sonnet-4-5",
+			cancelled: false,
+		});
+		await switching;
+	});
+
+	it("handles switch callback error", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				switchSession: vi.fn().mockRejectedValue(new Error("switch exploded")),
+			},
+		});
+
+		// Set up picks first
+		await bot.handleUpdate(
+			createTestUpdate({ message: { text: "/sessions" } }),
+		);
+		// Now click a switch button
+		await bot.handleUpdate(createCallbackUpdate("switch_0"));
+
+		expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("Failed:");
+		expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain(
+			"switch exploded",
+		);
+	});
+
+	it("handles newws callback error", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				newSession: vi.fn().mockRejectedValue(new Error("create exploded")),
+			},
+		});
+
+		// Set up workspace picks
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/new" } }));
+		// Click a workspace button
+		await bot.handleUpdate(createCallbackUpdate("newws_0"));
+
+		expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain("Failed:");
+		expect(api.editMessageText.mock.calls.at(-1)?.[2]).toContain(
+			"create exploded",
+		);
+	});
+
+	it("shows context usage with /context command", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				getContextUsage: vi.fn().mockReturnValue({
+					tokens: 15000,
+					contextWindow: 128000,
+					percent: 11.72,
+				}),
+				getSessionStats: vi.fn().mockReturnValue({
+					userMessages: 10,
+					assistantMessages: 10,
+					toolCalls: 25,
+					toolResults: 25,
+					totalMessages: 40,
+					tokens: {
+						input: 120000,
+						output: 30000,
+						cacheRead: 5000,
+						cacheWrite: 2000,
+						total: 157000,
+					},
+					cost: 0.12,
+					contextUsage: {
+						tokens: 15000,
+						contextWindow: 128000,
+						percent: 11.72,
+					},
+					sessionFile: "/tmp/session.jsonl",
+					sessionId: "test-session",
+				}),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/context" } }));
+
+		const sentText = String(api.sendMessage.mock.calls[0]?.[1]);
+		expect(sentText).toContain("Context Usage");
+		expect(sentText).toContain("15,000");
+		expect(sentText).toContain("128,000");
+		expect(sentText).toContain("11.72%");
+		expect(sentText).toContain("Session Stats");
+		expect(sentText).toContain("10");
+		expect(sentText).toContain("user");
+		expect(sentText).toContain("25");
+		expect(sentText).toContain("$0.1200");
+	});
+
+	it("shows 'no active session' with /context when session is missing", async () => {
+		const { bot, api } = setupBot({
+			piSessionOverrides: {
+				hasActiveSession: vi.fn().mockReturnValue(false),
+				getContextUsage: vi.fn().mockReturnValue(undefined),
+				getSessionStats: vi.fn().mockReturnValue(undefined),
+			},
+		});
+
+		await bot.handleUpdate(createTestUpdate({ message: { text: "/context" } }));
+
+		const sentText = String(api.sendMessage.mock.calls[0]?.[1]);
+		expect(sentText).toContain("No active session");
+	});
 });

--- a/test/bot/slash-command-cache.test.ts
+++ b/test/bot/slash-command-cache.test.ts
@@ -2,74 +2,88 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 
 function createSourceInfo(filePath: string) {
-  return {
-    path: filePath,
-    source: "local" as const,
-    scope: "project" as const,
-    origin: "top-level" as const,
-  };
+	return {
+		path: filePath,
+		source: "local" as const,
+		scope: "project" as const,
+		origin: "top-level" as const,
+	};
 }
 
 describe("bot slash-command argument hint caching", () => {
-  let tempDir: string | undefined;
+	let tempDir: string | undefined;
 
-  afterEach(() => {
-    vi.doUnmock("node:fs");
-    vi.resetModules();
-    vi.restoreAllMocks();
+	afterEach(() => {
+		vi.doUnmock("node:fs");
+		vi.resetModules();
+		vi.restoreAllMocks();
 
-    if (tempDir) {
-      rmSync(tempDir, { recursive: true, force: true });
-      tempDir = undefined;
-    }
-  });
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
 
-  it("reuses prompt argument hints per source path while building picker entries", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "telepi-slash-command-cache-"));
-    const promptPath = path.join(tempDir, "review.md");
-    writeFileSync(
-      promptPath,
-      [
-        "---",
-        "description: Review recent changes",
-        'argument-hint: "<PR-URL>"',
-        "---",
-        "Review changes.",
-        "",
-      ].join("\n"),
-    );
+	it("reuses prompt argument hints per source path while building picker entries", async () => {
+		tempDir = mkdtempSync(path.join(tmpdir(), "telepi-slash-command-cache-"));
+		const promptPath = path.join(tempDir, "review.md");
+		writeFileSync(
+			promptPath,
+			[
+				"---",
+				"description: Review recent changes",
+				'argument-hint: "<PR-URL>"',
+				"---",
+				"Review changes.",
+				"",
+			].join("\n"),
+		);
 
-    const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
-    const readFileSync = vi.fn(actualFs.readFileSync);
-    vi.doMock("node:fs", () => ({
-      ...actualFs,
-      readFileSync,
-    }));
+		const actualFs = await vi.importActual<typeof import("node:fs")>("node:fs");
+		const readFileSync = vi.fn(actualFs.readFileSync);
+		vi.doMock("node:fs", () => ({
+			...actualFs,
+			readFileSync,
+		}));
 
-    const { buildCommandPickerEntries } = await import("../../src/bot/slash-command.js");
-    const slashCommands = [
-      {
-        name: "review",
-        description: "Review recent changes",
-        source: "prompt",
-        sourceInfo: createSourceInfo(promptPath),
-      },
-      {
-        name: "review-again",
-        description: "Review recent changes again",
-        source: "prompt",
-        sourceInfo: createSourceInfo(promptPath),
-      },
-    ] satisfies SlashCommandInfo[];
+		const { buildCommandPickerEntries } = await import(
+			"../../src/bot/slash-command.js"
+		);
+		const slashCommands = [
+			{
+				name: "review",
+				description: "Review recent changes",
+				source: "prompt",
+				sourceInfo: createSourceInfo(promptPath),
+			},
+			{
+				name: "review-again",
+				description: "Review recent changes again",
+				source: "prompt",
+				sourceInfo: createSourceInfo(promptPath),
+			},
+		] satisfies SlashCommandInfo[];
 
-    const entries = buildCommandPickerEntries(slashCommands);
+		const entries = buildCommandPickerEntries(slashCommands);
 
-    expect(entries).toContainEqual(expect.objectContaining({ kind: "pi", name: "review", label: "📝 /review <PR-URL>" }));
-    expect(entries).toContainEqual(expect.objectContaining({ kind: "pi", name: "review-again", label: "📝 /review-again <PR-URL>" }));
-    expect(readFileSync).toHaveBeenCalledTimes(1);
-    expect(readFileSync).toHaveBeenCalledWith(promptPath, "utf8");
-  });
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				kind: "pi",
+				name: "review",
+				label: "📝 /review <PR-URL>",
+			}),
+		);
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				kind: "pi",
+				name: "review-again",
+				label: "📝 /review-again <PR-URL>",
+			}),
+		);
+		expect(readFileSync).toHaveBeenCalledTimes(1);
+		expect(readFileSync).toHaveBeenCalledWith(promptPath, "utf8");
+	});
 });

--- a/test/bot/slash-command.test.ts
+++ b/test/bot/slash-command.test.ts
@@ -2,286 +2,385 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import type { SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 
 import {
-  TELEPI_BOT_COMMANDS,
-  buildChatScopedCommands,
-  buildChatScopedCommandSignature,
-  buildCommandPickerEntries,
-  filterCommandPickerEntries,
-  getCommandPickerCounts,
-  getCommandPickerFilterName,
-  getTelepiNativeCommandMenu,
-  normalizeSlashCommand,
-  rewriteSlashCommandForTelegram,
+	buildChatScopedCommandSignature,
+	buildChatScopedCommands,
+	buildCommandPickerEntries,
+	filterCommandPickerEntries,
+	getCommandPickerCounts,
+	getCommandPickerFilterName,
+	getTelepiNativeCommandMenu,
+	normalizeSlashCommand,
+	rewriteSlashCommandForTelegram,
+	TELEPI_BOT_COMMANDS,
 } from "../../src/bot/slash-command.js";
 
 function createSourceInfo(filePath: string) {
-  return {
-    path: filePath,
-    source: "local" as const,
-    scope: "project" as const,
-    origin: "top-level" as const,
-  };
+	return {
+		path: filePath,
+		source: "local" as const,
+		scope: "project" as const,
+		origin: "top-level" as const,
+	};
 }
 
-function makeSlashCommand(name: string, overrides: Partial<SlashCommandInfo> = {}): SlashCommandInfo {
-  return {
-    name,
-    description: `${name} command`,
-    source: "extension",
-    sourceInfo: createSourceInfo(`/ext/${name}.ts`) as any,
-    ...overrides,
-  };
+function makeSlashCommand(
+	name: string,
+	overrides: Partial<SlashCommandInfo> = {},
+): SlashCommandInfo {
+	return {
+		name,
+		description: `${name} command`,
+		source: "extension",
+		sourceInfo: createSourceInfo(`/ext/${name}.ts`) as any,
+		...overrides,
+	};
 }
 
 describe("bot slash-command helpers", () => {
-  let tempDir: string | undefined;
+	let tempDir: string | undefined;
 
-  afterEach(() => {
-    if (tempDir) {
-      rmSync(tempDir, { recursive: true, force: true });
-      tempDir = undefined;
-    }
-  });
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
 
-  it("normalizes slash commands and respects addressed bot usernames", () => {
-    expect(normalizeSlashCommand("/review foo bar")).toEqual({
-      name: "review",
-      text: "/review foo bar",
-    });
+	it("normalizes slash commands and respects addressed bot usernames", () => {
+		expect(normalizeSlashCommand("/review foo bar")).toEqual({
+			name: "review",
+			text: "/review foo bar",
+		});
 
-    expect(normalizeSlashCommand("/review@TelePiBot foo", "telepibot")).toEqual({
-      name: "review",
-      text: "/review foo",
-    });
+		expect(normalizeSlashCommand("/review@TelePiBot foo", "telepibot")).toEqual(
+			{
+				name: "review",
+				text: "/review foo",
+			},
+		);
 
-    expect(normalizeSlashCommand("/review@OtherBot foo", "telepibot")).toBeUndefined();
-    expect(normalizeSlashCommand("not a command", "telepibot")).toBeUndefined();
-    expect(normalizeSlashCommand("/", "telepibot")).toBeUndefined();
-  });
+		expect(
+			normalizeSlashCommand("/review@OtherBot foo", "telepibot"),
+		).toBeUndefined();
+		expect(normalizeSlashCommand("not a command", "telepibot")).toBeUndefined();
+		expect(normalizeSlashCommand("/", "telepibot")).toBeUndefined();
+	});
 
-  it("detects TelePi bare native menus from discovered slash command metadata", () => {
-    const entries = [
-      { id: "list", label: "📋 /cron list", commandText: "/cron list" },
-      { id: "status", label: "📊 /cron status", commandText: "/cron status" },
-      { id: "add", label: "➕ /cron add", commandText: "/cron add" },
-      { id: "manage", label: "🛠️ /cron manage", commandText: "/cron manage" },
-    ];
-    const slashCommands: SlashCommandInfo[] = [
-      makeSlashCommand("cron", {
-        description: "Manage PiCron schedules",
-        integrations: {
-          telepi: {
-            bare: {
-              kind: "native-menu",
-              entries,
-            },
-          },
-        },
-      }),
-    ];
+	it("detects TelePi bare native menus from discovered slash command metadata", () => {
+		const entries = [
+			{ id: "list", label: "📋 /cron list", commandText: "/cron list" },
+			{ id: "status", label: "📊 /cron status", commandText: "/cron status" },
+			{ id: "add", label: "➕ /cron add", commandText: "/cron add" },
+			{ id: "manage", label: "🛠️ /cron manage", commandText: "/cron manage" },
+		];
+		const slashCommands: SlashCommandInfo[] = [
+			makeSlashCommand("cron", {
+				description: "Manage PiCron schedules",
+				integrations: {
+					telepi: {
+						bare: {
+							kind: "native-menu",
+							entries,
+						},
+					},
+				},
+			}),
+		];
 
-    expect(getTelepiNativeCommandMenu({ name: "cron", text: "/cron" }, slashCommands)).toEqual({
-      name: "cron",
-      bareCommandText: "/cron",
-      title: "/cron",
-      entries,
-    });
-  });
+		expect(
+			getTelepiNativeCommandMenu(
+				{ name: "cron", text: "/cron" },
+				slashCommands,
+			),
+		).toEqual({
+			name: "cron",
+			bareCommandText: "/cron",
+			title: "/cron",
+			entries,
+		});
+	});
 
-  it("treats missing or invalid native menu metadata as a normal slash command", () => {
-    expect(
-      getTelepiNativeCommandMenu(
-        { name: "cron", text: "/cron" },
-        [makeSlashCommand("cron", { description: "Manage PiCron schedules" })],
-      ),
-    ).toBeUndefined();
+	it("treats missing or invalid native menu metadata as a normal slash command", () => {
+		expect(
+			getTelepiNativeCommandMenu({ name: "cron", text: "/cron" }, [
+				makeSlashCommand("cron", { description: "Manage PiCron schedules" }),
+			]),
+		).toBeUndefined();
 
-    expect(
-      getTelepiNativeCommandMenu(
-        { name: "cron", text: "/cron" },
-        [
-          makeSlashCommand("cron", {
-            description: "Manage PiCron schedules",
-            integrations: {
-              telepi: {
-                bare: {
-                  kind: "native-menu",
-                  entries: [
-                    { id: "list", label: "📋 /cron list", commandText: "/cron list" },
-                    { id: "broken", label: "", commandText: "/cron status" } as any,
-                  ],
-                },
-              },
-            },
-          }),
-        ],
-      ),
-    ).toBeUndefined();
-  });
+		expect(
+			getTelepiNativeCommandMenu({ name: "cron", text: "/cron" }, [
+				makeSlashCommand("cron", {
+					description: "Manage PiCron schedules",
+					integrations: {
+						telepi: {
+							bare: {
+								kind: "native-menu",
+								entries: [
+									{
+										id: "list",
+										label: "📋 /cron list",
+										commandText: "/cron list",
+									},
+									{
+										id: "broken",
+										label: "",
+										commandText: "/cron status",
+									} as any,
+								],
+							},
+						},
+					},
+				}),
+			]),
+		).toBeUndefined();
+	});
 
-  it("builds command picker entries with TelePi commands first and source labels for Pi commands", () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "telepi-slash-command-"));
-    const reviewPromptPath = path.join(tempDir, "review.md");
-    writeFileSync(
-      reviewPromptPath,
-      [
-        "---",
-        "description: Review recent changes",
-        'argument-hint: "<PR-URL>"',
-        "---",
-        "Review changes.",
-        "",
-      ].join("\n"),
-    );
+	it("builds command picker entries with TelePi commands first and source labels for Pi commands", () => {
+		tempDir = mkdtempSync(path.join(tmpdir(), "telepi-slash-command-"));
+		const reviewPromptPath = path.join(tempDir, "review.md");
+		writeFileSync(
+			reviewPromptPath,
+			[
+				"---",
+				"description: Review recent changes",
+				'argument-hint: "<PR-URL>"',
+				"---",
+				"Review changes.",
+				"",
+			].join("\n"),
+		);
 
-    const slashCommands: SlashCommandInfo[] = [
-      {
-        name: "review",
-        description: "Review recent changes",
-        source: "prompt",
-        sourceInfo: createSourceInfo(reviewPromptPath),
-      },
-      {
-        name: "skill:browser-tools",
-        description: "Browser tools",
-        source: "skill",
-        sourceInfo: createSourceInfo("/skills/browser.md"),
-      },
-      {
-        name: "deploy",
-        description: "Deploy app",
-        source: "extension",
-        sourceInfo: createSourceInfo("/ext/deploy.ts"),
-      },
-      {
-        name: "agentic",
-        description: "Agent action",
-        source: "agent" as any,
-        sourceInfo: createSourceInfo("/agentic"),
-      },
-    ];
+		const slashCommands: SlashCommandInfo[] = [
+			{
+				name: "review",
+				description: "Review recent changes",
+				source: "prompt",
+				sourceInfo: createSourceInfo(reviewPromptPath),
+			},
+			{
+				name: "skill:browser-tools",
+				description: "Browser tools",
+				source: "skill",
+				sourceInfo: createSourceInfo("/skills/browser.md"),
+			},
+			{
+				name: "deploy",
+				description: "Deploy app",
+				source: "extension",
+				sourceInfo: createSourceInfo("/ext/deploy.ts"),
+			},
+			{
+				name: "agentic",
+				description: "Agent action",
+				source: "agent" as any,
+				sourceInfo: createSourceInfo("/agentic"),
+			},
+		];
 
-    const entries = buildCommandPickerEntries(slashCommands);
+		const entries = buildCommandPickerEntries(slashCommands);
 
-    expect(entries[0]).toMatchObject({
-      kind: "telepi",
-      command: "start",
-      label: "📱 /start",
-      commandText: "/start",
-    });
-    expect(entries.some((entry) => entry.kind === "telepi" && entry.command === "commands")).toBe(false);
+		expect(entries[0]).toMatchObject({
+			kind: "telepi",
+			command: "start",
+			label: "📱 /start",
+			commandText: "/start",
+		});
+		expect(
+			entries.some(
+				(entry) => entry.kind === "telepi" && entry.command === "commands",
+			),
+		).toBe(false);
 
-    expect(entries.slice(-4)).toEqual([
-      expect.objectContaining({
-        kind: "pi",
-        name: "review",
-        label: "📝 /review <PR-URL>",
-        commandText: "/review",
-      }),
-      expect.objectContaining({ kind: "pi", name: "skill:browser-tools", label: "🧰 /skill:browser-tools" }),
-      expect.objectContaining({ kind: "pi", name: "deploy", label: "🧩 /deploy" }),
-      expect.objectContaining({ kind: "pi", name: "agentic", label: "⚡ /agentic" }),
-    ]);
-  });
+		expect(entries.slice(-4)).toEqual([
+			expect.objectContaining({
+				kind: "pi",
+				name: "review",
+				label: "📝 /review <PR-URL>",
+				commandText: "/review",
+			}),
+			expect.objectContaining({
+				kind: "pi",
+				name: "skill:browser-tools",
+				label: "🧰 /skill:browser-tools",
+			}),
+			expect.objectContaining({
+				kind: "pi",
+				name: "deploy",
+				label: "🧩 /deploy",
+			}),
+			expect.objectContaining({
+				kind: "pi",
+				name: "agentic",
+				label: "⚡ /agentic",
+			}),
+		]);
+	});
 
-  it("uses direct argumentHint metadata without needing prompt file reads", () => {
-    const entries = buildCommandPickerEntries([
-      {
-        name: "review",
-        description: "Review recent changes",
-        source: "prompt",
-        argumentHint: "<PR-URL>",
-        sourceInfo: createSourceInfo("/missing/review.md"),
-      } as SlashCommandInfo & { argumentHint: string },
-    ]);
+	it("uses direct argumentHint metadata without needing prompt file reads", () => {
+		const entries = buildCommandPickerEntries([
+			{
+				name: "review",
+				description: "Review recent changes",
+				source: "prompt",
+				argumentHint: "<PR-URL>",
+				sourceInfo: createSourceInfo("/missing/review.md"),
+			} as SlashCommandInfo & { argumentHint: string },
+		]);
 
-    expect(entries).toContainEqual(expect.objectContaining({ kind: "pi", name: "review", label: "📝 /review <PR-URL>" }));
-  });
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				kind: "pi",
+				name: "review",
+				label: "📝 /review <PR-URL>",
+			}),
+		);
+	});
 
-  it("gracefully skips argument hints when prompt metadata is unavailable", () => {
-    const entries = buildCommandPickerEntries([
-      {
-        name: "review",
-        description: "Review recent changes",
-        source: "prompt",
-        sourceInfo: createSourceInfo("/missing/review.md"),
-      },
-      {
-        name: "deploy",
-        description: "Deploy app",
-        source: "extension",
-        sourceInfo: createSourceInfo("/ext/deploy.ts"),
-      },
-    ]);
+	it("gracefully skips argument hints when prompt metadata is unavailable", () => {
+		const entries = buildCommandPickerEntries([
+			{
+				name: "review",
+				description: "Review recent changes",
+				source: "prompt",
+				sourceInfo: createSourceInfo("/missing/review.md"),
+			},
+			{
+				name: "deploy",
+				description: "Deploy app",
+				source: "extension",
+				sourceInfo: createSourceInfo("/ext/deploy.ts"),
+			},
+		]);
 
-    expect(entries).toContainEqual(expect.objectContaining({ kind: "pi", name: "review", label: "📝 /review" }));
-    expect(entries).toContainEqual(expect.objectContaining({ kind: "pi", name: "deploy", label: "🧩 /deploy" }));
-  });
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				kind: "pi",
+				name: "review",
+				label: "📝 /review",
+			}),
+		);
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				kind: "pi",
+				name: "deploy",
+				label: "🧩 /deploy",
+			}),
+		);
+	});
 
-  it("filters and counts command picker entries by kind", () => {
-    const entries = buildCommandPickerEntries([
-      { name: "review", description: "Review", source: "prompt", sourceInfo: createSourceInfo("/prompts/review.md") },
-      { name: "deploy", description: "Deploy", source: "extension", sourceInfo: createSourceInfo("/ext/deploy.ts") },
-    ]);
+	it("filters and counts command picker entries by kind", () => {
+		const entries = buildCommandPickerEntries([
+			{
+				name: "review",
+				description: "Review",
+				source: "prompt",
+				sourceInfo: createSourceInfo("/prompts/review.md"),
+			},
+			{
+				name: "deploy",
+				description: "Deploy",
+				source: "extension",
+				sourceInfo: createSourceInfo("/ext/deploy.ts"),
+			},
+		]);
 
-    expect(getCommandPickerFilterName("all")).toBe("All");
-    expect(getCommandPickerFilterName("telepi")).toBe("TelePi");
-    expect(getCommandPickerFilterName("pi")).toBe("Pi");
+		expect(getCommandPickerFilterName("all")).toBe("All");
+		expect(getCommandPickerFilterName("telepi")).toBe("TelePi");
+		expect(getCommandPickerFilterName("pi")).toBe("Pi");
 
-    expect(getCommandPickerCounts(entries)).toEqual({
-      all: entries.length,
-      telepi: TELEPI_BOT_COMMANDS.length - 1,
-      pi: 2,
-    });
+		expect(getCommandPickerCounts(entries)).toEqual({
+			all: entries.length,
+			telepi: TELEPI_BOT_COMMANDS.length - 1,
+			pi: 2,
+		});
 
-    expect(filterCommandPickerEntries(entries, "telepi").every((entry) => entry.kind === "telepi")).toBe(true);
-    expect(filterCommandPickerEntries(entries, "pi").every((entry) => entry.kind === "pi")).toBe(true);
-    expect(filterCommandPickerEntries(entries, "all")).toEqual(entries);
-  });
+		expect(
+			filterCommandPickerEntries(entries, "telepi").every(
+				(entry) => entry.kind === "telepi",
+			),
+		).toBe(true);
+		expect(
+			filterCommandPickerEntries(entries, "pi").every(
+				(entry) => entry.kind === "pi",
+			),
+		).toBe(true);
+		expect(filterCommandPickerEntries(entries, "all")).toEqual(entries);
+	});
 
-  it("passes slash commands through unchanged for Telegram", () => {
-    expect(
-      rewriteSlashCommandForTelegram(
-        { name: "cron", text: "/cron" },
-        [{ name: "cron", description: "Manage PiCron schedules", source: "extension" } as SlashCommandInfo],
-      ),
-    ).toBe("/cron");
+	it("passes slash commands through unchanged for Telegram", () => {
+		expect(
+			rewriteSlashCommandForTelegram({ name: "cron", text: "/cron" }, [
+				{
+					name: "cron",
+					description: "Manage PiCron schedules",
+					source: "extension",
+				} as SlashCommandInfo,
+			]),
+		).toBe("/cron");
 
-    expect(
-      rewriteSlashCommandForTelegram(
-        { name: "cron", text: "/cron add" },
-        [{ name: "cron", description: "Manage PiCron schedules", source: "extension" } as SlashCommandInfo],
-      ),
-    ).toBe("/cron add");
+		expect(
+			rewriteSlashCommandForTelegram({ name: "cron", text: "/cron add" }, [
+				{
+					name: "cron",
+					description: "Manage PiCron schedules",
+					source: "extension",
+				} as SlashCommandInfo,
+			]),
+		).toBe("/cron add");
 
-    expect(
-      rewriteSlashCommandForTelegram(
-        { name: "review", text: "/review repo" },
-        [{ name: "cron", description: "Manage PiCron schedules", source: "extension" } as SlashCommandInfo],
-      ),
-    ).toBe("/review repo");
-  });
+		expect(
+			rewriteSlashCommandForTelegram({ name: "review", text: "/review repo" }, [
+				{
+					name: "cron",
+					description: "Manage PiCron schedules",
+					source: "extension",
+				} as SlashCommandInfo,
+			]),
+		).toBe("/review repo");
+	});
 
-  it("builds chat-scoped commands for Telegram and filters unsupported or conflicting names", () => {
-    const longDescription = "x".repeat(400);
-    const commands = buildChatScopedCommands([
-      { name: "review", description: longDescription, source: "prompt", sourceInfo: createSourceInfo("/prompts/review.md") },
-      { name: "switch", description: "Conflicts with local command", source: "extension", sourceInfo: createSourceInfo("/ext/switch.ts") },
-      { name: "skill:browser-tools", description: "Not Telegram-native", source: "skill", sourceInfo: createSourceInfo("/skills/browser.md") },
-      { name: "Review", description: "Duplicate after lowercasing", source: "prompt", sourceInfo: createSourceInfo("/prompts/review-duplicate.md") },
-    ]);
+	it("builds chat-scoped commands for Telegram and filters unsupported or conflicting names", () => {
+		const longDescription = "x".repeat(400);
+		const commands = buildChatScopedCommands([
+			{
+				name: "review",
+				description: longDescription,
+				source: "prompt",
+				sourceInfo: createSourceInfo("/prompts/review.md"),
+			},
+			{
+				name: "switch",
+				description: "Conflicts with local command",
+				source: "extension",
+				sourceInfo: createSourceInfo("/ext/switch.ts"),
+			},
+			{
+				name: "skill:browser-tools",
+				description: "Not Telegram-native",
+				source: "skill",
+				sourceInfo: createSourceInfo("/skills/browser.md"),
+			},
+			{
+				name: "Review",
+				description: "Duplicate after lowercasing",
+				source: "prompt",
+				sourceInfo: createSourceInfo("/prompts/review-duplicate.md"),
+			},
+		]);
 
-    expect(commands).toEqual([
-      ...TELEPI_BOT_COMMANDS,
-      {
-        command: "review",
-        description: `Pi: ${"x".repeat(251)}…`,
-      },
-    ]);
+		expect(commands).toEqual([
+			...TELEPI_BOT_COMMANDS,
+			{
+				command: "review",
+				description: `Pi: ${"x".repeat(251)}…`,
+			},
+		]);
 
-    expect(buildChatScopedCommandSignature(commands)).toBe(JSON.stringify(commands));
-  });
+		expect(buildChatScopedCommandSignature(commands)).toBe(
+			JSON.stringify(commands),
+		);
+	});
 });

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -7,2108 +7,2553 @@ import { vi } from "vitest";
 import type { TelePiConfig } from "../src/config.js";
 
 const mockState = vi.hoisted(() => {
-  const models = [
-    { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
-    { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
-  ];
+	const models = [
+		{ provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
+		{ provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+	];
 
-  let sessionCounter = 0;
-  let runtimeCounter = 0;
-  let sessionFileCounter = 0;
-  const createdSessions: Array<{ session: any; options: any }> = [];
-  const createdRuntimes: Array<{ runtime: any; options: any }> = [];
-  const modelRegistryInstances: any[] = [];
-  const authStorageInstances: any[] = [];
-  const sessionSubscribers = new WeakMap<object, (event: any) => void>();
-  const sessionPathWorkspaces = new Map<string, string>();
-  const resolvedSessionPaths = new Map<string, string>();
-  const defaultActiveBuiltInToolNames = ["read", "bash", "edit", "write"];
-  const extensionToolName = "extension-tool";
-  let slashCommands = [
-    { name: "deploy", description: "Deploy app", source: "extension", path: "/ext/deploy.ts" },
-    { name: "review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-  ];
+	let sessionCounter = 0;
+	let runtimeCounter = 0;
+	let sessionFileCounter = 0;
+	const createdSessions: Array<{ session: any; options: any }> = [];
+	const createdRuntimes: Array<{ runtime: any; options: any }> = [];
+	const modelRegistryInstances: any[] = [];
+	const authStorageInstances: any[] = [];
+	const sessionSubscribers = new WeakMap<object, (event: any) => void>();
+	const sessionPathWorkspaces = new Map<string, string>();
+	const resolvedSessionPaths = new Map<string, string>();
+	const defaultActiveBuiltInToolNames = ["read", "bash", "edit", "write"];
+	const extensionToolName = "extension-tool";
+	let slashCommands = [
+		{
+			name: "deploy",
+			description: "Deploy app",
+			source: "extension",
+			path: "/ext/deploy.ts",
+		},
+		{
+			name: "review",
+			description: "Review staged changes",
+			source: "prompt",
+			path: "/prompts/review.md",
+		},
+	];
 
-  const defaultSessions = () => {
-    const sessions = [
-      {
-        id: "s2",
-        firstMessage: "World",
-        path: "/sessions/s2.jsonl",
-        messageCount: 3,
-        cwd: "/workspace/projectB",
-        modified: new Date("2025-01-01T00:00:00.000Z"),
-        name: "Second",
-      },
-      {
-        id: "s1",
-        firstMessage: "Hello",
-        path: "/sessions/s1.jsonl",
-        messageCount: 5,
-        cwd: "/workspace/projectA",
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-        name: "First",
-      },
-    ];
+	const defaultSessions = () => {
+		const sessions = [
+			{
+				id: "s2",
+				firstMessage: "World",
+				path: "/sessions/s2.jsonl",
+				messageCount: 3,
+				cwd: "/workspace/projectB",
+				modified: new Date("2025-01-01T00:00:00.000Z"),
+				name: "Second",
+			},
+			{
+				id: "s1",
+				firstMessage: "Hello",
+				path: "/sessions/s1.jsonl",
+				messageCount: 5,
+				cwd: "/workspace/projectA",
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+				name: "First",
+			},
+		];
 
-    for (const session of sessions) {
-      sessionPathWorkspaces.set(session.path, session.cwd);
-    }
+		for (const session of sessions) {
+			sessionPathWorkspaces.set(session.path, session.cwd);
+		}
 
-    return sessions;
-  };
+		return sessions;
+	};
 
-  const createSessionManagerInstance = (workspace: string, sessionDir = "/sessions") => {
-    const manager: any = {
-      kind: "create",
-      workspace,
-      sessionDir,
-      sessionPath: undefined,
-      parentSession: undefined,
-      setSessionFile: vi.fn().mockImplementation((sessionPath: string) => {
-        manager.sessionPath = sessionPath;
-        sessionPathWorkspaces.set(sessionPath, workspace);
-      }),
-      newSession: vi.fn().mockImplementation((options?: { id?: string; parentSession?: string }) => {
-        manager.parentSession = options?.parentSession;
-        manager.sessionPath = path.join(sessionDir, `${options?.id ?? `generated-${++sessionFileCounter}`}.jsonl`);
-        sessionPathWorkspaces.set(manager.sessionPath, workspace);
-        return manager.sessionPath;
-      }),
-      getSessionFile: vi.fn().mockImplementation(() => manager.sessionPath),
-      getSessionDir: vi.fn().mockImplementation(() => manager.sessionDir),
-      getCwd: vi.fn().mockImplementation(() => manager.workspace),
-      getSessionId: vi.fn().mockImplementation(() => {
-        const sessionFile = manager.sessionPath;
-        return sessionFile ? path.basename(sessionFile, ".jsonl") : `manager-${sessionCounter + 1}`;
-      }),
-      isPersisted: vi.fn().mockImplementation(() => Boolean(manager.sessionPath)),
-      buildSessionContext: vi.fn().mockReturnValue({ messages: [] }),
-    };
-    return manager;
-  };
+	const createSessionManagerInstance = (
+		workspace: string,
+		sessionDir = "/sessions",
+	) => {
+		const manager: any = {
+			kind: "create",
+			workspace,
+			sessionDir,
+			sessionPath: undefined,
+			parentSession: undefined,
+			setSessionFile: vi.fn().mockImplementation((sessionPath: string) => {
+				manager.sessionPath = sessionPath;
+				sessionPathWorkspaces.set(sessionPath, workspace);
+			}),
+			newSession: vi
+				.fn()
+				.mockImplementation(
+					(options?: { id?: string; parentSession?: string }) => {
+						manager.parentSession = options?.parentSession;
+						manager.sessionPath = path.join(
+							sessionDir,
+							`${options?.id ?? `generated-${++sessionFileCounter}`}.jsonl`,
+						);
+						sessionPathWorkspaces.set(manager.sessionPath, workspace);
+						return manager.sessionPath;
+					},
+				),
+			getSessionFile: vi.fn().mockImplementation(() => manager.sessionPath),
+			getSessionDir: vi.fn().mockImplementation(() => manager.sessionDir),
+			getCwd: vi.fn().mockImplementation(() => manager.workspace),
+			getSessionId: vi.fn().mockImplementation(() => {
+				const sessionFile = manager.sessionPath;
+				return sessionFile
+					? path.basename(sessionFile, ".jsonl")
+					: `manager-${sessionCounter + 1}`;
+			}),
+			isPersisted: vi
+				.fn()
+				.mockImplementation(() => Boolean(manager.sessionPath)),
+			buildSessionContext: vi.fn().mockReturnValue({ messages: [] }),
+		};
+		return manager;
+	};
 
-  const createSession = (options: Record<string, unknown> = {}) => {
-    sessionCounter += 1;
+	const createSession = (options: Record<string, unknown> = {}) => {
+		sessionCounter += 1;
 
-    const bashExecute = vi.fn();
-    const sessionManager = options.sessionManager as any ?? createSessionManagerInstance(
-      (options.cwd as string | undefined) ?? "/workspace/base",
-    );
-    let activeToolNames = [
-      ...((options.activeToolNames as string[] | undefined) ?? [
-        ...defaultActiveBuiltInToolNames,
-        extensionToolName,
-      ]),
-    ];
+		const bashExecute = vi.fn();
+		const sessionManager =
+			(options.sessionManager as any) ??
+			createSessionManagerInstance(
+				(options.cwd as string | undefined) ?? "/workspace/base",
+			);
+		let activeToolNames = [
+			...((options.activeToolNames as string[] | undefined) ?? [
+				...defaultActiveBuiltInToolNames,
+				extensionToolName,
+			]),
+		];
 
-    const session: any = {
-      sessionId: options.sessionId ?? `session-${sessionCounter}`,
-      sessionFile: options.sessionFile ?? sessionManager.getSessionFile?.() ?? `/tmp/session-${sessionCounter}.jsonl`,
-      sessionName: options.sessionName,
-      model: options.model ?? models[0],
-      thinkingLevel: options.thinkingLevel ?? "medium",
-      scopedModels: options.scopedModels ?? [],
-      isStreaming: false,
-      agent: {
-        state: {
-          messages: [],
-          tools: [
-            { name: "read", description: "Read files", execute: vi.fn() },
-            { name: "bash", description: "Execute bash", execute: bashExecute, label: "bash", parameters: {} },
-            { name: "edit", description: "Edit files", execute: vi.fn() },
-            { name: "write", description: "Write files", execute: vi.fn() },
-          ],
-        },
-      },
-      prompt: vi.fn().mockResolvedValue(undefined),
-      bindExtensions: vi.fn().mockResolvedValue(undefined),
-      abort: vi.fn().mockResolvedValue(undefined),
-      reload: vi.fn().mockResolvedValue(undefined),
-      navigateTree: vi.fn().mockResolvedValue({ cancelled: false }),
-      getActiveToolNames: vi.fn().mockImplementation(() => [...activeToolNames]),
-      setActiveToolsByName: vi.fn().mockImplementation((toolNames: string[]) => {
-        activeToolNames = [...toolNames];
-      }),
-      extensionRunner: {
-        getCommands: vi.fn().mockImplementation(() => slashCommands),
-        hasHandlers: vi.fn().mockReturnValue(false),
-      },
-      sessionManager: {
-        ...sessionManager,
-        getTree: vi.fn().mockReturnValue([]),
-        getLeafId: vi.fn().mockReturnValue("leaf-id"),
-        getEntry: vi.fn().mockImplementation((id: string) =>
-          id === "known-id"
-            ? {
-                type: "message",
-                id: "known-id",
-                parentId: null,
-                timestamp: "2025-01-01T00:00:00Z",
-                message: { role: "user", content: "Known entry" },
-              }
-            : undefined,
-        ),
-        getChildren: vi.fn().mockReturnValue([]),
-        appendLabelChange: vi.fn(),
-      },
-      setModel: vi.fn().mockImplementation(async (model) => {
-        session.model = model;
-      }),
-      setThinkingLevel: vi.fn().mockImplementation((thinkingLevel) => {
-        session.thinkingLevel = thinkingLevel;
-      }),
-      subscribe: vi.fn().mockImplementation((callback) => {
-        sessionSubscribers.set(session, callback);
-        return () => {
-          if (sessionSubscribers.get(session) === callback) {
-            sessionSubscribers.delete(session);
-          }
-        };
-      }),
-      dispose: vi.fn(),
-    };
+		const session: any = {
+			sessionId: options.sessionId ?? `session-${sessionCounter}`,
+			sessionFile:
+				options.sessionFile ??
+				sessionManager.getSessionFile?.() ??
+				`/tmp/session-${sessionCounter}.jsonl`,
+			sessionName: options.sessionName,
+			model: options.model ?? models[0],
+			thinkingLevel: options.thinkingLevel ?? "medium",
+			scopedModels: options.scopedModels ?? [],
+			isStreaming: false,
+			agent: {
+				state: {
+					messages: [],
+					tools: [
+						{ name: "read", description: "Read files", execute: vi.fn() },
+						{
+							name: "bash",
+							description: "Execute bash",
+							execute: bashExecute,
+							label: "bash",
+							parameters: {},
+						},
+						{ name: "edit", description: "Edit files", execute: vi.fn() },
+						{ name: "write", description: "Write files", execute: vi.fn() },
+					],
+				},
+			},
+			prompt: vi.fn().mockResolvedValue(undefined),
+			bindExtensions: vi.fn().mockResolvedValue(undefined),
+			abort: vi.fn().mockResolvedValue(undefined),
+			reload: vi.fn().mockResolvedValue(undefined),
+			navigateTree: vi.fn().mockResolvedValue({ cancelled: false }),
+			getActiveToolNames: vi
+				.fn()
+				.mockImplementation(() => [...activeToolNames]),
+			setActiveToolsByName: vi
+				.fn()
+				.mockImplementation((toolNames: string[]) => {
+					activeToolNames = [...toolNames];
+				}),
+			extensionRunner: {
+				getCommands: vi.fn().mockImplementation(() => slashCommands),
+				hasHandlers: vi.fn().mockReturnValue(false),
+			},
+			sessionManager: {
+				...sessionManager,
+				getTree: vi.fn().mockReturnValue([]),
+				getLeafId: vi.fn().mockReturnValue("leaf-id"),
+				getEntry: vi.fn().mockImplementation((id: string) =>
+					id === "known-id"
+						? {
+								type: "message",
+								id: "known-id",
+								parentId: null,
+								timestamp: "2025-01-01T00:00:00Z",
+								message: { role: "user", content: "Known entry" },
+							}
+						: undefined,
+				),
+				getChildren: vi.fn().mockReturnValue([]),
+				appendLabelChange: vi.fn(),
+			},
+			setModel: vi.fn().mockImplementation(async (model) => {
+				session.model = model;
+			}),
+			setThinkingLevel: vi.fn().mockImplementation((thinkingLevel) => {
+				session.thinkingLevel = thinkingLevel;
+			}),
+			subscribe: vi.fn().mockImplementation((callback) => {
+				sessionSubscribers.set(session, callback);
+				return () => {
+					if (sessionSubscribers.get(session) === callback) {
+						sessionSubscribers.delete(session);
+					}
+				};
+			}),
+			dispose: vi.fn(),
+		};
 
-    createdSessions.push({ session, options: { ...options, bashExecute } });
-    return session;
-  };
+		createdSessions.push({ session, options: { ...options, bashExecute } });
+		return session;
+	};
 
-  const createAgentSession = vi.fn().mockImplementation(async (options: any) => {
-    const activeToolNames = options.tools
-      ? [...options.tools]
-      : options.noTools === "all"
-        ? []
-        : options.noTools === "builtin"
-          ? [extensionToolName]
-          : [...defaultActiveBuiltInToolNames, extensionToolName];
+	const createAgentSession = vi
+		.fn()
+		.mockImplementation(async (options: any) => {
+			const activeToolNames = options.tools
+				? [...options.tools]
+				: options.noTools === "all"
+					? []
+					: options.noTools === "builtin"
+						? [extensionToolName]
+						: [...defaultActiveBuiltInToolNames, extensionToolName];
 
-    return {
-      session: createSession({
-        cwd: options.services.cwd,
-        model: options.model,
-        thinkingLevel: options.thinkingLevel,
-        scopedModels: options.scopedModels,
-        sessionManager: options.sessionManager,
-        sessionFile: options.sessionManager?.getSessionFile?.(),
-        activeToolNames,
-      }),
-      extensionsResult: {
-        runtime: {
-          getCommands: vi.fn().mockImplementation(() => slashCommands),
-        },
-      },
-      modelFallbackMessage: options.model ? undefined : "fallback-model",
-    };
-  });
+			return {
+				session: createSession({
+					cwd: options.services.cwd,
+					model: options.model,
+					thinkingLevel: options.thinkingLevel,
+					scopedModels: options.scopedModels,
+					sessionManager: options.sessionManager,
+					sessionFile: options.sessionManager?.getSessionFile?.(),
+					activeToolNames,
+				}),
+				extensionsResult: {
+					runtime: {
+						getCommands: vi.fn().mockImplementation(() => slashCommands),
+					},
+				},
+				modelFallbackMessage: options.model ? undefined : "fallback-model",
+			};
+		});
 
-  const createAgentSessionServices = vi.fn().mockImplementation(async (options: any) => ({
-    cwd: options.cwd,
-    agentDir: options.agentDir ?? "/mock-agent",
-    authStorage: options.authStorage ?? { kind: "auth-storage" },
-    settingsManager: options.settingsManager,
-    modelRegistry: options.modelRegistry,
-    resourceLoader: { kind: "resource-loader", cwd: options.cwd },
-    diagnostics: [],
-  }));
+	const createAgentSessionServices = vi
+		.fn()
+		.mockImplementation(async (options: any) => ({
+			cwd: options.cwd,
+			agentDir: options.agentDir ?? "/mock-agent",
+			authStorage: options.authStorage ?? { kind: "auth-storage" },
+			settingsManager: options.settingsManager,
+			modelRegistry: options.modelRegistry,
+			resourceLoader: { kind: "resource-loader", cwd: options.cwd },
+			diagnostics: [],
+		}));
 
-  const createAgentSessionRuntime = vi.fn().mockImplementation(async (factory: any, options: any) => {
-    runtimeCounter += 1;
+	const createAgentSessionRuntime = vi
+		.fn()
+		.mockImplementation(async (factory: any, options: any) => {
+			runtimeCounter += 1;
 
-    let result = await factory(options);
-    let currentSession = result.session;
-    let currentServices = result.services;
-    let currentDiagnostics = result.diagnostics;
-    let currentFallbackMessage = result.modelFallbackMessage;
+			const result = await factory(options);
+			let currentSession = result.session;
+			let currentServices = result.services;
+			let currentDiagnostics = result.diagnostics;
+			let currentFallbackMessage = result.modelFallbackMessage;
 
-    const runtime: any = {
-      id: `runtime-${runtimeCounter}`,
-      get session() {
-        return currentSession;
-      },
-      get services() {
-        return currentServices;
-      },
-      get cwd() {
-        return currentServices.cwd;
-      },
-      get diagnostics() {
-        return currentDiagnostics;
-      },
-      get modelFallbackMessage() {
-        return currentFallbackMessage;
-      },
-      newSession: vi.fn().mockImplementation(async (runtimeOptions?: any) => {
-        const sessionDir = currentSession.sessionManager.getSessionDir();
-        const sessionManager = SessionManager.create(currentServices.cwd, sessionDir);
-        if (runtimeOptions?.parentSession) {
-          sessionManager.newSession({ parentSession: runtimeOptions.parentSession });
-        }
-        const nextResult = await factory({
-          cwd: currentServices.cwd,
-          agentDir: currentServices.agentDir,
-          sessionManager,
-          sessionStartEvent: { type: "session_start", reason: "new", previousSessionFile: currentSession.sessionFile },
-        });
-        currentSession.dispose();
-        currentSession = nextResult.session;
-        currentServices = nextResult.services;
-        currentDiagnostics = nextResult.diagnostics;
-        currentFallbackMessage = nextResult.modelFallbackMessage;
-        if (runtimeOptions?.setup) {
-          await runtimeOptions.setup(currentSession.sessionManager);
-          currentSession.agent.state.messages = currentSession.sessionManager.buildSessionContext().messages;
-        }
-        return { cancelled: false };
-      }),
-      switchSession: vi.fn().mockImplementation(
-        async (
-          sessionPath: string,
-          options?: { cwdOverride?: string } | string,
-        ) => {
-          const cwdOverride = typeof options === "string"
-            ? options
-            : options?.cwdOverride;
-          const sessionManager = SessionManager.open(sessionPath, undefined, cwdOverride);
-          const nextResult = await factory({
-            cwd: sessionManager.getCwd(),
-            agentDir: currentServices.agentDir,
-            sessionManager,
-            sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile: currentSession.sessionFile },
-          });
-          currentSession.dispose();
-          currentSession = nextResult.session;
-          currentServices = nextResult.services;
-          currentDiagnostics = nextResult.diagnostics;
-          currentFallbackMessage = nextResult.modelFallbackMessage;
-          return { cancelled: false };
-        },
-      ),
-      fork: vi.fn().mockImplementation(async (_entryId: string) => {
-        const sessionManager = SessionManager.create(currentServices.cwd, currentSession.sessionManager.getSessionDir());
-        sessionManager.newSession({ parentSession: currentSession.sessionFile });
-        const nextResult = await factory({
-          cwd: currentServices.cwd,
-          agentDir: currentServices.agentDir,
-          sessionManager,
-          sessionStartEvent: { type: "session_start", reason: "fork", previousSessionFile: currentSession.sessionFile },
-        });
-        currentSession.dispose();
-        currentSession = nextResult.session;
-        currentServices = nextResult.services;
-        currentDiagnostics = nextResult.diagnostics;
-        currentFallbackMessage = nextResult.modelFallbackMessage;
-        return { cancelled: false, selectedText: "Known entry" };
-      }),
-      dispose: vi.fn().mockImplementation(async () => {
-        currentSession.dispose();
-      }),
-    };
+			const runtime: any = {
+				id: `runtime-${runtimeCounter}`,
+				get session() {
+					return currentSession;
+				},
+				get services() {
+					return currentServices;
+				},
+				get cwd() {
+					return currentServices.cwd;
+				},
+				get diagnostics() {
+					return currentDiagnostics;
+				},
+				get modelFallbackMessage() {
+					return currentFallbackMessage;
+				},
+				newSession: vi.fn().mockImplementation(async (runtimeOptions?: any) => {
+					const sessionDir = currentSession.sessionManager.getSessionDir();
+					const sessionManager = SessionManager.create(
+						currentServices.cwd,
+						sessionDir,
+					);
+					if (runtimeOptions?.parentSession) {
+						sessionManager.newSession({
+							parentSession: runtimeOptions.parentSession,
+						});
+					}
+					const nextResult = await factory({
+						cwd: currentServices.cwd,
+						agentDir: currentServices.agentDir,
+						sessionManager,
+						sessionStartEvent: {
+							type: "session_start",
+							reason: "new",
+							previousSessionFile: currentSession.sessionFile,
+						},
+					});
+					currentSession.dispose();
+					currentSession = nextResult.session;
+					currentServices = nextResult.services;
+					currentDiagnostics = nextResult.diagnostics;
+					currentFallbackMessage = nextResult.modelFallbackMessage;
+					if (runtimeOptions?.setup) {
+						await runtimeOptions.setup(currentSession.sessionManager);
+						currentSession.agent.state.messages =
+							currentSession.sessionManager.buildSessionContext().messages;
+					}
+					return { cancelled: false };
+				}),
+				switchSession: vi
+					.fn()
+					.mockImplementation(
+						async (
+							sessionPath: string,
+							options?: { cwdOverride?: string } | string,
+						) => {
+							const cwdOverride =
+								typeof options === "string" ? options : options?.cwdOverride;
+							const sessionManager = SessionManager.open(
+								sessionPath,
+								undefined,
+								cwdOverride,
+							);
+							const nextResult = await factory({
+								cwd: sessionManager.getCwd(),
+								agentDir: currentServices.agentDir,
+								sessionManager,
+								sessionStartEvent: {
+									type: "session_start",
+									reason: "resume",
+									previousSessionFile: currentSession.sessionFile,
+								},
+							});
+							currentSession.dispose();
+							currentSession = nextResult.session;
+							currentServices = nextResult.services;
+							currentDiagnostics = nextResult.diagnostics;
+							currentFallbackMessage = nextResult.modelFallbackMessage;
+							return { cancelled: false };
+						},
+					),
+				fork: vi.fn().mockImplementation(async (_entryId: string) => {
+					const sessionManager = SessionManager.create(
+						currentServices.cwd,
+						currentSession.sessionManager.getSessionDir(),
+					);
+					sessionManager.newSession({
+						parentSession: currentSession.sessionFile,
+					});
+					const nextResult = await factory({
+						cwd: currentServices.cwd,
+						agentDir: currentServices.agentDir,
+						sessionManager,
+						sessionStartEvent: {
+							type: "session_start",
+							reason: "fork",
+							previousSessionFile: currentSession.sessionFile,
+						},
+					});
+					currentSession.dispose();
+					currentSession = nextResult.session;
+					currentServices = nextResult.services;
+					currentDiagnostics = nextResult.diagnostics;
+					currentFallbackMessage = nextResult.modelFallbackMessage;
+					return { cancelled: false, selectedText: "Known entry" };
+				}),
+				dispose: vi.fn().mockImplementation(async () => {
+					currentSession.dispose();
+				}),
+			};
 
-    createdRuntimes.push({ runtime, options });
-    return runtime;
-  });
+			createdRuntimes.push({ runtime, options });
+			return runtime;
+		});
 
-  const createCodingTools = vi.fn().mockReturnValue([
-    { name: "mock-tool", description: "Mock tool" },
-  ]);
+	const createCodingTools = vi
+		.fn()
+		.mockReturnValue([{ name: "mock-tool", description: "Mock tool" }]);
 
-  const AuthStorage = {
-    create: vi.fn().mockImplementation(() => {
-      const instance = {
-        kind: "auth-storage",
-        reload: vi.fn(),
-      };
-      authStorageInstances.push(instance);
-      return instance;
-    }),
-  };
+	const AuthStorage = {
+		create: vi.fn().mockImplementation(() => {
+			const instance = {
+				kind: "auth-storage",
+				reload: vi.fn(),
+			};
+			authStorageInstances.push(instance);
+			return instance;
+		}),
+	};
 
-  const ModelRegistry = {
-    create: vi.fn().mockImplementation(() => {
-      const instance = {
-        getAvailable: vi.fn().mockReturnValue(models),
-        getAll: vi.fn().mockReturnValue(models),
-        find: vi.fn().mockImplementation((provider: string, id: string) =>
-          models.find((model) => model.provider === provider && model.id === id),
-        ),
-      };
-      modelRegistryInstances.push(instance);
-      return instance;
-    }),
-  };
+	const ModelRegistry = {
+		create: vi.fn().mockImplementation(() => {
+			const instance = {
+				getAvailable: vi.fn().mockReturnValue(models),
+				getAll: vi.fn().mockReturnValue(models),
+				find: vi
+					.fn()
+					.mockImplementation((provider: string, id: string) =>
+						models.find(
+							(model) => model.provider === provider && model.id === id,
+						),
+					),
+			};
+			modelRegistryInstances.push(instance);
+			return instance;
+		}),
+	};
 
-  const SessionManager = {
-    create: vi.fn().mockImplementation((workspace: string, sessionDir?: string) =>
-      createSessionManagerInstance(workspace, sessionDir ?? "/sessions")
-    ),
-    open: vi.fn().mockImplementation((sessionPath: string, sessionDir?: string, cwdOverride?: string) => {
-      const manager = createSessionManagerInstance(
-        cwdOverride ?? sessionPathWorkspaces.get(sessionPath) ?? "/workspace/base",
-        sessionDir ?? path.resolve(sessionPath, ".."),
-      );
-      manager.kind = "open";
-      manager.setSessionFile(sessionPath);
-      return manager;
-    }),
-    listAll: vi.fn().mockResolvedValue(defaultSessions()),
-  };
+	const SessionManager = {
+		create: vi
+			.fn()
+			.mockImplementation((workspace: string, sessionDir?: string) =>
+				createSessionManagerInstance(workspace, sessionDir ?? "/sessions"),
+			),
+		open: vi
+			.fn()
+			.mockImplementation(
+				(sessionPath: string, sessionDir?: string, cwdOverride?: string) => {
+					const manager = createSessionManagerInstance(
+						cwdOverride ??
+							sessionPathWorkspaces.get(sessionPath) ??
+							"/workspace/base",
+						sessionDir ?? path.resolve(sessionPath, ".."),
+					);
+					manager.kind = "open";
+					manager.setSessionFile(sessionPath);
+					return manager;
+				},
+			),
+		listAll: vi.fn().mockResolvedValue(defaultSessions()),
+	};
 
-  const SettingsManager = {
-    create: vi.fn().mockImplementation(() => ({
-      getEnabledModels: vi.fn().mockReturnValue(undefined),
-      getDefaultProvider: vi.fn().mockReturnValue(undefined),
-      getDefaultModel: vi.fn().mockReturnValue(undefined),
-      drainErrors: vi.fn().mockReturnValue([]),
-    })),
-  };
+	const SettingsManager = {
+		create: vi.fn().mockImplementation(() => ({
+			getEnabledModels: vi.fn().mockReturnValue(undefined),
+			getDefaultProvider: vi.fn().mockReturnValue(undefined),
+			getDefaultModel: vi.fn().mockReturnValue(undefined),
+			drainErrors: vi.fn().mockReturnValue([]),
+		})),
+	};
 
-  return {
-    models,
-    createdSessions,
-    createdRuntimes,
-    modelRegistryInstances,
-    authStorageInstances,
-    createAgentSession,
-    createAgentSessionRuntime,
-    createAgentSessionServices,
-    createCodingTools,
-    AuthStorage,
-    ModelRegistry,
-    SessionManager,
-    SettingsManager,
-    getSubscriber: (session: object) => sessionSubscribers.get(session),
-    setSessionPathWorkspace: (sessionPath: string, workspace: string) => {
-      sessionPathWorkspaces.set(sessionPath, workspace);
-    },
-    resolveSessionPathForRuntime: (
-      sessionPath: string,
-      fallback: (sessionPath: string) => string,
-    ) => resolvedSessionPaths.get(sessionPath) ?? fallback(sessionPath),
-    setResolvedSessionPath: (sessionPath: string, resolvedPath: string) => {
-      resolvedSessionPaths.set(sessionPath, resolvedPath);
-    },
-    reset: () => {
-      sessionCounter = 0;
-      runtimeCounter = 0;
-      sessionFileCounter = 0;
-      createdSessions.length = 0;
-      createdRuntimes.length = 0;
-      modelRegistryInstances.length = 0;
-      sessionPathWorkspaces.clear();
-      resolvedSessionPaths.clear();
-      authStorageInstances.length = 0;
-      createAgentSession.mockClear();
-      createAgentSessionRuntime.mockClear();
-      createAgentSessionServices.mockClear();
-      createCodingTools.mockClear();
-      AuthStorage.create.mockClear();
-      ModelRegistry.create.mockClear();
-      SessionManager.create.mockClear();
-      SessionManager.open.mockClear();
-      SessionManager.listAll.mockReset();
-      SessionManager.listAll.mockResolvedValue(defaultSessions());
-      SettingsManager.create.mockClear();
-      slashCommands = [
-        { name: "deploy", description: "Deploy app", source: "extension", path: "/ext/deploy.ts" },
-        { name: "review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-      ];
-    },
-    setSlashCommands: (commands: Array<{ name: string; description?: string; source: string; path?: string }>) => {
-      slashCommands = commands;
-    },
-  };
+	return {
+		models,
+		createdSessions,
+		createdRuntimes,
+		modelRegistryInstances,
+		authStorageInstances,
+		createAgentSession,
+		createAgentSessionRuntime,
+		createAgentSessionServices,
+		createCodingTools,
+		AuthStorage,
+		ModelRegistry,
+		SessionManager,
+		SettingsManager,
+		getSubscriber: (session: object) => sessionSubscribers.get(session),
+		setSessionPathWorkspace: (sessionPath: string, workspace: string) => {
+			sessionPathWorkspaces.set(sessionPath, workspace);
+		},
+		resolveSessionPathForRuntime: (
+			sessionPath: string,
+			fallback: (sessionPath: string) => string,
+		) => resolvedSessionPaths.get(sessionPath) ?? fallback(sessionPath),
+		setResolvedSessionPath: (sessionPath: string, resolvedPath: string) => {
+			resolvedSessionPaths.set(sessionPath, resolvedPath);
+		},
+		reset: () => {
+			sessionCounter = 0;
+			runtimeCounter = 0;
+			sessionFileCounter = 0;
+			createdSessions.length = 0;
+			createdRuntimes.length = 0;
+			modelRegistryInstances.length = 0;
+			sessionPathWorkspaces.clear();
+			resolvedSessionPaths.clear();
+			authStorageInstances.length = 0;
+			createAgentSession.mockClear();
+			createAgentSessionRuntime.mockClear();
+			createAgentSessionServices.mockClear();
+			createCodingTools.mockClear();
+			AuthStorage.create.mockClear();
+			ModelRegistry.create.mockClear();
+			SessionManager.create.mockClear();
+			SessionManager.open.mockClear();
+			SessionManager.listAll.mockReset();
+			SessionManager.listAll.mockResolvedValue(defaultSessions());
+			SettingsManager.create.mockClear();
+			slashCommands = [
+				{
+					name: "deploy",
+					description: "Deploy app",
+					source: "extension",
+					path: "/ext/deploy.ts",
+				},
+				{
+					name: "review",
+					description: "Review staged changes",
+					source: "prompt",
+					path: "/prompts/review.md",
+				},
+			];
+		},
+		setSlashCommands: (
+			commands: Array<{
+				name: string;
+				description?: string;
+				source: string;
+				path?: string;
+			}>,
+		) => {
+			slashCommands = commands;
+		},
+	};
 });
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
-  createAgentSessionFromServices: mockState.createAgentSession,
-  createAgentSessionRuntime: mockState.createAgentSessionRuntime,
-  createAgentSessionServices: mockState.createAgentSessionServices,
-  createCodingTools: mockState.createCodingTools,
-  AuthStorage: mockState.AuthStorage,
-  ModelRegistry: mockState.ModelRegistry,
-  SessionManager: mockState.SessionManager,
-  SettingsManager: mockState.SettingsManager,
-  getAgentDir: vi.fn().mockReturnValue("/mock-agent"),
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	createAgentSessionFromServices: mockState.createAgentSession,
+	createAgentSessionRuntime: mockState.createAgentSessionRuntime,
+	createAgentSessionServices: mockState.createAgentSessionServices,
+	createCodingTools: mockState.createCodingTools,
+	AuthStorage: mockState.AuthStorage,
+	ModelRegistry: mockState.ModelRegistry,
+	SessionManager: mockState.SessionManager,
+	SettingsManager: mockState.SettingsManager,
+	getAgentDir: vi.fn().mockReturnValue("/mock-agent"),
 }));
 
 vi.mock("../src/pi-session-paths.js", async () => {
-  const actual = await vi.importActual<typeof import("../src/pi-session-paths.js")>("../src/pi-session-paths.js");
+	const actual = await vi.importActual<
+		typeof import("../src/pi-session-paths.js")
+	>("../src/pi-session-paths.js");
 
-  return {
-    ...actual,
-    resolveSessionPathForRuntime: vi.fn((sessionPath: string) =>
-      mockState.resolveSessionPathForRuntime(sessionPath, actual.resolveSessionPathForRuntime)
-    ),
-  };
+	return {
+		...actual,
+		resolveSessionPathForRuntime: vi.fn((sessionPath: string) =>
+			mockState.resolveSessionPathForRuntime(
+				sessionPath,
+				actual.resolveSessionPathForRuntime,
+			),
+		),
+	};
 });
 
-import { getPiSessionContextKey, PiSessionRegistry, PiSessionService } from "../src/pi-session.js";
+import {
+	getPiSessionContextKey,
+	PiSessionRegistry,
+	PiSessionService,
+} from "../src/pi-session.js";
 
 describe("PiSessionService", () => {
-  const createConfig = (overrides: Partial<TelePiConfig> = {}): TelePiConfig => ({
-    telegramBotToken: "bot-token",
-    telegramAllowedUserIds: [123],
-    telegramAllowedUserIdSet: new Set([123]),
-    workspace: "/workspace/base",
-    piSessionPath: undefined,
-    piModel: undefined,
-    toolVerbosity: "summary",
-    promptInboxDir: undefined,
-    promptInboxIntervalMs: 60000,
-    ...overrides,
-  });
-
-  beforeEach(() => {
-    mockState.reset();
-  });
-
-  const getPatchedBashTool = (session: any) =>
-    session.agent.state.tools.find((tool: any) => tool.name === "bash");
-
-  it("creates a session service and initializes the Pi session runtime", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    expect(mockState.AuthStorage.create).toHaveBeenCalledTimes(1);
-    expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(1);
-    expect(mockState.ModelRegistry.create).toHaveBeenCalledWith(expect.objectContaining({ kind: "auth-storage" }));
-    expect(mockState.createAgentSessionRuntime).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        cwd: "/workspace/base",
-        agentDir: "/mock-agent",
-      }),
-    );
-    expect(mockState.SettingsManager.create).toHaveBeenCalledWith("/workspace/base");
-    expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cwd: "/workspace/base",
-        authStorage: expect.objectContaining({ kind: "auth-storage" }),
-      }),
-    );
-    expect(mockState.createCodingTools).toHaveBeenCalledWith("/workspace/base");
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        services: expect.objectContaining({ cwd: "/workspace/base" }),
-        model: undefined,
-        scopedModels: [],
-      }),
-    );
-    expect(mockState.createAgentSession.mock.calls[0]?.[0]).not.toHaveProperty("tools");
-
-    expect(service.getInfo()).toEqual({
-      sessionId: "session-1",
-      sessionFile: "/tmp/session-1.jsonl",
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: "fallback-model",
-      model: "anthropic/claude-sonnet-4-5",
-    });
-  });
-
-  it("activates coding built-ins after session creation without disabling extension/custom tools on pi 0.70.x", async () => {
-    mockState.createCodingTools.mockReturnValueOnce([
-      { name: "read", description: "Read files" },
-      { name: "bash", description: "Execute bash" },
-      { name: "write", description: "Write files" },
-      { name: "find", description: "Find files" },
-      { name: "ls", description: "List files" },
-    ]);
-
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    expect(mockState.createAgentSession.mock.calls[0]?.[0]).not.toHaveProperty("tools");
-    expect(currentSession.setActiveToolsByName).toHaveBeenCalledWith(
-      expect.arrayContaining(["read", "bash", "edit", "write", "find", "ls", "extension-tool"]),
-    );
-    expect(service.getSession().getActiveToolNames()).toEqual(
-      expect.arrayContaining(["read", "bash", "edit", "write", "find", "ls", "extension-tool"]),
-    );
-  });
-
-  it("collects runtime diagnostics for Telegram-visible session info", async () => {
-    mockState.SettingsManager.create.mockImplementationOnce(() => ({
-      getEnabledModels: vi.fn().mockReturnValue(undefined),
-      getDefaultProvider: vi.fn().mockReturnValue(undefined),
-      getDefaultModel: vi.fn().mockReturnValue(undefined),
-      drainErrors: vi.fn().mockReturnValue([
-        { scope: "project", error: new Error("failed to parse .pi/settings.json") },
-      ]),
-    }));
-
-    const originalCreateServices = mockState.createAgentSessionServices.getMockImplementation();
-    mockState.createAgentSessionServices.mockImplementationOnce(async (options: any) => {
-      const result = await originalCreateServices!(options);
-      return {
-        ...result,
-        diagnostics: [{ type: "warning", message: "Project auth: no API key configured for anthropic" }],
-        resourceLoader: {
-          ...result.resourceLoader,
-          getExtensions: vi.fn().mockReturnValue({
-            extensions: [],
-            errors: [{ path: "/ext/bad.ts", error: "boom" }],
-            runtime: { pendingProviderRegistrations: [] },
-          }),
-          getSkills: vi.fn().mockReturnValue({
-            skills: [],
-            diagnostics: [{ type: "warning", message: "skill path does not exist", path: "/skills/missing" }],
-          }),
-          getPrompts: vi.fn().mockReturnValue({ prompts: [], diagnostics: [] }),
-          getThemes: vi.fn().mockReturnValue({
-            themes: [],
-            diagnostics: [{ type: "warning", message: "theme path does not exist", path: "/themes/missing.json" }],
-          }),
-        },
-      };
-    });
-
-    const service = await PiSessionService.create(createConfig());
-
-    expect(service.getInfo()).toMatchObject({
-      diagnostics: [
-        { type: "warning", message: "Project auth: no API key configured for anthropic" },
-        { type: "warning", message: "Project settings: failed to parse .pi/settings.json" },
-        { type: "error", message: 'Failed to load extension "/ext/bad.ts": boom' },
-        { type: "warning", message: "Skill issue (/skills/missing): skill path does not exist" },
-        { type: "warning", message: "Theme issue (/themes/missing.json): theme path does not exist" },
-      ],
-    });
-  });
-
-  it("patches the live bash tool via agent state mutation", async () => {
-    await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    const originalExecute = mockState.createdSessions[0]?.options?.bashExecute;
-    const bashTool = currentSession.agent.state.tools.find((tool: any) => tool.name === "bash");
-
-    expect(bashTool.description).toContain("Commands time out after 120 seconds by default.");
-    expect(bashTool.execute).not.toBe(originalExecute);
-
-    await bashTool.execute("tool-1", { command: "pwd" });
-
-    expect(originalExecute).toHaveBeenCalledWith(
-      "tool-1",
-      { command: "pwd", timeout: 120 },
-      undefined,
-      undefined,
-    );
-  });
-
-  it("rejects TelePi launchctl self-management commands before they execute", async () => {
-    await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    const originalBashTool = mockState.createdSessions[0]?.options?.bashExecute;
-    const patchedBashTool = getPatchedBashTool(currentSession);
-
-    const blockedCommands = [
-      "launchctl kickstart -k gui/$UID/com.telepi",
-      "echo ready & launchctl kickstart -k gui/$UID/com.telepi",
-      "sudo -E launchctl kickstart -k gui/$UID/com.telepi",
-      '(launchctl kickstart -k gui/$UID/com.telepi)',
-      'bash -c "launchctl kickstart -k gui/$UID/com.telepi"',
-    ];
-
-    for (const [index, command] of blockedCommands.entries()) {
-      expect(() => patchedBashTool.execute(`tool-${index + 1}`, { command })).toThrow(
-        "Blocked TelePi self-management command. launchctl commands targeting com.telepi cannot run from inside a TelePi session.",
-      );
-    }
-
-    expect(originalBashTool).not.toHaveBeenCalled();
-  });
-
-  it("adds the provider-response notice extension factory to session services", async () => {
-    await PiSessionService.create(createConfig());
-
-    expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceLoaderOptions: expect.objectContaining({
-          extensionFactories: [expect.any(Function)],
-        }),
-      }),
-    );
-  });
-
-  it("binds extension hooks through the underlying session", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    const bindings = {
-      onError: vi.fn(),
-      uiContext: { notify: vi.fn() },
-    } as any;
-
-    await service.bindExtensions(bindings);
-
-    expect(currentSession.bindExtensions).toHaveBeenCalledWith(bindings);
-  });
-
-  it("lists discovered slash commands from the Pi session runtime", async () => {
-    mockState.setSlashCommands([
-      { name: "skill:browser-tools", description: "Browser automation", source: "skill", path: "/skills/browser.md" },
-      { name: "/review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-      { name: "deploy", description: "Deploy app", source: "extension", path: "/ext/deploy.ts" },
-      { name: "deploy", description: "Duplicate deploy", source: "extension", path: "/ext/deploy-2.ts" },
-    ]);
-
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.listSlashCommands()).resolves.toEqual([
-      { name: "deploy", description: "Deploy app", source: "extension", path: "/ext/deploy.ts" },
-      { name: "review", description: "Review staged changes", source: "prompt", path: "/prompts/review.md" },
-      { name: "skill:browser-tools", description: "Browser automation", source: "skill", path: "/skills/browser.md" },
-    ]);
-  });
-
-  it("returns an empty slash-command list when runtime discovery is unavailable", async () => {
-    const originalImpl = mockState.createAgentSession.getMockImplementation();
-    mockState.createAgentSession.mockImplementationOnce(async (options: any) => {
-      const result = await (originalImpl as any)(options);
-      result.extensionsResult = {
-        runtime: {},
-      };
-      return result;
-    });
-
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.listSlashCommands()).resolves.toEqual([]);
-  });
-
-  it("resolves PI_MODEL overrides during creation", async () => {
-    await PiSessionService.create(createConfig({ piModel: "openai/gpt-4o" }));
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
-      }),
-    );
-  });
-
-  it("supports model lookup by bare id during creation", async () => {
-    await PiSessionService.create(createConfig({ piModel: "gpt-4o" }));
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
-      }),
-    );
-  });
-
-  it("delegates isStreaming and tracks active sessions", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    currentSession.isStreaming = true;
-
-    expect(service.isStreaming()).toBe(true);
-    expect(service.hasActiveSession()).toBe(true);
-  });
-
-  it("creates a new session in the current workspace via AgentSessionRuntime", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-
-    const result = await service.newSession();
-
-    expect(runtime.newSession).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      created: true,
-      info: service.getInfo(),
-    });
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
-  });
-
-  it("forwards runtime new-session options and rebinds extensions and subscriptions after replacement", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const initialSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const bindings = { uiContext: { notify: vi.fn() } } as any;
-    const onTextDelta = vi.fn();
-
-    await service.bindExtensions(bindings);
-    service.subscribe({
-      onTextDelta,
-      onToolStart: vi.fn(),
-      onToolUpdate: vi.fn(),
-      onToolEnd: vi.fn(),
-      onAgentEnd: vi.fn(),
-    });
-
-    const setup = vi.fn().mockResolvedValue(undefined);
-    const withSession = vi.fn().mockResolvedValue(undefined);
-    const result = await service.newSession({ parentSession: "/tmp/parent.jsonl", setup, withSession });
-    const nextSession = mockState.createdSessions[1]?.session;
-
-    expect(runtime.newSession).toHaveBeenCalledWith({ parentSession: "/tmp/parent.jsonl", setup, withSession });
-    expect(result.created).toBe(true);
-    expect(setup).toHaveBeenCalledWith(nextSession.sessionManager);
-    expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
-    expect(mockState.getSubscriber(initialSession)).toBeUndefined();
-    expect(mockState.getSubscriber(nextSession)).toBeTypeOf("function");
-
-    mockState.getSubscriber(nextSession)?.({
-      type: "message_update",
-      assistantMessageEvent: { type: "text_delta", delta: "Rebound" },
-    });
-    expect(onTextDelta).toHaveBeenCalledWith("Rebound");
-  });
-
-  it("creates a new handle when starting a session in another workspace", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-
-    const result = await service.newSession("/workspace/other");
-
-    expect(mockState.SessionManager.create).toHaveBeenLastCalledWith("/workspace/other");
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(result.created).toBe(true);
-    expect(result.info.workspace).toBe("/workspace/other");
-    expect(service.getCurrentWorkspace()).toBe("/workspace/other");
-  });
-
-  it("throws when withSession is requested for a cross-workspace new session", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    await expect(service.newSession({ workspace: "/workspace/other", withSession })).rejects.toThrow(
-      "TelePi only supports withSession callbacks for runtime-backed new-session replacements.",
-    );
-
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(1);
-    expect(withSession).not.toHaveBeenCalled();
-    expect(service.getCurrentWorkspace()).toBe("/workspace/base");
-  });
-
-  it("clears the active handle when extension rebinding fails during replacement", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const bindings = { uiContext: { notify: vi.fn() } } as any;
-    const originalCreateAgentSession = mockState.createAgentSession.getMockImplementation();
-
-    await service.bindExtensions(bindings);
-    mockState.createAgentSession.mockImplementationOnce(async (options: any) => {
-      const result = await originalCreateAgentSession!(options);
-      result.session.bindExtensions.mockRejectedValueOnce(new Error("extension rebinding exploded"));
-      return result;
-    });
-
-    await expect(service.newSession("/workspace/other")).rejects.toThrow("extension rebinding exploded");
-
-    expect(mockState.createdSessions[1]?.session.bindExtensions).toHaveBeenCalledWith(bindings);
-    expect(mockState.createdRuntimes[1]?.runtime.dispose).toHaveBeenCalledTimes(1);
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(service.hasActiveSession()).toBe(false);
-    expect(service.getInfo()).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-    expect(() => service.getSession()).toThrow("Pi session is not initialized");
-  });
-
-  it("clears the active handle when extension rebinding fails during same-runtime new-session replacement", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const bindings = { uiContext: { notify: vi.fn() } } as any;
-    const originalCreateAgentSession = mockState.createAgentSession.getMockImplementation();
-
-    await service.bindExtensions(bindings);
-    service.subscribe({
-      onTextDelta: vi.fn(),
-      onToolStart: vi.fn(),
-      onToolUpdate: vi.fn(),
-      onToolEnd: vi.fn(),
-      onAgentEnd: vi.fn(),
-    });
-
-    mockState.createAgentSession.mockImplementationOnce(async (options: any) => {
-      const result = await originalCreateAgentSession!(options);
-      result.session.bindExtensions.mockRejectedValueOnce(new Error("extension rebinding exploded"));
-      return result;
-    });
-
-    await expect(service.newSession()).rejects.toThrow("extension rebinding exploded");
-
-    const nextSession = mockState.createdSessions[1]?.session;
-    expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
-    expect(runtime.dispose).toHaveBeenCalledTimes(1);
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(nextSession.dispose).toHaveBeenCalledTimes(1);
-    expect(mockState.getSubscriber(previousSession)).toBeUndefined();
-    expect(mockState.getSubscriber(nextSession)).toBeUndefined();
-    expect(service.hasActiveSession()).toBe(false);
-    expect(service.getInfo()).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-    expect(() => service.getSession()).toThrow("Pi session is not initialized");
-  });
-
-  it("disposes the created runtime when cross-workspace setup fails", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const setup = vi.fn().mockRejectedValue(new Error("setup exploded"));
-
-    await expect(service.newSession({ workspace: "/workspace/other", setup })).rejects.toThrow("setup exploded");
-
-    expect(setup).toHaveBeenCalledWith(mockState.createdSessions[1]?.session.sessionManager);
-    expect(mockState.createdRuntimes[1]?.runtime.dispose).toHaveBeenCalledTimes(1);
-    expect(mockState.createdSessions[1]?.session.dispose).toHaveBeenCalledTimes(1);
-    expect(previousSession.dispose).not.toHaveBeenCalled();
-    expect(service.getCurrentWorkspace()).toBe("/workspace/base");
-    expect(service.getInfo().sessionId).toBe("session-1");
-  });
-
-  it("switches to a specific saved session and workspace via AgentSessionRuntime", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-
-    const info = await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
-
-    expect(runtime.switchSession).toHaveBeenCalledWith(
-      "/sessions/saved.jsonl",
-      { cwdOverride: "/workspace/projectA" },
-    );
-    expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(
-      "/sessions/saved.jsonl",
-      undefined,
-      "/workspace/projectA",
-    );
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(info.workspace).toBe("/workspace/projectA");
-    expect(info.sessionFile).toBe("/sessions/saved.jsonl");
-  });
-
-  it("forwards runtime switch-session options", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    await service.switchSession("/sessions/saved.jsonl", {
-      workspace: "/workspace/projectA",
-      withSession,
-    });
-
-    expect(runtime.switchSession).toHaveBeenCalledWith(
-      "/sessions/saved.jsonl",
-      { cwdOverride: "/workspace/projectA", withSession },
-    );
-  });
-
-  it("adopts the runtime-resolved cwd when switching without an explicit workspace override", async () => {
-    const targetWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-
-    try {
-      const sessionPath = path.join(targetWorkspace, "cross-cwd.jsonl");
-      writeFileSync(
-        sessionPath,
-        `${JSON.stringify({
-          type: "session",
-          version: 3,
-          id: "crosscwd1",
-          timestamp: "2025-01-03T00:00:00.000Z",
-          cwd: targetWorkspace,
-        })}\n`,
-      );
-      const service = await PiSessionService.create(createConfig({ workspace: "/workspace/projectA" }));
-      const runtime = mockState.createdRuntimes[0]?.runtime;
-
-      const info = await service.switchSession(sessionPath);
-
-      expect(runtime.switchSession).toHaveBeenCalledWith(sessionPath, { cwdOverride: targetWorkspace });
-      expect(service.getCurrentWorkspace()).toBe(targetWorkspace);
-      expect(info.workspace).toBe(targetWorkspace);
-    } finally {
-      rmSync(targetWorkspace, { recursive: true, force: true });
-    }
-  });
-
-  it("switches using the resolved session path when the caller passes a ~ path", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
-
-    try {
-      const sessionPath = path.join(tempDir, "tilde-switch.jsonl");
-      writeFileSync(
-        sessionPath,
-        `${JSON.stringify({
-          type: "session",
-          version: 3,
-          id: "tilde-switch",
-          timestamp: "2025-01-03T00:00:00.000Z",
-          cwd: tempDir,
-        })}\n`,
-      );
-      const tildePath = sessionPath.replace(homedir(), "~");
-      const service = await PiSessionService.create(createConfig({ workspace: "/workspace/projectA" }));
-      const runtime = mockState.createdRuntimes[0]?.runtime;
-
-      const info = await service.switchSession(tildePath);
-
-      expect(runtime.switchSession).toHaveBeenCalledWith(sessionPath, { cwdOverride: tempDir });
-      expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(sessionPath, undefined, tempDir);
-      expect(info.sessionFile).toBe(sessionPath);
-      expect(info.workspace).toBe(tempDir);
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("switches using the remapped runtime session path instead of the raw caller input", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const rawSessionPath = "/Users/example/.pi/agent/sessions/remapped.jsonl";
-
-    try {
-      const resolvedSessionPath = path.join(tempDir, "remapped.jsonl");
-      writeFileSync(
-        resolvedSessionPath,
-        `${JSON.stringify({
-          type: "session",
-          version: 3,
-          id: "remapped1",
-          timestamp: "2025-01-03T00:00:00.000Z",
-          cwd: tempDir,
-        })}\n`,
-      );
-      mockState.setResolvedSessionPath(rawSessionPath, resolvedSessionPath);
-      const service = await PiSessionService.create(createConfig({ workspace: "/workspace/projectA" }));
-      const runtime = mockState.createdRuntimes[0]?.runtime;
-
-      const info = await service.switchSession(rawSessionPath);
-
-      expect(runtime.switchSession).toHaveBeenCalledWith(resolvedSessionPath, { cwdOverride: tempDir });
-      expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(resolvedSessionPath, undefined, tempDir);
-      expect(info.sessionFile).toBe(resolvedSessionPath);
-      expect(info.workspace).toBe(tempDir);
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("rethrows unexpected session-resolution errors instead of silently falling back", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("list exploded"));
-    const service = await PiSessionService.create(createConfig());
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-
-    await expect(service.switchSession("s1")).rejects.toThrow("list exploded");
-    expect(runtime.switchSession).not.toHaveBeenCalled();
-  });
-
-  it("switches using the resolved session path after handback when no handle is active", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
-
-    try {
-      const sessionPath = path.join(tempDir, "tilde-reopen.jsonl");
-      writeFileSync(
-        sessionPath,
-        `${JSON.stringify({
-          type: "session",
-          version: 3,
-          id: "tilde-reopen",
-          timestamp: "2025-01-03T00:00:00.000Z",
-          cwd: tempDir,
-        })}\n`,
-      );
-      const tildePath = sessionPath.replace(homedir(), "~");
-      const service = await PiSessionService.create(createConfig({ workspace: "/workspace/projectA" }));
-
-      await service.handback();
-      expect(service.hasActiveSession()).toBe(false);
-
-      const info = await service.switchSession(tildePath);
-
-      expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(sessionPath, undefined, tempDir);
-      expect(info.sessionFile).toBe(sessionPath);
-      expect(info.workspace).toBe(tempDir);
-      expect(service.hasActiveSession()).toBe(true);
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("throws when withSession is requested for a switch without an active handle", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    await service.handback();
-    expect(service.hasActiveSession()).toBe(false);
-
-    await expect(service.switchSession("/sessions/saved.jsonl", { withSession })).rejects.toThrow(
-      "TelePi only supports withSession callbacks for runtime-backed session switches.",
-    );
-
-    expect(mockState.SessionManager.open).not.toHaveBeenCalled();
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(1);
-    expect(withSession).not.toHaveBeenCalled();
-  });
-
-  it("recreates the model registry each time the runtime factory creates a same-runtime replacement session", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const firstRegistry = mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
-
-    await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
-
-    const secondRegistry = mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
-    expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-    expect(firstRegistry).toBe(mockState.modelRegistryInstances[0]);
-    expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
-    expect(secondRegistry).not.toBe(firstRegistry);
-  });
-
-  it("recreates the model registry and reapplies coding-tool activation for cross-runtime replacements", async () => {
-    mockState.createCodingTools.mockReturnValue([
-      { name: "read", description: "Read files" },
-      { name: "bash", description: "Execute bash" },
-      { name: "edit", description: "Edit files" },
-      { name: "write", description: "Write files" },
-      { name: "find", description: "Find files" },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-    const firstRegistry = mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
-
-    await service.newSession("/workspace/other");
-
-    const secondRegistry = mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
-    const replacementSession = mockState.createdSessions[1]?.session;
-    expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-    expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
-    expect(secondRegistry).not.toBe(firstRegistry);
-    expect(replacementSession.setActiveToolsByName).toHaveBeenCalledWith(
-      expect.arrayContaining(["read", "bash", "edit", "write", "find", "extension-tool"]),
-    );
-    expect(replacementSession.getActiveToolNames()).toEqual(
-      expect.arrayContaining(["read", "bash", "edit", "write", "find", "extension-tool"]),
-    );
-  });
-
-  it("returns the runtime cancellation signal when switching sessions is cancelled", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const initialInfo = service.getInfo();
-
-    runtime.switchSession.mockResolvedValueOnce({ cancelled: true });
-
-    const result = await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
-
-    expect(result).toEqual({
-      ...initialInfo,
-      cancelled: true,
-    });
-    expect(previousSession.dispose).not.toHaveBeenCalled();
-  });
-
-  it("clears the active handle when extension rebinding fails during same-runtime session switching", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const bindings = { uiContext: { notify: vi.fn() } } as any;
-    const originalCreateAgentSession = mockState.createAgentSession.getMockImplementation();
-
-    await service.bindExtensions(bindings);
-    service.subscribe({
-      onTextDelta: vi.fn(),
-      onToolStart: vi.fn(),
-      onToolUpdate: vi.fn(),
-      onToolEnd: vi.fn(),
-      onAgentEnd: vi.fn(),
-    });
-
-    mockState.createAgentSession.mockImplementationOnce(async (options: any) => {
-      const result = await originalCreateAgentSession!(options);
-      result.session.bindExtensions.mockRejectedValueOnce(new Error("extension rebinding exploded"));
-      return result;
-    });
-
-    await expect(service.switchSession("/sessions/saved.jsonl", "/workspace/projectA")).rejects.toThrow(
-      "extension rebinding exploded",
-    );
-
-    const nextSession = mockState.createdSessions[1]?.session;
-    expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
-    expect(runtime.dispose).toHaveBeenCalledTimes(1);
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(nextSession.dispose).toHaveBeenCalledTimes(1);
-    expect(mockState.getSubscriber(previousSession)).toBeUndefined();
-    expect(mockState.getSubscriber(nextSession)).toBeUndefined();
-    expect(service.hasActiveSession()).toBe(false);
-    expect(service.getCurrentWorkspace()).toBe("/workspace/base");
-    expect(service.getInfo()).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-  });
-
-  it("hands back the active session and clears the handle", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    await expect(service.handback()).resolves.toEqual({
-      sessionFile: "/tmp/session-1.jsonl",
-      workspace: "/workspace/base",
-    });
-
-    expect(currentSession.dispose).toHaveBeenCalledTimes(1);
-    expect(service.hasActiveSession()).toBe(false);
-    expect(service.getInfo()).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-  });
-
-  it("returns an empty handback after the session is already handed back", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    await service.handback();
-
-    await expect(service.handback()).resolves.toEqual({
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-    });
-  });
-
-  it("blocks handback when continuing a session in a fallback workspace", async () => {
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "moved.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "moved1234",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: "/definitely/missing/workspace",
-      })}\n`,
-    );
-    const service = await PiSessionService.create(createConfig());
-
-    await service.switchSession(sessionPath, "/workspace/base");
-    await expect(service.handback()).rejects.toThrow(
-      "Cannot hand back this session while its saved workspace is unavailable (/definitely/missing/workspace).",
-    );
-    expect(service.hasActiveSession()).toBe(true);
-  });
-
-  it("aborts the active session and becomes a no-op without one", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    await service.abort();
-    expect(currentSession.abort).toHaveBeenCalledTimes(1);
-
-    await service.handback();
-    await expect(service.abort()).resolves.toBeUndefined();
-    expect(currentSession.abort).toHaveBeenCalledTimes(1);
-  });
-
-  it("lists all sessions sorted by modified date descending", async () => {
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "older",
-        firstMessage: "Old",
-        path: "/sessions/old.jsonl",
-        messageCount: 1,
-        cwd: "/workspace/b",
-        modified: new Date("2025-01-01T00:00:00.000Z"),
-        name: "Old name",
-      },
-      {
-        id: "newer",
-        firstMessage: "New",
-        path: "/sessions/new.jsonl",
-        messageCount: 2,
-        cwd: "/workspace/a",
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-        name: "New name",
-      },
-    ]);
-
-    const service = await PiSessionService.create(createConfig());
-    const sessions = await service.listAllSessions();
-
-    expect(sessions.map((session) => session.id)).toEqual(["newer", "older"]);
-    expect(sessions[0]).toMatchObject({ name: "New name", cwd: "/workspace/a" });
-  });
-
-  it("lists unique workspaces in sorted order", async () => {
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "a",
-        firstMessage: "One",
-        path: "/sessions/a.jsonl",
-        messageCount: 1,
-        cwd: "/workspace/z",
-        modified: new Date(),
-      },
-      {
-        id: "b",
-        firstMessage: "Two",
-        path: "/sessions/b.jsonl",
-        messageCount: 2,
-        cwd: "/workspace/a",
-        modified: new Date(),
-      },
-      {
-        id: "c",
-        firstMessage: "Three",
-        path: "/sessions/c.jsonl",
-        messageCount: 3,
-        cwd: "/workspace/z",
-        modified: new Date(),
-      },
-    ]);
-
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.listWorkspaces()).resolves.toEqual(["/workspace/a", "/workspace/z"]);
-  });
-
-  it("resolves a saved session reference by path, exact ID, or unique ID prefix", async () => {
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const tempDirTwo = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "one.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "abc12345",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: tempDir,
-      })}\n`,
-    );
-    mockState.SessionManager.listAll.mockResolvedValue([
-      {
-        id: "abc12345",
-        firstMessage: "One",
-        path: sessionPath,
-        messageCount: 1,
-        cwd: tempDir,
-        modified: new Date("2025-01-03T00:00:00.000Z"),
-      },
-      {
-        id: "def67890",
-        firstMessage: "Two",
-        path: "/sessions/two.jsonl",
-        messageCount: 1,
-        cwd: tempDirTwo,
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual({
-      id: "abc12345",
-      path: sessionPath,
-      cwd: tempDir,
-      matchType: "path",
-    });
-    await expect(service.resolveSessionReference("def67890")).resolves.toEqual({
-      id: "def67890",
-      path: "/sessions/two.jsonl",
-      cwd: tempDirTwo,
-      matchType: "id",
-    });
-    await expect(service.resolveSessionReference("abc1")).resolves.toEqual({
-      id: "abc12345",
-      path: sessionPath,
-      cwd: tempDir,
-      matchType: "prefix",
-    });
-  });
-
-  it("falls back to an explicit existing session path even when the session index is unavailable", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "manual.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "manual1234",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: tempDir,
-      })}\n`,
-    );
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual({
-      id: "manual1234",
-      path: sessionPath,
-      cwd: tempDir,
-      matchType: "path",
-    });
-  });
-
-  it("falls back to the current workspace when an explicit session path has an unavailable workspace", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "moved.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "moved1234",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: "/definitely/missing/workspace",
-      })}\n`,
-    );
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual({
-      id: "moved1234",
-      path: sessionPath,
-      cwd: undefined,
-      workspaceWarning:
-        "Saved workspace /definitely/missing/workspace is unavailable in this TelePi runtime. Continuing in the current workspace instead.",
-      matchType: "path",
-    });
-  });
-
-  it("expands ~ when switching by explicit session path", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "tilde.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "tilde1234",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: tempDir,
-      })}\n`,
-    );
-    const tildePath = sessionPath.replace(homedir(), "~");
-
-    try {
-      const service = await PiSessionService.create(createConfig());
-      await expect(service.resolveSessionReference(tildePath)).resolves.toEqual({
-        id: "tilde1234",
-        path: sessionPath,
-        cwd: tempDir,
-        matchType: "path",
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("allows explicit path recovery for existing session files with an invalid header", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "broken.jsonl");
-    writeFileSync(sessionPath, "not-json\n");
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual({
-      id: "broken.jsonl",
-      path: sessionPath,
-      cwd: undefined,
-      matchType: "path",
-    });
-  });
-
-  it("accepts legacy session files without cwd when switching by explicit path", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "legacy.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        id: "legacy1234",
-      })}\n`,
-    );
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual({
-      id: "legacy1234",
-      path: sessionPath,
-      cwd: undefined,
-      matchType: "path",
-    });
-  });
-
-  it("prefers exact ID matches over prefix matches", async () => {
-    const exactWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const prefixWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "abc",
-        firstMessage: "Exact",
-        path: "/sessions/exact.jsonl",
-        messageCount: 1,
-        cwd: exactWorkspace,
-        modified: new Date("2025-01-03T00:00:00.000Z"),
-      },
-      {
-        id: "abcdef12",
-        firstMessage: "Prefix",
-        path: "/sessions/prefix.jsonl",
-        messageCount: 1,
-        cwd: prefixWorkspace,
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference("abc")).resolves.toEqual({
-      id: "abc",
-      path: "/sessions/exact.jsonl",
-      cwd: exactWorkspace,
-      matchType: "id",
-    });
-  });
-
-  it("falls back to the current workspace for saved session IDs whose workspace is unavailable", async () => {
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "bad12345",
-        firstMessage: "Broken",
-        path: "/sessions/bad.jsonl",
-        messageCount: 1,
-        cwd: "/definitely/missing/workspace",
-        modified: new Date("2025-01-03T00:00:00.000Z"),
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference("bad12345")).resolves.toEqual({
-      id: "bad12345",
-      path: "/sessions/bad.jsonl",
-      cwd: undefined,
-      workspaceWarning:
-        "Saved workspace /definitely/missing/workspace is unavailable in this TelePi runtime. Continuing in the current workspace instead.",
-      matchType: "id",
-    });
-  });
-
-  it("prefers a unique prefix match from the current workspace before searching globally", async () => {
-    const currentWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const otherWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "abc-local",
-        firstMessage: "Local",
-        path: "/sessions/local.jsonl",
-        messageCount: 1,
-        cwd: currentWorkspace,
-        modified: new Date("2025-01-03T00:00:00.000Z"),
-      },
-      {
-        id: "abc-global",
-        firstMessage: "Global",
-        path: "/sessions/global.jsonl",
-        messageCount: 1,
-        cwd: otherWorkspace,
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig({ workspace: currentWorkspace }));
-
-    await expect(service.resolveSessionReference("abc")).resolves.toEqual({
-      id: "abc-local",
-      path: "/sessions/local.jsonl",
-      cwd: currentWorkspace,
-      matchType: "prefix",
-    });
-  });
-
-  it("rejects ambiguous or missing saved session references", async () => {
-    mockState.SessionManager.listAll.mockResolvedValueOnce([
-      {
-        id: "abcd1111",
-        firstMessage: "One",
-        path: "/sessions/one.jsonl",
-        messageCount: 1,
-        cwd: "/workspace/one",
-        modified: new Date("2025-01-03T00:00:00.000Z"),
-      },
-      {
-        id: "abcd2222",
-        firstMessage: "Two",
-        path: "/sessions/two.jsonl",
-        messageCount: 1,
-        cwd: "/workspace/two",
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveSessionReference("abcd")).rejects.toThrow(
-      'Session ID prefix "abcd" matches 2 saved sessions.',
-    );
-    await expect(service.resolveSessionReference("missing")).rejects.toThrow(
-      'No saved session matches "missing".',
-    );
-    await expect(service.resolveSessionReference("/sessions/missing.jsonl")).rejects.toThrow(
-      "Saved session not found: /sessions/missing.jsonl",
-    );
-  });
-
-  it("resolves a workspace for a saved session reference", async () => {
-    const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const secondWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
-    const sessionPath = path.join(tempDir, "s1.jsonl");
-    writeFileSync(
-      sessionPath,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: "s1",
-        timestamp: "2025-01-03T00:00:00.000Z",
-        cwd: tempDir,
-      })}\n`,
-    );
-    mockState.SessionManager.listAll.mockResolvedValue([
-      {
-        id: "s1",
-        firstMessage: "Hello",
-        path: sessionPath,
-        messageCount: 5,
-        cwd: tempDir,
-        modified: new Date("2025-01-02T00:00:00.000Z"),
-        name: "First",
-      },
-      {
-        id: "s2",
-        firstMessage: "World",
-        path: "/sessions/s2.jsonl",
-        messageCount: 3,
-        cwd: secondWorkspace,
-        modified: new Date("2025-01-01T00:00:00.000Z"),
-        name: "Second",
-      },
-    ]);
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveWorkspaceForSession(sessionPath)).resolves.toBe(tempDir);
-    await expect(service.resolveWorkspaceForSession("s2")).resolves.toBe(secondWorkspace);
-  });
-
-  it("returns undefined when resolving a workspace fails", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveWorkspaceForSession("/sessions/missing.jsonl")).resolves.toBeUndefined();
-  });
-
-  it("returns undefined when an ID-based workspace lookup hits an unexpected index failure", async () => {
-    mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.resolveWorkspaceForSession("s1")).resolves.toBeUndefined();
-  });
-
-  it("lists models with the current one marked", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.listModels()).resolves.toEqual([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-5",
-        name: "Claude Sonnet",
-        current: true,
-        thinkingLevel: undefined,
-      },
-      {
-        provider: "openai",
-        id: "gpt-4o",
-        name: "GPT-4o",
-        current: false,
-        thinkingLevel: undefined,
-      },
-    ]);
-  });
-
-  it("lists only scoped models when the session has a model scope", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    currentSession.scopedModels = [{ model: mockState.models[1], thinkingLevel: "high" }];
-
-    await expect(service.listModels()).resolves.toEqual([
-      {
-        provider: "openai",
-        id: "gpt-4o",
-        name: "GPT-4o",
-        current: false,
-        thinkingLevel: "high",
-      },
-    ]);
-  });
-
-  it("can list all models even when a scope is active", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    currentSession.scopedModels = [{ model: mockState.models[1], thinkingLevel: "high" }];
-
-    await expect(service.listModels(true)).resolves.toEqual([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-5",
-        name: "Claude Sonnet",
-        current: true,
-        thinkingLevel: undefined,
-      },
-      {
-        provider: "openai",
-        id: "gpt-4o",
-        name: "GPT-4o",
-        current: false,
-        thinkingLevel: "high",
-      },
-    ]);
-  });
-
-  it("derives scoped models from pi settings when enabled models are configured", async () => {
-    mockState.SettingsManager.create.mockReturnValueOnce({
-      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
-      getDefaultProvider: vi.fn().mockReturnValue(undefined),
-      getDefaultModel: vi.fn().mockReturnValue(undefined),
-      drainErrors: vi.fn().mockReturnValue([]),
-    });
-
-    await PiSessionService.create(createConfig());
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scopedModels: [{ model: mockState.models[1] }],
-      }),
-    );
-  });
-
-  it("starts a new session on the preferred scoped default model", async () => {
-    mockState.SettingsManager.create.mockReturnValueOnce({
-      getEnabledModels: vi.fn().mockReturnValue(["anthropic/claude-sonnet-4-5", "openai/gpt-4o:high"]),
-      getDefaultProvider: vi.fn().mockReturnValue("openai"),
-      getDefaultModel: vi.fn().mockReturnValue("gpt-4o"),
-      drainErrors: vi.fn().mockReturnValue([]),
-    });
-
-    await PiSessionService.create(createConfig());
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: mockState.models[1],
-        thinkingLevel: "high",
-        scopedModels: [
-          { model: mockState.models[0] },
-          { model: mockState.models[1], thinkingLevel: "high" },
-        ],
-      }),
-    );
-  });
-
-  it("falls back to the first scoped model when no scoped default is saved", async () => {
-    mockState.SettingsManager.create.mockReturnValueOnce({
-      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o:high"]),
-      getDefaultProvider: vi.fn().mockReturnValue(undefined),
-      getDefaultModel: vi.fn().mockReturnValue(undefined),
-      drainErrors: vi.fn().mockReturnValue([]),
-    });
-
-    await PiSessionService.create(createConfig());
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: mockState.models[1],
-        thinkingLevel: "high",
-      }),
-    );
-  });
-
-  it("does not override the model when opening an existing session file", async () => {
-    mockState.SettingsManager.create.mockReturnValueOnce({
-      getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o:high"]),
-      getDefaultProvider: vi.fn().mockReturnValue(undefined),
-      getDefaultModel: vi.fn().mockReturnValue(undefined),
-      drainErrors: vi.fn().mockReturnValue([]),
-    });
-
-    await PiSessionService.create(createConfig({ piSessionPath: "/etc/hosts" }));
-
-    expect(mockState.createAgentSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: undefined,
-        thinkingLevel: undefined,
-        scopedModels: [{ model: mockState.models[1], thinkingLevel: "high" }],
-      }),
-    );
-  });
-
-  it("switches models via the underlying session", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    await expect(service.setModel("openai", "gpt-4o")).resolves.toBe("openai/gpt-4o");
-    expect(currentSession.setModel).toHaveBeenCalledWith({
-      provider: "openai",
-      id: "gpt-4o",
-      name: "GPT-4o",
-    });
-    expect(currentSession.setThinkingLevel).not.toHaveBeenCalled();
-  });
-
-  it("applies a scoped thinking-level override when switching models", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    await expect(service.setModel("openai", "gpt-4o", "high")).resolves.toBe("openai/gpt-4o");
-    expect(currentSession.setModel).toHaveBeenCalledWith({
-      provider: "openai",
-      id: "gpt-4o",
-      name: "GPT-4o",
-    });
-    expect(currentSession.setThinkingLevel).toHaveBeenCalledWith("high");
-  });
-
-  it("forks via AgentSessionRuntime", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const withSession = vi.fn().mockResolvedValue(undefined);
-
-    await expect(service.fork("known-id", { position: "before", withSession })).resolves.toEqual({ cancelled: false });
-    expect(runtime.fork).toHaveBeenCalledWith("known-id", { position: "before", withSession });
-  });
-
-  it("clears the active handle when extension rebinding fails during same-runtime forks", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const previousSession = mockState.createdSessions[0]?.session;
-    const runtime = mockState.createdRuntimes[0]?.runtime;
-    const bindings = { uiContext: { notify: vi.fn() } } as any;
-    const originalCreateAgentSession = mockState.createAgentSession.getMockImplementation();
-
-    await service.bindExtensions(bindings);
-
-    mockState.createAgentSession.mockImplementationOnce(async (options: any) => {
-      const result = await originalCreateAgentSession!(options);
-      result.session.bindExtensions.mockRejectedValueOnce(new Error("extension rebinding exploded"));
-      return result;
-    });
-
-    await expect(service.fork("known-id")).rejects.toThrow("extension rebinding exploded");
-
-    const nextSession = mockState.createdSessions[1]?.session;
-    expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
-    expect(runtime.dispose).toHaveBeenCalledTimes(1);
-    expect(previousSession.dispose).toHaveBeenCalledTimes(1);
-    expect(nextSession.dispose).toHaveBeenCalledTimes(1);
-    expect(service.hasActiveSession()).toBe(false);
-    expect(service.getInfo()).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-  });
-
-  it("delegates tree access, navigation, and labels", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    currentSession.sessionManager.getTree.mockReturnValue([
-      {
-        entry: {
-          type: "message",
-          id: "labelled-id",
-          parentId: null,
-          timestamp: "2025-01-01T00:00:00Z",
-          message: { role: "user", content: "Pinned point" },
-        },
-        children: [],
-        label: "checkpoint",
-      },
-    ]);
-    currentSession.sessionManager.getChildren.mockReturnValueOnce([
-      {
-        type: "message",
-        id: "child-id",
-        parentId: "known-id",
-        timestamp: "2025-01-01T00:00:00Z",
-        message: { role: "assistant", content: "Child" },
-      },
-    ]);
-
-    expect(service.getTree()).toEqual([
-      expect.objectContaining({
-        entry: expect.objectContaining({ id: "labelled-id" }),
-        label: "checkpoint",
-      }),
-    ]);
-    expect(currentSession.sessionManager.getTree).toHaveBeenCalledTimes(1);
-
-    expect(service.getLeafId()).toBe("leaf-id");
-    expect(currentSession.sessionManager.getLeafId).toHaveBeenCalledTimes(1);
-
-    expect(service.getEntry("known-id")).toEqual(
-      expect.objectContaining({ type: "message", id: "known-id" }),
-    );
-    expect(service.getEntry("missing-id")).toBeUndefined();
-
-    expect(service.getChildren("known-id")).toEqual([
-      expect.objectContaining({ id: "child-id" }),
-    ]);
-    expect(currentSession.sessionManager.getChildren).toHaveBeenCalledWith("known-id");
-
-    await expect(service.navigateTree("known-id", { summarize: true })).resolves.toEqual({
-      cancelled: false,
-    });
-    expect(currentSession.navigateTree).toHaveBeenCalledWith("known-id", { summarize: true });
-
-    await expect(service.fork("known-id")).resolves.toEqual({ cancelled: false });
-    expect(mockState.createdRuntimes[0]?.runtime.fork).toHaveBeenCalledWith("known-id", undefined);
-
-    const forkedSession = mockState.createdSessions[1]?.session;
-    forkedSession.sessionManager.getTree.mockReturnValue(currentSession.sessionManager.getTree());
-
-    await expect(service.reload()).resolves.toBeUndefined();
-    expect(forkedSession.reload).toHaveBeenCalledTimes(1);
-
-    service.setLabel("known-id", "saved");
-    expect(forkedSession.sessionManager.appendLabelChange).toHaveBeenCalledWith("known-id", "saved");
-
-    expect(service.getLabels()).toEqual([
-      {
-        id: "labelled-id",
-        label: "checkpoint",
-        description: 'user: "Pinned point"',
-      },
-    ]);
-  });
-
-  it("throws for tree helpers when no active session exists", async () => {
-    const service = await PiSessionService.create(createConfig());
-    await service.handback();
-
-    expect(() => service.getTree()).toThrow("Pi session is not initialized");
-    expect(() => service.getLeafId()).toThrow("Pi session is not initialized");
-    expect(() => service.getEntry("known-id")).toThrow("Pi session is not initialized");
-    expect(() => service.getChildren("known-id")).toThrow("Pi session is not initialized");
-    expect(() => service.setLabel("known-id", "saved")).toThrow("Pi session is not initialized");
-    expect(() => service.getLabels()).toThrow("Pi session is not initialized");
-    await expect(service.navigateTree("known-id")).rejects.toThrow("Pi session is not initialized");
-  });
-
-  it("subscribes to session events and forwards callbacks", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    const onTextDelta = vi.fn();
-    const onToolStart = vi.fn();
-    const onToolUpdate = vi.fn();
-    const onToolEnd = vi.fn();
-    const onAgentEnd = vi.fn();
-
-    const unsubscribe = service.subscribe({
-      onTextDelta,
-      onToolStart,
-      onToolUpdate,
-      onToolEnd,
-      onAgentEnd,
-    });
-
-    const emit = mockState.getSubscriber(currentSession);
-    emit?.({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Hello" } });
-    emit?.({ type: "tool_execution_start", toolName: "bash", toolCallId: "tool-1" });
-    emit?.({ type: "tool_execution_update", toolCallId: "tool-1", partialResult: { ok: true } });
-    emit?.({ type: "tool_execution_end", toolCallId: "tool-1", isError: false });
-    emit?.({ type: "agent_end" });
-    unsubscribe();
-
-    expect(onTextDelta).toHaveBeenCalledWith("Hello");
-    expect(onToolStart).toHaveBeenCalledWith("bash", "tool-1");
-    expect(onToolUpdate).toHaveBeenCalledWith("tool-1", '{\n  "ok": true\n}');
-    expect(onToolEnd).toHaveBeenCalledWith("tool-1", false);
-    expect(onAgentEnd).toHaveBeenCalledTimes(1);
-  });
-
-  it("reloads auth storage before prompting", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    await service.prompt("hello");
-
-    expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
-  });
-
-  it("passes image attachments through when prompting", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    const images = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }] as any;
-
-    await service.prompt("hello", images);
-
-    expect(currentSession.prompt).toHaveBeenCalledWith("hello", { images });
-  });
-
-  it("reloads auth storage before listing models", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    await service.listModels();
-
-    expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
-  });
-
-  it("wraps prompt errors with a helpful message", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-    currentSession.prompt.mockRejectedValueOnce(new Error("boom"));
-
-    await expect(service.prompt("hello")).rejects.toThrow("Pi session prompt failed: boom");
-  });
-
-  it("disposes the active session", async () => {
-    const service = await PiSessionService.create(createConfig());
-    const currentSession = mockState.createdSessions[0]?.session;
-
-    service.dispose();
-
-    expect(currentSession.dispose).toHaveBeenCalledTimes(1);
-    expect(service.hasActiveSession()).toBe(false);
-  });
-
-  it("throws when setting an unknown model", async () => {
-    const service = await PiSessionService.create(createConfig());
-
-    await expect(service.setModel("unknown", "fake-model")).rejects.toThrow("Model not found: unknown/fake-model");
-  });
-
-  it("throws when getSession is called after dispose", async () => {
-    const service = await PiSessionService.create(createConfig());
-    service.dispose();
-
-    expect(() => service.getSession()).toThrow("Pi session is not initialized");
-  });
-
-  it("re-creates handle when newSession is called without an active handle", async () => {
-    const service = await PiSessionService.create(createConfig());
-    await service.handback(); // clear handle
-    expect(service.hasActiveSession()).toBe(false);
-
-    const result = await service.newSession();
-
-    expect(result.created).toBe(true);
-    expect(service.hasActiveSession()).toBe(true);
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
-  });
-
-  it("builds stable context keys for chat/topic pairs", () => {
-    expect(getPiSessionContextKey({ chatId: 123 })).toBe("123::root");
-    expect(getPiSessionContextKey({ chatId: 123, messageThreadId: 77 })).toBe("123::77");
-  });
-
-  it("creates independent services per Telegram context", async () => {
-    const registry = await PiSessionRegistry.create(createConfig({ piSessionPath: "/sessions/bootstrap.jsonl" }));
-
-    const rootService = await registry.getOrCreate({ chatId: 1 });
-    const topicService = await registry.getOrCreate({ chatId: 1, messageThreadId: 99 });
-    const rootAgain = await registry.getOrCreate({ chatId: 1 });
-
-    expect(rootAgain).toBe(rootService);
-    expect(topicService).not.toBe(rootService);
-    expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
-    expect(mockState.SessionManager.open).toHaveBeenNthCalledWith(1, "/sessions/bootstrap.jsonl", undefined, "/workspace/base");
-    expect(mockState.SessionManager.create).toHaveBeenNthCalledWith(1, "/workspace/base");
-    expect(mockState.createAgentSession).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        services: expect.objectContaining({ cwd: "/workspace/base" }),
-        sessionManager: expect.objectContaining({ sessionPath: "/sessions/bootstrap.jsonl" }),
-      }),
-    );
-  });
-
-  it("deduplicates concurrent getOrCreate calls for the same context", async () => {
-    const registry = await PiSessionRegistry.create(createConfig());
-    const originalImpl = mockState.createAgentSessionRuntime.getMockImplementation();
-    let resolveCreate!: () => void;
-
-    mockState.createAgentSessionRuntime.mockImplementationOnce(async (factory: any, options: any) => {
-      await new Promise<void>((resolve) => {
-        resolveCreate = resolve;
-      });
-      return originalImpl!(factory, options);
-    });
-
-    const first = registry.getOrCreate({ chatId: 7, messageThreadId: 1 });
-    const second = registry.getOrCreate({ chatId: 7, messageThreadId: 1 });
-
-    await Promise.resolve();
-    expect(mockState.createAgentSessionRuntime).toHaveBeenCalledTimes(1);
-
-    resolveCreate();
-    const [firstService, secondService] = await Promise.all([first, second]);
-
-    expect(firstService).toBe(secondService);
-    expect(mockState.createAgentSessionRuntime).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns fallback info for untouched contexts in the registry", async () => {
-    const registry = await PiSessionRegistry.create(createConfig());
-
-    expect(registry.getInfo({ chatId: 42 })).toEqual({
-      sessionId: "(no active session)",
-      sessionFile: undefined,
-      workspace: "/workspace/base",
-      sessionName: undefined,
-      modelFallbackMessage: undefined,
-      model: undefined,
-    });
-  });
-
-  it("removes and disposes individual context services", async () => {
-    const registry = await PiSessionRegistry.create(createConfig());
-    const service = await registry.getOrCreate({ chatId: 9, messageThreadId: 3 });
-
-    registry.remove({ chatId: 9, messageThreadId: 3 });
-
-    expect(service.hasActiveSession()).toBe(false);
-    expect(registry.get({ chatId: 9, messageThreadId: 3 })).toBeUndefined();
-  });
-
-  it("rejects inflight creations that are removed before they finish", async () => {
-    const registry = await PiSessionRegistry.create(createConfig());
-    const originalImpl = mockState.createAgentSessionRuntime.getMockImplementation();
-    let resolveCreate!: () => void;
-
-    mockState.createAgentSessionRuntime.mockImplementationOnce(async (factory: any, options: any) => {
-      await new Promise<void>((resolve) => {
-        resolveCreate = resolve;
-      });
-      return originalImpl!(factory, options);
-    });
-
-    const pending = registry.getOrCreate({ chatId: 11, messageThreadId: 4 });
-    await Promise.resolve();
-    registry.remove({ chatId: 11, messageThreadId: 4 });
-    resolveCreate();
-
-    await expect(pending).rejects.toThrow("Session removed during initialization");
-    expect(registry.get({ chatId: 11, messageThreadId: 4 })).toBeUndefined();
-  });
+	const createConfig = (
+		overrides: Partial<TelePiConfig> = {},
+	): TelePiConfig => ({
+		telegramBotToken: "bot-token",
+		telegramAllowedUserIds: [123],
+		telegramAllowedUserIdSet: new Set([123]),
+		workspace: "/workspace/base",
+		piSessionPath: undefined,
+		piModel: undefined,
+		toolVerbosity: "summary",
+		promptInboxDir: undefined,
+		promptInboxIntervalMs: 60000,
+		...overrides,
+	});
+
+	beforeEach(() => {
+		mockState.reset();
+	});
+
+	const getPatchedBashTool = (session: any) =>
+		session.agent.state.tools.find((tool: any) => tool.name === "bash");
+
+	it("creates a session service and initializes the Pi session runtime", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		expect(mockState.AuthStorage.create).toHaveBeenCalledTimes(1);
+		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(1);
+		expect(mockState.ModelRegistry.create).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "auth-storage" }),
+		);
+		expect(mockState.createAgentSessionRuntime).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.objectContaining({
+				cwd: "/workspace/base",
+				agentDir: "/mock-agent",
+			}),
+		);
+		expect(mockState.SettingsManager.create).toHaveBeenCalledWith(
+			"/workspace/base",
+		);
+		expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cwd: "/workspace/base",
+				authStorage: expect.objectContaining({ kind: "auth-storage" }),
+			}),
+		);
+		expect(mockState.createCodingTools).toHaveBeenCalledWith("/workspace/base");
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				services: expect.objectContaining({ cwd: "/workspace/base" }),
+				model: undefined,
+				scopedModels: [],
+			}),
+		);
+		expect(mockState.createAgentSession.mock.calls[0]?.[0]).not.toHaveProperty(
+			"tools",
+		);
+
+		expect(service.getInfo()).toEqual({
+			sessionId: "session-1",
+			sessionFile: "/tmp/session-1.jsonl",
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: "fallback-model",
+			model: "anthropic/claude-sonnet-4-5",
+		});
+	});
+
+	it("activates coding built-ins after session creation without disabling extension/custom tools on pi 0.70.x", async () => {
+		mockState.createCodingTools.mockReturnValueOnce([
+			{ name: "read", description: "Read files" },
+			{ name: "bash", description: "Execute bash" },
+			{ name: "write", description: "Write files" },
+			{ name: "find", description: "Find files" },
+			{ name: "ls", description: "List files" },
+		]);
+
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		expect(mockState.createAgentSession.mock.calls[0]?.[0]).not.toHaveProperty(
+			"tools",
+		);
+		expect(currentSession.setActiveToolsByName).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				"read",
+				"bash",
+				"edit",
+				"write",
+				"find",
+				"ls",
+				"extension-tool",
+			]),
+		);
+		expect(service.getSession().getActiveToolNames()).toEqual(
+			expect.arrayContaining([
+				"read",
+				"bash",
+				"edit",
+				"write",
+				"find",
+				"ls",
+				"extension-tool",
+			]),
+		);
+	});
+
+	it("collects runtime diagnostics for Telegram-visible session info", async () => {
+		mockState.SettingsManager.create.mockImplementationOnce(() => ({
+			getEnabledModels: vi.fn().mockReturnValue(undefined),
+			getDefaultProvider: vi.fn().mockReturnValue(undefined),
+			getDefaultModel: vi.fn().mockReturnValue(undefined),
+			drainErrors: vi.fn().mockReturnValue([
+				{
+					scope: "project",
+					error: new Error("failed to parse .pi/settings.json"),
+				},
+			]),
+		}));
+
+		const originalCreateServices =
+			mockState.createAgentSessionServices.getMockImplementation();
+		mockState.createAgentSessionServices.mockImplementationOnce(
+			async (options: any) => {
+				const result = await originalCreateServices!(options);
+				return {
+					...result,
+					diagnostics: [
+						{
+							type: "warning",
+							message: "Project auth: no API key configured for anthropic",
+						},
+					],
+					resourceLoader: {
+						...result.resourceLoader,
+						getExtensions: vi.fn().mockReturnValue({
+							extensions: [],
+							errors: [{ path: "/ext/bad.ts", error: "boom" }],
+							runtime: { pendingProviderRegistrations: [] },
+						}),
+						getSkills: vi.fn().mockReturnValue({
+							skills: [],
+							diagnostics: [
+								{
+									type: "warning",
+									message: "skill path does not exist",
+									path: "/skills/missing",
+								},
+							],
+						}),
+						getPrompts: vi
+							.fn()
+							.mockReturnValue({ prompts: [], diagnostics: [] }),
+						getThemes: vi.fn().mockReturnValue({
+							themes: [],
+							diagnostics: [
+								{
+									type: "warning",
+									message: "theme path does not exist",
+									path: "/themes/missing.json",
+								},
+							],
+						}),
+					},
+				};
+			},
+		);
+
+		const service = await PiSessionService.create(createConfig());
+
+		expect(service.getInfo()).toMatchObject({
+			diagnostics: [
+				{
+					type: "warning",
+					message: "Project auth: no API key configured for anthropic",
+				},
+				{
+					type: "warning",
+					message: "Project settings: failed to parse .pi/settings.json",
+				},
+				{
+					type: "error",
+					message: 'Failed to load extension "/ext/bad.ts": boom',
+				},
+				{
+					type: "warning",
+					message: "Skill issue (/skills/missing): skill path does not exist",
+				},
+				{
+					type: "warning",
+					message:
+						"Theme issue (/themes/missing.json): theme path does not exist",
+				},
+			],
+		});
+	});
+
+	it("patches the live bash tool via agent state mutation", async () => {
+		await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		const originalExecute = mockState.createdSessions[0]?.options?.bashExecute;
+		const bashTool = currentSession.agent.state.tools.find(
+			(tool: any) => tool.name === "bash",
+		);
+
+		expect(bashTool.description).toContain(
+			"Commands time out after 120 seconds by default.",
+		);
+		expect(bashTool.execute).not.toBe(originalExecute);
+
+		await bashTool.execute("tool-1", { command: "pwd" });
+
+		expect(originalExecute).toHaveBeenCalledWith(
+			"tool-1",
+			{ command: "pwd", timeout: 120 },
+			undefined,
+			undefined,
+		);
+	});
+
+	it("rejects TelePi launchctl self-management commands before they execute", async () => {
+		await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		const originalBashTool = mockState.createdSessions[0]?.options?.bashExecute;
+		const patchedBashTool = getPatchedBashTool(currentSession);
+
+		const blockedCommands = [
+			"launchctl kickstart -k gui/$UID/com.telepi",
+			"echo ready & launchctl kickstart -k gui/$UID/com.telepi",
+			"sudo -E launchctl kickstart -k gui/$UID/com.telepi",
+			"(launchctl kickstart -k gui/$UID/com.telepi)",
+			'bash -c "launchctl kickstart -k gui/$UID/com.telepi"',
+		];
+
+		for (const [index, command] of blockedCommands.entries()) {
+			expect(() =>
+				patchedBashTool.execute(`tool-${index + 1}`, { command }),
+			).toThrow(
+				"Blocked TelePi self-management command. launchctl commands targeting com.telepi cannot run from inside a TelePi session.",
+			);
+		}
+
+		expect(originalBashTool).not.toHaveBeenCalled();
+	});
+
+	it("adds the provider-response notice extension factory to session services", async () => {
+		await PiSessionService.create(createConfig());
+
+		expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resourceLoaderOptions: expect.objectContaining({
+					extensionFactories: [expect.any(Function)],
+				}),
+			}),
+		);
+	});
+
+	it("binds extension hooks through the underlying session", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		const bindings = {
+			onError: vi.fn(),
+			uiContext: { notify: vi.fn() },
+		} as any;
+
+		await service.bindExtensions(bindings);
+
+		expect(currentSession.bindExtensions).toHaveBeenCalledWith(bindings);
+	});
+
+	it("lists discovered slash commands from the Pi session runtime", async () => {
+		mockState.setSlashCommands([
+			{
+				name: "skill:browser-tools",
+				description: "Browser automation",
+				source: "skill",
+				path: "/skills/browser.md",
+			},
+			{
+				name: "/review",
+				description: "Review staged changes",
+				source: "prompt",
+				path: "/prompts/review.md",
+			},
+			{
+				name: "deploy",
+				description: "Deploy app",
+				source: "extension",
+				path: "/ext/deploy.ts",
+			},
+			{
+				name: "deploy",
+				description: "Duplicate deploy",
+				source: "extension",
+				path: "/ext/deploy-2.ts",
+			},
+		]);
+
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.listSlashCommands()).resolves.toEqual([
+			{
+				name: "deploy",
+				description: "Deploy app",
+				source: "extension",
+				path: "/ext/deploy.ts",
+			},
+			{
+				name: "review",
+				description: "Review staged changes",
+				source: "prompt",
+				path: "/prompts/review.md",
+			},
+			{
+				name: "skill:browser-tools",
+				description: "Browser automation",
+				source: "skill",
+				path: "/skills/browser.md",
+			},
+		]);
+	});
+
+	it("returns an empty slash-command list when runtime discovery is unavailable", async () => {
+		const originalImpl = mockState.createAgentSession.getMockImplementation();
+		mockState.createAgentSession.mockImplementationOnce(
+			async (options: any) => {
+				const result = await (originalImpl as any)(options);
+				result.extensionsResult = {
+					runtime: {},
+				};
+				return result;
+			},
+		);
+
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.listSlashCommands()).resolves.toEqual([]);
+	});
+
+	it("resolves PI_MODEL overrides during creation", async () => {
+		await PiSessionService.create(createConfig({ piModel: "openai/gpt-4o" }));
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+			}),
+		);
+	});
+
+	it("supports model lookup by bare id during creation", async () => {
+		await PiSessionService.create(createConfig({ piModel: "gpt-4o" }));
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+			}),
+		);
+	});
+
+	it("delegates isStreaming and tracks active sessions", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		currentSession.isStreaming = true;
+
+		expect(service.isStreaming()).toBe(true);
+		expect(service.hasActiveSession()).toBe(true);
+	});
+
+	it("creates a new session in the current workspace via AgentSessionRuntime", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+
+		const result = await service.newSession();
+
+		expect(runtime.newSession).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			created: true,
+			info: service.getInfo(),
+		});
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
+	});
+
+	it("forwards runtime new-session options and rebinds extensions and subscriptions after replacement", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const initialSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const bindings = { uiContext: { notify: vi.fn() } } as any;
+		const onTextDelta = vi.fn();
+
+		await service.bindExtensions(bindings);
+		service.subscribe({
+			onTextDelta,
+			onToolStart: vi.fn(),
+			onToolUpdate: vi.fn(),
+			onToolEnd: vi.fn(),
+			onAgentEnd: vi.fn(),
+		});
+
+		const setup = vi.fn().mockResolvedValue(undefined);
+		const withSession = vi.fn().mockResolvedValue(undefined);
+		const result = await service.newSession({
+			parentSession: "/tmp/parent.jsonl",
+			setup,
+			withSession,
+		});
+		const nextSession = mockState.createdSessions[1]?.session;
+
+		expect(runtime.newSession).toHaveBeenCalledWith({
+			parentSession: "/tmp/parent.jsonl",
+			setup,
+			withSession,
+		});
+		expect(result.created).toBe(true);
+		expect(setup).toHaveBeenCalledWith(nextSession.sessionManager);
+		expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
+		expect(mockState.getSubscriber(initialSession)).toBeUndefined();
+		expect(mockState.getSubscriber(nextSession)).toBeTypeOf("function");
+
+		mockState.getSubscriber(nextSession)?.({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "Rebound" },
+		});
+		expect(onTextDelta).toHaveBeenCalledWith("Rebound");
+	});
+
+	it("creates a new handle when starting a session in another workspace", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+
+		const result = await service.newSession("/workspace/other");
+
+		expect(mockState.SessionManager.create).toHaveBeenLastCalledWith(
+			"/workspace/other",
+		);
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(result.created).toBe(true);
+		expect(result.info.workspace).toBe("/workspace/other");
+		expect(service.getCurrentWorkspace()).toBe("/workspace/other");
+	});
+
+	it("throws when withSession is requested for a cross-workspace new session", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		await expect(
+			service.newSession({ workspace: "/workspace/other", withSession }),
+		).rejects.toThrow(
+			"TelePi only supports withSession callbacks for runtime-backed new-session replacements.",
+		);
+
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(1);
+		expect(withSession).not.toHaveBeenCalled();
+		expect(service.getCurrentWorkspace()).toBe("/workspace/base");
+	});
+
+	it("clears the active handle when extension rebinding fails during replacement", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const bindings = { uiContext: { notify: vi.fn() } } as any;
+		const originalCreateAgentSession =
+			mockState.createAgentSession.getMockImplementation();
+
+		await service.bindExtensions(bindings);
+		mockState.createAgentSession.mockImplementationOnce(
+			async (options: any) => {
+				const result = await originalCreateAgentSession!(options);
+				result.session.bindExtensions.mockRejectedValueOnce(
+					new Error("extension rebinding exploded"),
+				);
+				return result;
+			},
+		);
+
+		await expect(service.newSession("/workspace/other")).rejects.toThrow(
+			"extension rebinding exploded",
+		);
+
+		expect(
+			mockState.createdSessions[1]?.session.bindExtensions,
+		).toHaveBeenCalledWith(bindings);
+		expect(mockState.createdRuntimes[1]?.runtime.dispose).toHaveBeenCalledTimes(
+			1,
+		);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(service.hasActiveSession()).toBe(false);
+		expect(service.getInfo()).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+		expect(() => service.getSession()).toThrow("Pi session is not initialized");
+	});
+
+	it("clears the active handle when extension rebinding fails during same-runtime new-session replacement", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const bindings = { uiContext: { notify: vi.fn() } } as any;
+		const originalCreateAgentSession =
+			mockState.createAgentSession.getMockImplementation();
+
+		await service.bindExtensions(bindings);
+		service.subscribe({
+			onTextDelta: vi.fn(),
+			onToolStart: vi.fn(),
+			onToolUpdate: vi.fn(),
+			onToolEnd: vi.fn(),
+			onAgentEnd: vi.fn(),
+		});
+
+		mockState.createAgentSession.mockImplementationOnce(
+			async (options: any) => {
+				const result = await originalCreateAgentSession!(options);
+				result.session.bindExtensions.mockRejectedValueOnce(
+					new Error("extension rebinding exploded"),
+				);
+				return result;
+			},
+		);
+
+		await expect(service.newSession()).rejects.toThrow(
+			"extension rebinding exploded",
+		);
+
+		const nextSession = mockState.createdSessions[1]?.session;
+		expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
+		expect(runtime.dispose).toHaveBeenCalledTimes(1);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(nextSession.dispose).toHaveBeenCalledTimes(1);
+		expect(mockState.getSubscriber(previousSession)).toBeUndefined();
+		expect(mockState.getSubscriber(nextSession)).toBeUndefined();
+		expect(service.hasActiveSession()).toBe(false);
+		expect(service.getInfo()).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+		expect(() => service.getSession()).toThrow("Pi session is not initialized");
+	});
+
+	it("disposes the created runtime when cross-workspace setup fails", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const setup = vi.fn().mockRejectedValue(new Error("setup exploded"));
+
+		await expect(
+			service.newSession({ workspace: "/workspace/other", setup }),
+		).rejects.toThrow("setup exploded");
+
+		expect(setup).toHaveBeenCalledWith(
+			mockState.createdSessions[1]?.session.sessionManager,
+		);
+		expect(mockState.createdRuntimes[1]?.runtime.dispose).toHaveBeenCalledTimes(
+			1,
+		);
+		expect(mockState.createdSessions[1]?.session.dispose).toHaveBeenCalledTimes(
+			1,
+		);
+		expect(previousSession.dispose).not.toHaveBeenCalled();
+		expect(service.getCurrentWorkspace()).toBe("/workspace/base");
+		expect(service.getInfo().sessionId).toBe("session-1");
+	});
+
+	it("switches to a specific saved session and workspace via AgentSessionRuntime", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+
+		const info = await service.switchSession(
+			"/sessions/saved.jsonl",
+			"/workspace/projectA",
+		);
+
+		expect(runtime.switchSession).toHaveBeenCalledWith(
+			"/sessions/saved.jsonl",
+			{ cwdOverride: "/workspace/projectA" },
+		);
+		expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(
+			"/sessions/saved.jsonl",
+			undefined,
+			"/workspace/projectA",
+		);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(info.workspace).toBe("/workspace/projectA");
+		expect(info.sessionFile).toBe("/sessions/saved.jsonl");
+	});
+
+	it("forwards runtime switch-session options", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		await service.switchSession("/sessions/saved.jsonl", {
+			workspace: "/workspace/projectA",
+			withSession,
+		});
+
+		expect(runtime.switchSession).toHaveBeenCalledWith(
+			"/sessions/saved.jsonl",
+			{ cwdOverride: "/workspace/projectA", withSession },
+		);
+	});
+
+	it("adopts the runtime-resolved cwd when switching without an explicit workspace override", async () => {
+		const targetWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+
+		try {
+			const sessionPath = path.join(targetWorkspace, "cross-cwd.jsonl");
+			writeFileSync(
+				sessionPath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "crosscwd1",
+					timestamp: "2025-01-03T00:00:00.000Z",
+					cwd: targetWorkspace,
+				})}\n`,
+			);
+			const service = await PiSessionService.create(
+				createConfig({ workspace: "/workspace/projectA" }),
+			);
+			const runtime = mockState.createdRuntimes[0]?.runtime;
+
+			const info = await service.switchSession(sessionPath);
+
+			expect(runtime.switchSession).toHaveBeenCalledWith(sessionPath, {
+				cwdOverride: targetWorkspace,
+			});
+			expect(service.getCurrentWorkspace()).toBe(targetWorkspace);
+			expect(info.workspace).toBe(targetWorkspace);
+		} finally {
+			rmSync(targetWorkspace, { recursive: true, force: true });
+		}
+	});
+
+	it("switches using the resolved session path when the caller passes a ~ path", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
+
+		try {
+			const sessionPath = path.join(tempDir, "tilde-switch.jsonl");
+			writeFileSync(
+				sessionPath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "tilde-switch",
+					timestamp: "2025-01-03T00:00:00.000Z",
+					cwd: tempDir,
+				})}\n`,
+			);
+			const tildePath = sessionPath.replace(homedir(), "~");
+			const service = await PiSessionService.create(
+				createConfig({ workspace: "/workspace/projectA" }),
+			);
+			const runtime = mockState.createdRuntimes[0]?.runtime;
+
+			const info = await service.switchSession(tildePath);
+
+			expect(runtime.switchSession).toHaveBeenCalledWith(sessionPath, {
+				cwdOverride: tempDir,
+			});
+			expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(
+				sessionPath,
+				undefined,
+				tempDir,
+			);
+			expect(info.sessionFile).toBe(sessionPath);
+			expect(info.workspace).toBe(tempDir);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("switches using the remapped runtime session path instead of the raw caller input", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const rawSessionPath = "/Users/example/.pi/agent/sessions/remapped.jsonl";
+
+		try {
+			const resolvedSessionPath = path.join(tempDir, "remapped.jsonl");
+			writeFileSync(
+				resolvedSessionPath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "remapped1",
+					timestamp: "2025-01-03T00:00:00.000Z",
+					cwd: tempDir,
+				})}\n`,
+			);
+			mockState.setResolvedSessionPath(rawSessionPath, resolvedSessionPath);
+			const service = await PiSessionService.create(
+				createConfig({ workspace: "/workspace/projectA" }),
+			);
+			const runtime = mockState.createdRuntimes[0]?.runtime;
+
+			const info = await service.switchSession(rawSessionPath);
+
+			expect(runtime.switchSession).toHaveBeenCalledWith(resolvedSessionPath, {
+				cwdOverride: tempDir,
+			});
+			expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(
+				resolvedSessionPath,
+				undefined,
+				tempDir,
+			);
+			expect(info.sessionFile).toBe(resolvedSessionPath);
+			expect(info.workspace).toBe(tempDir);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rethrows unexpected session-resolution errors instead of silently falling back", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(
+			new Error("list exploded"),
+		);
+		const service = await PiSessionService.create(createConfig());
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+
+		await expect(service.switchSession("s1")).rejects.toThrow("list exploded");
+		expect(runtime.switchSession).not.toHaveBeenCalled();
+	});
+
+	it("switches using the resolved session path after handback when no handle is active", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
+
+		try {
+			const sessionPath = path.join(tempDir, "tilde-reopen.jsonl");
+			writeFileSync(
+				sessionPath,
+				`${JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "tilde-reopen",
+					timestamp: "2025-01-03T00:00:00.000Z",
+					cwd: tempDir,
+				})}\n`,
+			);
+			const tildePath = sessionPath.replace(homedir(), "~");
+			const service = await PiSessionService.create(
+				createConfig({ workspace: "/workspace/projectA" }),
+			);
+
+			await service.handback();
+			expect(service.hasActiveSession()).toBe(false);
+
+			const info = await service.switchSession(tildePath);
+
+			expect(mockState.SessionManager.open).toHaveBeenLastCalledWith(
+				sessionPath,
+				undefined,
+				tempDir,
+			);
+			expect(info.sessionFile).toBe(sessionPath);
+			expect(info.workspace).toBe(tempDir);
+			expect(service.hasActiveSession()).toBe(true);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("throws when withSession is requested for a switch without an active handle", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		await service.handback();
+		expect(service.hasActiveSession()).toBe(false);
+
+		await expect(
+			service.switchSession("/sessions/saved.jsonl", { withSession }),
+		).rejects.toThrow(
+			"TelePi only supports withSession callbacks for runtime-backed session switches.",
+		);
+
+		expect(mockState.SessionManager.open).not.toHaveBeenCalled();
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(1);
+		expect(withSession).not.toHaveBeenCalled();
+	});
+
+	it("recreates the model registry each time the runtime factory creates a same-runtime replacement session", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const firstRegistry =
+			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
+
+		await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
+
+		const secondRegistry =
+			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
+		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
+		expect(firstRegistry).toBe(mockState.modelRegistryInstances[0]);
+		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
+		expect(secondRegistry).not.toBe(firstRegistry);
+	});
+
+	it("recreates the model registry and reapplies coding-tool activation for cross-runtime replacements", async () => {
+		mockState.createCodingTools.mockReturnValue([
+			{ name: "read", description: "Read files" },
+			{ name: "bash", description: "Execute bash" },
+			{ name: "edit", description: "Edit files" },
+			{ name: "write", description: "Write files" },
+			{ name: "find", description: "Find files" },
+		]);
+		const service = await PiSessionService.create(createConfig());
+		const firstRegistry =
+			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
+
+		await service.newSession("/workspace/other");
+
+		const secondRegistry =
+			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
+		const replacementSession = mockState.createdSessions[1]?.session;
+		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
+		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
+		expect(secondRegistry).not.toBe(firstRegistry);
+		expect(replacementSession.setActiveToolsByName).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				"read",
+				"bash",
+				"edit",
+				"write",
+				"find",
+				"extension-tool",
+			]),
+		);
+		expect(replacementSession.getActiveToolNames()).toEqual(
+			expect.arrayContaining([
+				"read",
+				"bash",
+				"edit",
+				"write",
+				"find",
+				"extension-tool",
+			]),
+		);
+	});
+
+	it("returns the runtime cancellation signal when switching sessions is cancelled", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const initialInfo = service.getInfo();
+
+		runtime.switchSession.mockResolvedValueOnce({ cancelled: true });
+
+		const result = await service.switchSession(
+			"/sessions/saved.jsonl",
+			"/workspace/projectA",
+		);
+
+		expect(result).toEqual({
+			...initialInfo,
+			cancelled: true,
+		});
+		expect(previousSession.dispose).not.toHaveBeenCalled();
+	});
+
+	it("clears the active handle when extension rebinding fails during same-runtime session switching", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const bindings = { uiContext: { notify: vi.fn() } } as any;
+		const originalCreateAgentSession =
+			mockState.createAgentSession.getMockImplementation();
+
+		await service.bindExtensions(bindings);
+		service.subscribe({
+			onTextDelta: vi.fn(),
+			onToolStart: vi.fn(),
+			onToolUpdate: vi.fn(),
+			onToolEnd: vi.fn(),
+			onAgentEnd: vi.fn(),
+		});
+
+		mockState.createAgentSession.mockImplementationOnce(
+			async (options: any) => {
+				const result = await originalCreateAgentSession!(options);
+				result.session.bindExtensions.mockRejectedValueOnce(
+					new Error("extension rebinding exploded"),
+				);
+				return result;
+			},
+		);
+
+		await expect(
+			service.switchSession("/sessions/saved.jsonl", "/workspace/projectA"),
+		).rejects.toThrow("extension rebinding exploded");
+
+		const nextSession = mockState.createdSessions[1]?.session;
+		expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
+		expect(runtime.dispose).toHaveBeenCalledTimes(1);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(nextSession.dispose).toHaveBeenCalledTimes(1);
+		expect(mockState.getSubscriber(previousSession)).toBeUndefined();
+		expect(mockState.getSubscriber(nextSession)).toBeUndefined();
+		expect(service.hasActiveSession()).toBe(false);
+		expect(service.getCurrentWorkspace()).toBe("/workspace/base");
+		expect(service.getInfo()).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+	});
+
+	it("hands back the active session and clears the handle", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		await expect(service.handback()).resolves.toEqual({
+			sessionFile: "/tmp/session-1.jsonl",
+			workspace: "/workspace/base",
+		});
+
+		expect(currentSession.dispose).toHaveBeenCalledTimes(1);
+		expect(service.hasActiveSession()).toBe(false);
+		expect(service.getInfo()).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+	});
+
+	it("returns an empty handback after the session is already handed back", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		await service.handback();
+
+		await expect(service.handback()).resolves.toEqual({
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+		});
+	});
+
+	it("blocks handback when continuing a session in a fallback workspace", async () => {
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "moved.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "moved1234",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: "/definitely/missing/workspace",
+			})}\n`,
+		);
+		const service = await PiSessionService.create(createConfig());
+
+		await service.switchSession(sessionPath, "/workspace/base");
+		await expect(service.handback()).rejects.toThrow(
+			"Cannot hand back this session while its saved workspace is unavailable (/definitely/missing/workspace).",
+		);
+		expect(service.hasActiveSession()).toBe(true);
+	});
+
+	it("aborts the active session and becomes a no-op without one", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		await service.abort();
+		expect(currentSession.abort).toHaveBeenCalledTimes(1);
+
+		await service.handback();
+		await expect(service.abort()).resolves.toBeUndefined();
+		expect(currentSession.abort).toHaveBeenCalledTimes(1);
+	});
+
+	it("lists all sessions sorted by modified date descending", async () => {
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "older",
+				firstMessage: "Old",
+				path: "/sessions/old.jsonl",
+				messageCount: 1,
+				cwd: "/workspace/b",
+				modified: new Date("2025-01-01T00:00:00.000Z"),
+				name: "Old name",
+			},
+			{
+				id: "newer",
+				firstMessage: "New",
+				path: "/sessions/new.jsonl",
+				messageCount: 2,
+				cwd: "/workspace/a",
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+				name: "New name",
+			},
+		]);
+
+		const service = await PiSessionService.create(createConfig());
+		const sessions = await service.listAllSessions();
+
+		expect(sessions.map((session) => session.id)).toEqual(["newer", "older"]);
+		expect(sessions[0]).toMatchObject({
+			name: "New name",
+			cwd: "/workspace/a",
+		});
+	});
+
+	it("lists unique workspaces in sorted order", async () => {
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "a",
+				firstMessage: "One",
+				path: "/sessions/a.jsonl",
+				messageCount: 1,
+				cwd: "/workspace/z",
+				modified: new Date(),
+			},
+			{
+				id: "b",
+				firstMessage: "Two",
+				path: "/sessions/b.jsonl",
+				messageCount: 2,
+				cwd: "/workspace/a",
+				modified: new Date(),
+			},
+			{
+				id: "c",
+				firstMessage: "Three",
+				path: "/sessions/c.jsonl",
+				messageCount: 3,
+				cwd: "/workspace/z",
+				modified: new Date(),
+			},
+		]);
+
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.listWorkspaces()).resolves.toEqual([
+			"/workspace/a",
+			"/workspace/z",
+		]);
+	});
+
+	it("resolves a saved session reference by path, exact ID, or unique ID prefix", async () => {
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const tempDirTwo = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "one.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "abc12345",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: tempDir,
+			})}\n`,
+		);
+		mockState.SessionManager.listAll.mockResolvedValue([
+			{
+				id: "abc12345",
+				firstMessage: "One",
+				path: sessionPath,
+				messageCount: 1,
+				cwd: tempDir,
+				modified: new Date("2025-01-03T00:00:00.000Z"),
+			},
+			{
+				id: "def67890",
+				firstMessage: "Two",
+				path: "/sessions/two.jsonl",
+				messageCount: 1,
+				cwd: tempDirTwo,
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+			},
+		]);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual(
+			{
+				id: "abc12345",
+				path: sessionPath,
+				cwd: tempDir,
+				matchType: "path",
+			},
+		);
+		await expect(service.resolveSessionReference("def67890")).resolves.toEqual({
+			id: "def67890",
+			path: "/sessions/two.jsonl",
+			cwd: tempDirTwo,
+			matchType: "id",
+		});
+		await expect(service.resolveSessionReference("abc1")).resolves.toEqual({
+			id: "abc12345",
+			path: sessionPath,
+			cwd: tempDir,
+			matchType: "prefix",
+		});
+	});
+
+	it("falls back to an explicit existing session path even when the session index is unavailable", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "manual.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "manual1234",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: tempDir,
+			})}\n`,
+		);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual(
+			{
+				id: "manual1234",
+				path: sessionPath,
+				cwd: tempDir,
+				matchType: "path",
+			},
+		);
+	});
+
+	it("falls back to the current workspace when an explicit session path has an unavailable workspace", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "moved.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "moved1234",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: "/definitely/missing/workspace",
+			})}\n`,
+		);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual(
+			{
+				id: "moved1234",
+				path: sessionPath,
+				cwd: undefined,
+				workspaceWarning:
+					"Saved workspace /definitely/missing/workspace is unavailable in this TelePi runtime. Continuing in the current workspace instead.",
+				matchType: "path",
+			},
+		);
+	});
+
+	it("expands ~ when switching by explicit session path", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(homedir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "tilde.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "tilde1234",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: tempDir,
+			})}\n`,
+		);
+		const tildePath = sessionPath.replace(homedir(), "~");
+
+		try {
+			const service = await PiSessionService.create(createConfig());
+			await expect(service.resolveSessionReference(tildePath)).resolves.toEqual(
+				{
+					id: "tilde1234",
+					path: sessionPath,
+					cwd: tempDir,
+					matchType: "path",
+				},
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("allows explicit path recovery for existing session files with an invalid header", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "broken.jsonl");
+		writeFileSync(sessionPath, "not-json\n");
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual(
+			{
+				id: "broken.jsonl",
+				path: sessionPath,
+				cwd: undefined,
+				matchType: "path",
+			},
+		);
+	});
+
+	it("accepts legacy session files without cwd when switching by explicit path", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "legacy.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				id: "legacy1234",
+			})}\n`,
+		);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference(sessionPath)).resolves.toEqual(
+			{
+				id: "legacy1234",
+				path: sessionPath,
+				cwd: undefined,
+				matchType: "path",
+			},
+		);
+	});
+
+	it("prefers exact ID matches over prefix matches", async () => {
+		const exactWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const prefixWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "abc",
+				firstMessage: "Exact",
+				path: "/sessions/exact.jsonl",
+				messageCount: 1,
+				cwd: exactWorkspace,
+				modified: new Date("2025-01-03T00:00:00.000Z"),
+			},
+			{
+				id: "abcdef12",
+				firstMessage: "Prefix",
+				path: "/sessions/prefix.jsonl",
+				messageCount: 1,
+				cwd: prefixWorkspace,
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+			},
+		]);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference("abc")).resolves.toEqual({
+			id: "abc",
+			path: "/sessions/exact.jsonl",
+			cwd: exactWorkspace,
+			matchType: "id",
+		});
+	});
+
+	it("falls back to the current workspace for saved session IDs whose workspace is unavailable", async () => {
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "bad12345",
+				firstMessage: "Broken",
+				path: "/sessions/bad.jsonl",
+				messageCount: 1,
+				cwd: "/definitely/missing/workspace",
+				modified: new Date("2025-01-03T00:00:00.000Z"),
+			},
+		]);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference("bad12345")).resolves.toEqual({
+			id: "bad12345",
+			path: "/sessions/bad.jsonl",
+			cwd: undefined,
+			workspaceWarning:
+				"Saved workspace /definitely/missing/workspace is unavailable in this TelePi runtime. Continuing in the current workspace instead.",
+			matchType: "id",
+		});
+	});
+
+	it("prefers a unique prefix match from the current workspace before searching globally", async () => {
+		const currentWorkspace = mkdtempSync(
+			path.join(tmpdir(), "telepi-session-"),
+		);
+		const otherWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "abc-local",
+				firstMessage: "Local",
+				path: "/sessions/local.jsonl",
+				messageCount: 1,
+				cwd: currentWorkspace,
+				modified: new Date("2025-01-03T00:00:00.000Z"),
+			},
+			{
+				id: "abc-global",
+				firstMessage: "Global",
+				path: "/sessions/global.jsonl",
+				messageCount: 1,
+				cwd: otherWorkspace,
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+			},
+		]);
+		const service = await PiSessionService.create(
+			createConfig({ workspace: currentWorkspace }),
+		);
+
+		await expect(service.resolveSessionReference("abc")).resolves.toEqual({
+			id: "abc-local",
+			path: "/sessions/local.jsonl",
+			cwd: currentWorkspace,
+			matchType: "prefix",
+		});
+	});
+
+	it("rejects ambiguous or missing saved session references", async () => {
+		mockState.SessionManager.listAll.mockResolvedValueOnce([
+			{
+				id: "abcd1111",
+				firstMessage: "One",
+				path: "/sessions/one.jsonl",
+				messageCount: 1,
+				cwd: "/workspace/one",
+				modified: new Date("2025-01-03T00:00:00.000Z"),
+			},
+			{
+				id: "abcd2222",
+				firstMessage: "Two",
+				path: "/sessions/two.jsonl",
+				messageCount: 1,
+				cwd: "/workspace/two",
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+			},
+		]);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveSessionReference("abcd")).rejects.toThrow(
+			'Session ID prefix "abcd" matches 2 saved sessions.',
+		);
+		await expect(service.resolveSessionReference("missing")).rejects.toThrow(
+			'No saved session matches "missing".',
+		);
+		await expect(
+			service.resolveSessionReference("/sessions/missing.jsonl"),
+		).rejects.toThrow("Saved session not found: /sessions/missing.jsonl");
+	});
+
+	it("resolves a workspace for a saved session reference", async () => {
+		const tempDir = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const secondWorkspace = mkdtempSync(path.join(tmpdir(), "telepi-session-"));
+		const sessionPath = path.join(tempDir, "s1.jsonl");
+		writeFileSync(
+			sessionPath,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "s1",
+				timestamp: "2025-01-03T00:00:00.000Z",
+				cwd: tempDir,
+			})}\n`,
+		);
+		mockState.SessionManager.listAll.mockResolvedValue([
+			{
+				id: "s1",
+				firstMessage: "Hello",
+				path: sessionPath,
+				messageCount: 5,
+				cwd: tempDir,
+				modified: new Date("2025-01-02T00:00:00.000Z"),
+				name: "First",
+			},
+			{
+				id: "s2",
+				firstMessage: "World",
+				path: "/sessions/s2.jsonl",
+				messageCount: 3,
+				cwd: secondWorkspace,
+				modified: new Date("2025-01-01T00:00:00.000Z"),
+				name: "Second",
+			},
+		]);
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.resolveWorkspaceForSession(sessionPath)).resolves.toBe(
+			tempDir,
+		);
+		await expect(service.resolveWorkspaceForSession("s2")).resolves.toBe(
+			secondWorkspace,
+		);
+	});
+
+	it("returns undefined when resolving a workspace fails", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(
+			service.resolveWorkspaceForSession("/sessions/missing.jsonl"),
+		).resolves.toBeUndefined();
+	});
+
+	it("returns undefined when an ID-based workspace lookup hits an unexpected index failure", async () => {
+		mockState.SessionManager.listAll.mockRejectedValueOnce(new Error("boom"));
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(
+			service.resolveWorkspaceForSession("s1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("lists models with the current one marked", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.listModels()).resolves.toEqual([
+			{
+				provider: "anthropic",
+				id: "claude-sonnet-4-5",
+				name: "Claude Sonnet",
+				current: true,
+				thinkingLevel: undefined,
+			},
+			{
+				provider: "openai",
+				id: "gpt-4o",
+				name: "GPT-4o",
+				current: false,
+				thinkingLevel: undefined,
+			},
+		]);
+	});
+
+	it("lists only scoped models when the session has a model scope", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		currentSession.scopedModels = [
+			{ model: mockState.models[1], thinkingLevel: "high" },
+		];
+
+		await expect(service.listModels()).resolves.toEqual([
+			{
+				provider: "openai",
+				id: "gpt-4o",
+				name: "GPT-4o",
+				current: false,
+				thinkingLevel: "high",
+			},
+		]);
+	});
+
+	it("can list all models even when a scope is active", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		currentSession.scopedModels = [
+			{ model: mockState.models[1], thinkingLevel: "high" },
+		];
+
+		await expect(service.listModels(true)).resolves.toEqual([
+			{
+				provider: "anthropic",
+				id: "claude-sonnet-4-5",
+				name: "Claude Sonnet",
+				current: true,
+				thinkingLevel: undefined,
+			},
+			{
+				provider: "openai",
+				id: "gpt-4o",
+				name: "GPT-4o",
+				current: false,
+				thinkingLevel: "high",
+			},
+		]);
+	});
+
+	it("derives scoped models from pi settings when enabled models are configured", async () => {
+		mockState.SettingsManager.create.mockReturnValueOnce({
+			getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o"]),
+			getDefaultProvider: vi.fn().mockReturnValue(undefined),
+			getDefaultModel: vi.fn().mockReturnValue(undefined),
+			drainErrors: vi.fn().mockReturnValue([]),
+		});
+
+		await PiSessionService.create(createConfig());
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scopedModels: [{ model: mockState.models[1] }],
+			}),
+		);
+	});
+
+	it("starts a new session on the preferred scoped default model", async () => {
+		mockState.SettingsManager.create.mockReturnValueOnce({
+			getEnabledModels: vi
+				.fn()
+				.mockReturnValue(["anthropic/claude-sonnet-4-5", "openai/gpt-4o:high"]),
+			getDefaultProvider: vi.fn().mockReturnValue("openai"),
+			getDefaultModel: vi.fn().mockReturnValue("gpt-4o"),
+			drainErrors: vi.fn().mockReturnValue([]),
+		});
+
+		await PiSessionService.create(createConfig());
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: mockState.models[1],
+				thinkingLevel: "high",
+				scopedModels: [
+					{ model: mockState.models[0] },
+					{ model: mockState.models[1], thinkingLevel: "high" },
+				],
+			}),
+		);
+	});
+
+	it("falls back to the first scoped model when no scoped default is saved", async () => {
+		mockState.SettingsManager.create.mockReturnValueOnce({
+			getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o:high"]),
+			getDefaultProvider: vi.fn().mockReturnValue(undefined),
+			getDefaultModel: vi.fn().mockReturnValue(undefined),
+			drainErrors: vi.fn().mockReturnValue([]),
+		});
+
+		await PiSessionService.create(createConfig());
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: mockState.models[1],
+				thinkingLevel: "high",
+			}),
+		);
+	});
+
+	it("does not override the model when opening an existing session file", async () => {
+		mockState.SettingsManager.create.mockReturnValueOnce({
+			getEnabledModels: vi.fn().mockReturnValue(["openai/gpt-4o:high"]),
+			getDefaultProvider: vi.fn().mockReturnValue(undefined),
+			getDefaultModel: vi.fn().mockReturnValue(undefined),
+			drainErrors: vi.fn().mockReturnValue([]),
+		});
+
+		await PiSessionService.create(
+			createConfig({ piSessionPath: "/etc/hosts" }),
+		);
+
+		expect(mockState.createAgentSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: undefined,
+				thinkingLevel: undefined,
+				scopedModels: [{ model: mockState.models[1], thinkingLevel: "high" }],
+			}),
+		);
+	});
+
+	it("switches models via the underlying session", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		await expect(service.setModel("openai", "gpt-4o")).resolves.toBe(
+			"openai/gpt-4o",
+		);
+		expect(currentSession.setModel).toHaveBeenCalledWith({
+			provider: "openai",
+			id: "gpt-4o",
+			name: "GPT-4o",
+		});
+		expect(currentSession.setThinkingLevel).not.toHaveBeenCalled();
+	});
+
+	it("applies a scoped thinking-level override when switching models", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		await expect(service.setModel("openai", "gpt-4o", "high")).resolves.toBe(
+			"openai/gpt-4o",
+		);
+		expect(currentSession.setModel).toHaveBeenCalledWith({
+			provider: "openai",
+			id: "gpt-4o",
+			name: "GPT-4o",
+		});
+		expect(currentSession.setThinkingLevel).toHaveBeenCalledWith("high");
+	});
+
+	it("forks via AgentSessionRuntime", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const withSession = vi.fn().mockResolvedValue(undefined);
+
+		await expect(
+			service.fork("known-id", { position: "before", withSession }),
+		).resolves.toEqual({ cancelled: false });
+		expect(runtime.fork).toHaveBeenCalledWith("known-id", {
+			position: "before",
+			withSession,
+		});
+	});
+
+	it("clears the active handle when extension rebinding fails during same-runtime forks", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const previousSession = mockState.createdSessions[0]?.session;
+		const runtime = mockState.createdRuntimes[0]?.runtime;
+		const bindings = { uiContext: { notify: vi.fn() } } as any;
+		const originalCreateAgentSession =
+			mockState.createAgentSession.getMockImplementation();
+
+		await service.bindExtensions(bindings);
+
+		mockState.createAgentSession.mockImplementationOnce(
+			async (options: any) => {
+				const result = await originalCreateAgentSession!(options);
+				result.session.bindExtensions.mockRejectedValueOnce(
+					new Error("extension rebinding exploded"),
+				);
+				return result;
+			},
+		);
+
+		await expect(service.fork("known-id")).rejects.toThrow(
+			"extension rebinding exploded",
+		);
+
+		const nextSession = mockState.createdSessions[1]?.session;
+		expect(nextSession.bindExtensions).toHaveBeenCalledWith(bindings);
+		expect(runtime.dispose).toHaveBeenCalledTimes(1);
+		expect(previousSession.dispose).toHaveBeenCalledTimes(1);
+		expect(nextSession.dispose).toHaveBeenCalledTimes(1);
+		expect(service.hasActiveSession()).toBe(false);
+		expect(service.getInfo()).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+	});
+
+	it("delegates tree access, navigation, and labels", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		currentSession.sessionManager.getTree.mockReturnValue([
+			{
+				entry: {
+					type: "message",
+					id: "labelled-id",
+					parentId: null,
+					timestamp: "2025-01-01T00:00:00Z",
+					message: { role: "user", content: "Pinned point" },
+				},
+				children: [],
+				label: "checkpoint",
+			},
+		]);
+		currentSession.sessionManager.getChildren.mockReturnValueOnce([
+			{
+				type: "message",
+				id: "child-id",
+				parentId: "known-id",
+				timestamp: "2025-01-01T00:00:00Z",
+				message: { role: "assistant", content: "Child" },
+			},
+		]);
+
+		expect(service.getTree()).toEqual([
+			expect.objectContaining({
+				entry: expect.objectContaining({ id: "labelled-id" }),
+				label: "checkpoint",
+			}),
+		]);
+		expect(currentSession.sessionManager.getTree).toHaveBeenCalledTimes(1);
+
+		expect(service.getLeafId()).toBe("leaf-id");
+		expect(currentSession.sessionManager.getLeafId).toHaveBeenCalledTimes(1);
+
+		expect(service.getEntry("known-id")).toEqual(
+			expect.objectContaining({ type: "message", id: "known-id" }),
+		);
+		expect(service.getEntry("missing-id")).toBeUndefined();
+
+		expect(service.getChildren("known-id")).toEqual([
+			expect.objectContaining({ id: "child-id" }),
+		]);
+		expect(currentSession.sessionManager.getChildren).toHaveBeenCalledWith(
+			"known-id",
+		);
+
+		await expect(
+			service.navigateTree("known-id", { summarize: true }),
+		).resolves.toEqual({
+			cancelled: false,
+		});
+		expect(currentSession.navigateTree).toHaveBeenCalledWith("known-id", {
+			summarize: true,
+		});
+
+		await expect(service.fork("known-id")).resolves.toEqual({
+			cancelled: false,
+		});
+		expect(mockState.createdRuntimes[0]?.runtime.fork).toHaveBeenCalledWith(
+			"known-id",
+			undefined,
+		);
+
+		const forkedSession = mockState.createdSessions[1]?.session;
+		forkedSession.sessionManager.getTree.mockReturnValue(
+			currentSession.sessionManager.getTree(),
+		);
+
+		await expect(service.reload()).resolves.toBeUndefined();
+		expect(forkedSession.reload).toHaveBeenCalledTimes(1);
+
+		service.setLabel("known-id", "saved");
+		expect(forkedSession.sessionManager.appendLabelChange).toHaveBeenCalledWith(
+			"known-id",
+			"saved",
+		);
+
+		expect(service.getLabels()).toEqual([
+			{
+				id: "labelled-id",
+				label: "checkpoint",
+				description: 'user: "Pinned point"',
+			},
+		]);
+	});
+
+	it("throws for tree helpers when no active session exists", async () => {
+		const service = await PiSessionService.create(createConfig());
+		await service.handback();
+
+		expect(() => service.getTree()).toThrow("Pi session is not initialized");
+		expect(() => service.getLeafId()).toThrow("Pi session is not initialized");
+		expect(() => service.getEntry("known-id")).toThrow(
+			"Pi session is not initialized",
+		);
+		expect(() => service.getChildren("known-id")).toThrow(
+			"Pi session is not initialized",
+		);
+		expect(() => service.setLabel("known-id", "saved")).toThrow(
+			"Pi session is not initialized",
+		);
+		expect(() => service.getLabels()).toThrow("Pi session is not initialized");
+		await expect(service.navigateTree("known-id")).rejects.toThrow(
+			"Pi session is not initialized",
+		);
+	});
+
+	it("subscribes to session events and forwards callbacks", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		const onTextDelta = vi.fn();
+		const onToolStart = vi.fn();
+		const onToolUpdate = vi.fn();
+		const onToolEnd = vi.fn();
+		const onAgentEnd = vi.fn();
+
+		const unsubscribe = service.subscribe({
+			onTextDelta,
+			onToolStart,
+			onToolUpdate,
+			onToolEnd,
+			onAgentEnd,
+		});
+
+		const emit = mockState.getSubscriber(currentSession);
+		emit?.({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+		});
+		emit?.({
+			type: "tool_execution_start",
+			toolName: "bash",
+			toolCallId: "tool-1",
+		});
+		emit?.({
+			type: "tool_execution_update",
+			toolCallId: "tool-1",
+			partialResult: { ok: true },
+		});
+		emit?.({
+			type: "tool_execution_end",
+			toolCallId: "tool-1",
+			isError: false,
+		});
+		emit?.({ type: "agent_end" });
+		unsubscribe();
+
+		expect(onTextDelta).toHaveBeenCalledWith("Hello");
+		expect(onToolStart).toHaveBeenCalledWith("bash", "tool-1");
+		expect(onToolUpdate).toHaveBeenCalledWith("tool-1", '{\n  "ok": true\n}');
+		expect(onToolEnd).toHaveBeenCalledWith("tool-1", false);
+		expect(onAgentEnd).toHaveBeenCalledTimes(1);
+	});
+
+	it("reloads auth storage before prompting", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		await service.prompt("hello");
+
+		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+	});
+
+	it("passes image attachments through when prompting", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		const images = [
+			{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+		] as any;
+
+		await service.prompt("hello", images);
+
+		expect(currentSession.prompt).toHaveBeenCalledWith("hello", { images });
+	});
+
+	it("reloads auth storage before listing models", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		await service.listModels();
+
+		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+	});
+
+	it("wraps prompt errors with a helpful message", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+		currentSession.prompt.mockRejectedValueOnce(new Error("boom"));
+
+		await expect(service.prompt("hello")).rejects.toThrow(
+			"Pi session prompt failed: boom",
+		);
+	});
+
+	it("disposes the active session", async () => {
+		const service = await PiSessionService.create(createConfig());
+		const currentSession = mockState.createdSessions[0]?.session;
+
+		service.dispose();
+
+		expect(currentSession.dispose).toHaveBeenCalledTimes(1);
+		expect(service.hasActiveSession()).toBe(false);
+	});
+
+	it("throws when setting an unknown model", async () => {
+		const service = await PiSessionService.create(createConfig());
+
+		await expect(service.setModel("unknown", "fake-model")).rejects.toThrow(
+			"Model not found: unknown/fake-model",
+		);
+	});
+
+	it("throws when getSession is called after dispose", async () => {
+		const service = await PiSessionService.create(createConfig());
+		service.dispose();
+
+		expect(() => service.getSession()).toThrow("Pi session is not initialized");
+	});
+
+	it("re-creates handle when newSession is called without an active handle", async () => {
+		const service = await PiSessionService.create(createConfig());
+		await service.handback(); // clear handle
+		expect(service.hasActiveSession()).toBe(false);
+
+		const result = await service.newSession();
+
+		expect(result.created).toBe(true);
+		expect(service.hasActiveSession()).toBe(true);
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
+	});
+
+	it("builds stable context keys for chat/topic pairs", () => {
+		expect(getPiSessionContextKey({ chatId: 123 })).toBe("123::root");
+		expect(getPiSessionContextKey({ chatId: 123, messageThreadId: 77 })).toBe(
+			"123::77",
+		);
+	});
+
+	it("creates independent services per Telegram context", async () => {
+		const registry = await PiSessionRegistry.create(
+			createConfig({ piSessionPath: "/sessions/bootstrap.jsonl" }),
+		);
+
+		const rootService = await registry.getOrCreate({ chatId: 1 });
+		const topicService = await registry.getOrCreate({
+			chatId: 1,
+			messageThreadId: 99,
+		});
+		const rootAgain = await registry.getOrCreate({ chatId: 1 });
+
+		expect(rootAgain).toBe(rootService);
+		expect(topicService).not.toBe(rootService);
+		expect(mockState.createAgentSession).toHaveBeenCalledTimes(2);
+		expect(mockState.SessionManager.open).toHaveBeenNthCalledWith(
+			1,
+			"/sessions/bootstrap.jsonl",
+			undefined,
+			"/workspace/base",
+		);
+		expect(mockState.SessionManager.create).toHaveBeenNthCalledWith(
+			1,
+			"/workspace/base",
+		);
+		expect(mockState.createAgentSession).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				services: expect.objectContaining({ cwd: "/workspace/base" }),
+				sessionManager: expect.objectContaining({
+					sessionPath: "/sessions/bootstrap.jsonl",
+				}),
+			}),
+		);
+	});
+
+	it("deduplicates concurrent getOrCreate calls for the same context", async () => {
+		const registry = await PiSessionRegistry.create(createConfig());
+		const originalImpl =
+			mockState.createAgentSessionRuntime.getMockImplementation();
+		let resolveCreate!: () => void;
+
+		mockState.createAgentSessionRuntime.mockImplementationOnce(
+			async (factory: any, options: any) => {
+				await new Promise<void>((resolve) => {
+					resolveCreate = resolve;
+				});
+				return originalImpl!(factory, options);
+			},
+		);
+
+		const first = registry.getOrCreate({ chatId: 7, messageThreadId: 1 });
+		const second = registry.getOrCreate({ chatId: 7, messageThreadId: 1 });
+
+		await Promise.resolve();
+		expect(mockState.createAgentSessionRuntime).toHaveBeenCalledTimes(1);
+
+		resolveCreate();
+		const [firstService, secondService] = await Promise.all([first, second]);
+
+		expect(firstService).toBe(secondService);
+		expect(mockState.createAgentSessionRuntime).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns fallback info for untouched contexts in the registry", async () => {
+		const registry = await PiSessionRegistry.create(createConfig());
+
+		expect(registry.getInfo({ chatId: 42 })).toEqual({
+			sessionId: "(no active session)",
+			sessionFile: undefined,
+			workspace: "/workspace/base",
+			sessionName: undefined,
+			modelFallbackMessage: undefined,
+			model: undefined,
+		});
+	});
+
+	it("removes and disposes individual context services", async () => {
+		const registry = await PiSessionRegistry.create(createConfig());
+		const service = await registry.getOrCreate({
+			chatId: 9,
+			messageThreadId: 3,
+		});
+
+		registry.remove({ chatId: 9, messageThreadId: 3 });
+
+		expect(service.hasActiveSession()).toBe(false);
+		expect(registry.get({ chatId: 9, messageThreadId: 3 })).toBeUndefined();
+	});
+
+	it("rejects inflight creations that are removed before they finish", async () => {
+		const registry = await PiSessionRegistry.create(createConfig());
+		const originalImpl =
+			mockState.createAgentSessionRuntime.getMockImplementation();
+		let resolveCreate!: () => void;
+
+		mockState.createAgentSessionRuntime.mockImplementationOnce(
+			async (factory: any, options: any) => {
+				await new Promise<void>((resolve) => {
+					resolveCreate = resolve;
+				});
+				return originalImpl!(factory, options);
+			},
+		);
+
+		const pending = registry.getOrCreate({ chatId: 11, messageThreadId: 4 });
+		await Promise.resolve();
+		registry.remove({ chatId: 11, messageThreadId: 4 });
+		resolveCreate();
+
+		await expect(pending).rejects.toThrow(
+			"Session removed during initialization",
+		);
+		expect(registry.get({ chatId: 11, messageThreadId: 4 })).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What

Migrate TelePi from `@mariozechner/pi-*` to `@earendil-works/pi-*` namespace and bump SDK to `^0.80.3`.

18 files modified across source, tests, and configuration.

## Why

Pi SDK has migrated its npm namespace from `@mariozechner/*` to `@earendil-works/*`. TelePi was pinned to `@mariozechner/pi-coding-agent@0.70.2`, causing `Cannot find module '@earendil-works/pi-*'` errors when Pi extensions load at runtime (see issue #15).

## How

- Replaced `@mariozechner/pi-coding-agent` with `@earendil-works/pi-coding-agent@^0.80.3` in `package.json`
- Added explicit `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai` dependencies (types require direct deps)
- Updated imports in 16 source and test files to use the new namespace
- Added `getEditorComponent()` stub in `telegram-ui-context.ts` for the new `ExtensionUIContext` interface
- No behavioral changes — TypeScript compiles cleanly and all 418 tests pass

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)