### PR TITLE
feat: voice replies (TTS), file handling, image analysis, reply context, shutdown fix

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,6 @@
 import { readFile, unlink } from "node:fs/promises";
+import { mkdirSync, copyFileSync } from "node:fs";
+import path from "node:path";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import { autoRetry } from "@grammyjs/auto-retry";
@@ -70,7 +72,7 @@ import {
 	type PiSessionService,
 } from "./pi-session.js";
 import { type TreeFilterMode, truncateText } from "./tree.js";
-import { getVoiceBackendStatus, transcribeAudio } from "./voice.js";
+import { describeImageWithGemini, getVoiceBackendStatus, synthesizeSpeech, transcribeAudio } from "./voice.js";
 
 const EDIT_DEBOUNCE_MS = 1500;
 const TYPING_INTERVAL_MS = 4500;
@@ -127,6 +129,29 @@ function resolveImageMimeType(
 	const extension =
 		extensionIndex >= 0 ? filePath.slice(extensionIndex).toLowerCase() : "";
 	return IMAGE_MIME_BY_EXTENSION[extension] ?? "image/jpeg";
+}
+
+/**
+ * If the user replied to a previous message, prepend its content as context.
+ */
+function buildReplyContext(ctx: Context, userText: string): string {
+	const repliedTo = ctx.message?.reply_to_message;
+	if (!repliedTo) return userText;
+
+	const repliedText =
+		repliedTo.text ||
+		repliedTo.caption ||
+		(repliedTo.voice ? "[voice message]" : "") ||
+		(repliedTo.photo ? "[photo]" : "") ||
+		(repliedTo.document ? `[file: ${repliedTo.document.file_name || "unnamed"}]` : "") ||
+		"[message]";
+
+	const repliedFrom = repliedTo.from?.first_name || "unknown";
+
+	// If the replied message is from the bot, mark it as assistant's previous response
+	const role = repliedTo.from?.is_bot ? "Assistant" : repliedFrom;
+
+	return `[Replying to ${role}: "${repliedText}"]\n\n${userText}`;
 }
 
 export function createBot(
@@ -523,6 +548,7 @@ export function createBot(
 		refreshChatScopedCommands,
 		extensionDialogs,
 		sendBusyReply,
+		synthesizeSpeech,
 	});
 
 	if (config.promptInboxDir) {
@@ -1309,7 +1335,10 @@ export function createBot(
 	});
 
 	bot.on("message:text", async (ctx) => {
-		const userText = ctx.message.text.trim();
+		let userText = ctx.message.text.trim();
+		// If replying to a message, include it as context
+		userText = buildReplyContext(ctx, userText);
+		console.log("Received message from", ctx.from?.id, ":", userText.substring(0, 200));
 		if (!userText) {
 			return;
 		}
@@ -1411,12 +1440,13 @@ export function createBot(
 				| undefined,
 		);
 		const documentMimeType = ctx.message.document?.mime_type;
+		const documentFileName = ctx.message.document?.file_name;
 		const isImageDocument =
 			documentMimeType?.toLowerCase().startsWith("image/") ?? false;
-		const documentFileId = isImageDocument
-			? ctx.message.document?.file_id
-			: undefined;
-		const fileId = photoFileId ?? documentFileId;
+		const isPhoto = Boolean(photoFileId);
+
+		// Determine what kind of file we got
+		const fileId = photoFileId ?? ctx.message.document?.file_id;
 		if (!fileId) {
 			return;
 		}
@@ -1425,42 +1455,115 @@ export function createBot(
 		let tempFilePath: string | undefined;
 		let promptText: string | undefined;
 		let images: ImageContent[] | undefined;
+		const isImage = isPhoto || isImageDocument;
 
 		try {
 			await sendChatAction(ctx.api, target, "typing");
-			tempFilePath = await downloadTelegramFile(
-				ctx.api,
-				config.telegramBotToken,
-				fileId,
-				{
-					fileKind: "image file",
-					tempFilePrefix: "telepi-image",
-				},
-			);
 
-			const imageBytes = await readFile(tempFilePath);
-			const imageMimeType = resolveImageMimeType(
-				tempFilePath,
-				documentMimeType,
-			);
-			promptText = ctx.message.caption?.trim() || DEFAULT_IMAGE_PROMPT;
-			const preview = truncateText(promptText.replace(/\s+/g, " "), 240);
-			images = [
-				{
-					type: "image",
-					data: imageBytes.toString("base64"),
-					mimeType: imageMimeType,
-				},
-			];
+			if (isImage) {
+				// --- IMAGE HANDLING: Gemini describes → pi processes text ---
+				tempFilePath = await downloadTelegramFile(
+					ctx.api,
+					config.telegramBotToken,
+					fileId,
+					{
+						fileKind: "image file",
+						tempFilePrefix: "telepi-image",
+					},
+				);
 
-			await safeReply(
-				ctx,
-				`🖼️ ${escapeHTML(preview)}`,
-				{ fallbackText: `🖼️ ${preview}` },
-				target,
-			);
+				const imageBytes = await readFile(tempFilePath);
+				const imageMimeType = resolveImageMimeType(
+					tempFilePath,
+					documentMimeType,
+				);
+				const userCaption = ctx.message.caption?.trim();
+
+				// Ask Gemini to describe the image
+				const geminiPrompt = userCaption
+					? `The user sent this image with the caption: "${userCaption}". Describe what you see in the image in detail, addressing the user's caption.`
+					: "Describe this image in detail. What do you see?";
+
+				const description = await describeImageWithGemini(
+					imageBytes.toString("base64"),
+					imageMimeType,
+					geminiPrompt,
+				);
+
+				// Feed Gemini's description as text to pi (DeepSeek can't see images)
+				promptText = userCaption
+					? `[The user sent an image. Here is what Gemini sees in it:\n\n${description}\n\nThe user's caption was: "${userCaption}"]\n\nPlease respond to the user based on the image description above.`
+					: `[The user sent an image. Here is what Gemini sees in it:\n\n${description}]\n\nPlease describe or respond to this image.`;
+
+				// Include reply context if the user replied to a message
+				promptText = buildReplyContext(ctx, promptText);
+
+				// Don't send images to pi — Gemini already described it
+				images = undefined;
+
+				const preview = userCaption
+					? truncateText(userCaption.replace(/\s+/g, " "), 240)
+					: "Image analysis";
+				await safeReply(
+					ctx,
+					`🖼️ ${escapeHTML(preview)}`,
+					{ fallbackText: `🖼️ ${preview}` },
+					target,
+				);
+			} else {
+				// --- FILE HANDLING: download to local path for tools ---
+				const fileName = documentFileName || `file_${Date.now()}`;
+				tempFilePath = await downloadTelegramFile(
+					ctx.api,
+					config.telegramBotToken,
+					fileId,
+					{
+						fileKind: "document",
+						tempFilePrefix: "telepi-file",
+					},
+				);
+
+				// Move to a persistent temp location with original name
+				const filesDir = "/tmp/telepi-files";
+				mkdirSync(filesDir, { recursive: true });
+				const savedPath = path.join(filesDir, fileName);
+				copyFileSync(tempFilePath, savedPath);
+
+				const caption = ctx.message.caption?.trim();
+				const userPrompt = caption || `I'm sending you a file: ${fileName}`;
+				promptText = `${userPrompt}\n\nThe file is saved locally at: ${savedPath}\nYou can use your tools to read or process it.`;
+
+				// Include reply context
+				promptText = buildReplyContext(ctx, promptText);
+
+				const fileSize = ctx.message.document?.file_size;
+				const sizeStr = fileSize
+					? fileSize > 1024 * 1024
+						? `${(fileSize / (1024 * 1024)).toFixed(1)}MB`
+						: fileSize > 1024
+							? `${(fileSize / 1024).toFixed(0)}KB`
+							: `${fileSize}B`
+					: "unknown size";
+
+				await safeReply(
+					ctx,
+					`📄 ${escapeHTML(fileName)} (${sizeStr})${
+						caption ? `\n${escapeHTML(truncateText(caption.replace(/\s+/g, " "), 200))}` : ""
+					}`,
+					{
+						fallbackText: `📄 ${fileName} (${sizeStr})${caption ? ` - ${caption}` : ""}`,
+					},
+					target,
+				);
+
+				// Don't delete this temp file path (will be cleaned up separately)
+			}
 		} catch (error) {
-			const failure = renderPrefixedError("Image handling failed", error, true);
+			const failure = renderPrefixedError(
+				isImage ? "Image handling failed" : "File handling failed",
+				error,
+				true,
+			);
 			await safeReply(
 				ctx,
 				failure.text,
@@ -1473,12 +1576,16 @@ export function createBot(
 			return;
 		} finally {
 			chatState.endTranscribing(target);
-			if (tempFilePath) {
+			// Clean up the download temp file (the persistent copy at /tmp/telepi-files/ remains)
+			if (tempFilePath && !isImage) {
+				// For non-image files, the download temp is separate from the saved copy
+				await unlink(tempFilePath).catch(() => {});
+			} else if (tempFilePath) {
 				await unlink(tempFilePath).catch(() => {});
 			}
 		}
 
-		if (!promptText || !images) {
+		if (!promptText) {
 			return;
 		}
 
@@ -1486,6 +1593,7 @@ export function createBot(
 	});
 
 	bot.on(["message:voice", "message:audio"], async (ctx) => {
+		console.log("Received voice/audio message from", ctx.from?.id, "duration:", ctx.message.voice?.duration ?? ctx.message.audio?.duration, "s");
 		const target = getTelegramTarget(ctx);
 		if (!target) {
 			return;
@@ -1561,7 +1669,9 @@ export function createBot(
 			return;
 		}
 
-		await handleUserPrompt(ctx, target, transcript);
+		// Include reply context
+		const contextualTranscript = buildReplyContext(ctx, transcript);
+		await handleUserPrompt(ctx, target, contextualTranscript, undefined, undefined, true);
 	});
 
 	bot.catch((error) => {

--- a/src/bot/prompt-handler.ts
+++ b/src/bot/prompt-handler.ts
@@ -1,6 +1,6 @@
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type { SlashCommandInfo } from "@earendil-works/pi-coding-agent";
-import { type Bot, type Context, InlineKeyboard } from "grammy";
+import { type Bot, type Context, InlineKeyboard, InputFile } from "grammy";
 import type { ToolVerbosity } from "../config.js";
 import { formatError } from "../errors.js";
 import type { PiSessionContext, PiSessionService } from "../pi-session.js";
@@ -36,6 +36,7 @@ export type HandleUserPrompt = (
 	userText: string,
 	preloadedSlashCommands?: SlashCommandInfo[],
 	images?: ImageContent[],
+	voiceReply?: boolean,
 ) => Promise<boolean>;
 
 interface CreatePromptHandlerOptions {
@@ -62,12 +63,13 @@ interface CreatePromptHandlerOptions {
 		"openSelect" | "openConfirm" | "openInput"
 	>;
 	sendBusyReply: (ctx: Context) => Promise<void>;
+	synthesizeSpeech?: (text: string) => Promise<Buffer>;
 }
 
 type PromptFlowDeps = Omit<
 	CreatePromptHandlerOptions,
 	"isBusy" | "taskRunner" | "sendBusyReply"
->;
+> & { voiceReply?: boolean };
 
 type ToolState = {
 	toolName: string;
@@ -93,6 +95,8 @@ async function runPromptFlow(
 		syncChatScopedCommands,
 		refreshChatScopedCommands,
 		extensionDialogs,
+		synthesizeSpeech,
+		voiceReply,
 	} = deps;
 
 	const piSession = await ensureActiveSession(ctx, target);
@@ -320,6 +324,23 @@ async function runPromptFlow(
 		}
 
 		await deliverRenderedChunks(splitMarkdownForTelegram(finalText));
+
+		// Send voice reply if the input was a voice message
+		if (voiceReply && synthesizeSpeech) {
+			try {
+				const oggBuffer = await synthesizeSpeech(accumulatedText);
+				await bot.api.sendVoice(
+					target.chatId,
+					new InputFile(oggBuffer, "reply.ogg"),
+					{
+						message_thread_id: target.messageThreadId,
+					},
+				);
+			} catch (error) {
+				console.error("Failed to send voice reply:", error);
+				// Don't block the text response — text was already sent above
+			}
+		}
 	};
 
 	await piSession.bindExtensions({
@@ -580,6 +601,7 @@ export function createPromptHandler(
 		userText: string,
 		preloadedSlashCommands?: SlashCommandInfo[],
 		images?: ImageContent[],
+		voiceReply?: boolean,
 	): Promise<boolean> => {
 		if (isBusy(target)) {
 			await sendBusyReply(ctx);
@@ -588,7 +610,7 @@ export function createPromptHandler(
 
 		const result = taskRunner.tryStartPrompt(target, userText, () =>
 			runPromptFlow(
-				promptFlowDeps,
+				{ ...promptFlowDeps, voiceReply },
 				ctx,
 				target,
 				userText,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,12 +40,20 @@ export async function startBot(): Promise<void> {
     shuttingDown = true;
 
     console.log(`Received ${signal}, shutting down TelePi...`);
-    bot?.stop();
 
-    setTimeout(() => {
+    // Properly await bot.stop() so the long-polling session is cleanly terminated
+    const cleanup = async () => {
+      try {
+        await bot?.stop();
+      } catch {
+        // ignore stop errors during shutdown
+      }
       disposeSessions();
       console.log("TelePi stopped.");
-    }, 500);
+      // Give logs time to flush, then exit
+      setTimeout(() => process.exit(0), 100);
+    };
+    cleanup();
   };
 
   process.once("SIGINT", () => shutdown("SIGINT"));

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -1,18 +1,29 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { existsSync, mkdtempSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { getPlatformInstallHint } from "./install/platform.js";
 
 export interface TranscriptionResult {
   text: string;
-  backend: "parakeet" | "sherpa-onnx" | "openai";
+  backend: "parakeet" | "sherpa-onnx" | "whisper-cpp" | "openai";
   durationMs: number;
 }
 
-export type TranscriptionBackend = "parakeet" | "sherpa-onnx" | "openai";
+export type TranscriptionBackend = "parakeet" | "sherpa-onnx" | "whisper-cpp" | "openai";
+
+export interface TtsResult {
+  filePath: string;
+  format: string;
+  durationMs: number;
+}
+
+function getWhisperCppUrl(): string {
+  return process.env.WHISPER_CPP_URL?.trim() || "";
+}
 
 // Minimal interface for the parakeet-coreml engine instance.
 interface ParakeetEngine {
@@ -74,7 +85,10 @@ Option 2: Install Sherpa-ONNX for local/offline Parakeet transcription on Intel-
     ${SHERPA_MODEL_DOCS_URL}
   Set ${SHERPA_ONNX_MODEL_DIR_ENV}=/path/to/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8
 
-Option 3: Set OPENAI_API_KEY for cloud transcription (~$0.006/min):
+Option 3: Set WHISPER_CPP_URL for local transcription via whisper.cpp server (free, private):
+  WHISPER_CPP_URL=http://your-whisper-server:8080/inference
+
+Option 4: Set OPENAI_API_KEY for cloud transcription (~$0.006/min):
   Add OPENAI_API_KEY=sk-... to your .env file`;
 
 const _require = createRequire(import.meta.url);
@@ -142,6 +156,10 @@ export async function transcribeAudio(filePath: string): Promise<TranscriptionRe
     }
   }
 
+  if (hasWhisperCppUrl()) {
+    return await transcribeWithWhisperCpp(filePath);
+  }
+
   if (hasOpenAIApiKey()) {
     return await transcribeWithOpenAI(filePath);
   }
@@ -174,6 +192,10 @@ export async function getVoiceBackendStatus(): Promise<VoiceBackendStatus> {
     }
   } else if (sherpaConfig.status === "misconfigured") {
     warning = sherpaConfig.message;
+  }
+
+  if (hasWhisperCppUrl()) {
+    backends.push("whisper-cpp");
   }
 
   if (hasOpenAIApiKey()) {
@@ -307,6 +329,89 @@ async function transcribeWithSherpaOnnx(
     } finally {
       stream.free?.();
     }
+  });
+}
+
+function hasWhisperCppUrl(): boolean {
+  return getWhisperCppUrl().length > 0;
+}
+
+async function transcribeWithWhisperCpp(filePath: string): Promise<TranscriptionResult> {
+  const whisperCppUrl = getWhisperCppUrl();
+  const startedAt = Date.now();
+
+  // whisper.cpp server only accepts 16kHz mono WAV. Telegram sends OGG/Opus.
+  // Convert to WAV via ffmpeg first.
+  const wavPath = filePath + ".whisper.wav";
+  try {
+    await convertToWav(filePath, wavPath);
+    const audioBuffer = await readFile(wavPath);
+
+    const form = new FormData();
+    form.append("file", new Blob([audioBuffer], { type: "audio/wav" }), "audio.wav");
+    form.append("response_format", "json");
+
+    const response = await fetch(whisperCppUrl, {
+      method: "POST",
+      body: form,
+    });
+
+    if (!response.ok) {
+      const errorText = (await response.text().catch(() => "")).trim();
+      throw new Error(
+        `whisper.cpp transcription failed (${response.status}): ${errorText || response.statusText || "Unknown error"}`,
+      );
+    }
+
+    const payload = (await response.json()) as { text?: unknown };
+    const text = typeof payload.text === "string" ? payload.text.trim() : "";
+
+    return {
+      text,
+      backend: "whisper-cpp",
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    // Clean up temp WAV file
+    rm(wavPath, { force: true }).catch(() => {});
+  }
+}
+
+function convertToWav(inputPath: string, outputPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const args = [
+      "-y",
+      "-i", inputPath,
+      "-ar", "16000",
+      "-ac", "1",
+      "-sample_fmt", "s16",
+      outputPath,
+    ];
+
+    const proc = spawn("ffmpeg", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    proc.once("error", (error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        reject(new Error(FFMPEG_INSTALL_MESSAGE));
+        return;
+      }
+      reject(error);
+    });
+
+    proc.once("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffmpeg wav conversion failed (exit ${code}): ${stderr.trim() || "unknown error"}`));
+        return;
+      }
+      resolve();
+    });
   });
 }
 
@@ -506,6 +611,285 @@ function decodeAudioToSamples(filePath: string): Promise<Float32Array> {
 
 function hasOpenAIApiKey(): boolean {
   return Boolean(process.env.OPENAI_API_KEY?.trim());
+}
+
+// ---------------------------------------------------------------------------
+// TTS (Text-to-Speech) via edge-tts + ffmpeg → OGG/Opus for Telegram voice
+// ---------------------------------------------------------------------------
+
+const TTS_VOICE = process.env.TELEPI_TTS_VOICE?.trim() || "en-US-JennyNeural";
+
+// DeepSeek API for spoken-rewrite step
+function getDeepseekApiKey(): string {
+  return process.env.DEEPSEEK_API_KEY?.trim() || "";
+}
+function getDeepseekBaseUrl(): string {
+  return process.env.DEEPSEEK_BASE_URL?.trim() || "https://api.deepseek.com";
+}
+
+// Gemini API for image description (free tier, vision-only)
+function getGeminiApiKey(): string {
+  return process.env.GEMINI_API_KEY?.trim() || "";
+}
+
+/**
+ * Describe an image using Gemini (free vision model).
+ * Returns a text description that can be fed to a non-vision LLM.
+ */
+export async function describeImageWithGemini(
+  imageBase64: string,
+  mimeType: string,
+  prompt?: string,
+): Promise<string> {
+  const apiKey = getGeminiApiKey();
+  if (!apiKey) {
+    throw new Error("GEMINI_API_KEY not configured — cannot describe images");
+  }
+
+  const userPrompt = prompt || "Describe this image in detail. What do you see?";
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { text: userPrompt },
+              {
+                inline_data: {
+                  mime_type: mimeType,
+                  data: imageBase64,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = (await response.text().catch(() => "")).trim();
+    throw new Error(
+      `Gemini image description failed (${response.status}): ${errorText || response.statusText || "Unknown error"}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    candidates?: Array<{
+      content?: { parts?: Array<{ text?: string }> };
+    }>;
+  };
+
+  const text = data.candidates?.[0]?.content?.parts
+    ?.map((part) => part.text ?? "")
+    .join("\n")
+    .trim();
+
+  if (!text) {
+    throw new Error("Gemini returned an empty description");
+  }
+
+  return text;
+}
+
+/**
+ * Convert a text response into natural spoken conversation using LLM.
+ * Returns a concise, conversational version suitable for TTS.
+ */
+export async function conversationalizeText(text: string): Promise<string> {
+  const apiKey = getDeepseekApiKey();
+  if (!apiKey) {
+    // No API key configured — fall back to basic cleanup
+    return cleanupForSpeech(text);
+  }
+
+  try {
+    const response = await fetch(`${getDeepseekBaseUrl()}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "deepseek-chat",
+        messages: [
+          {
+            role: "system",
+            content: `You are a friendly voice assistant. Rewrite written responses into natural spoken English as if you're talking to someone. Rules:
+- Sound warm and conversational — like you're explaining something to a friend
+- Strip ALL markdown, code blocks, bullet points, and formatting
+- Use contractions ("it's", "I've", "you'll"), casual transitions ("so", "basically", "oh and")
+- Adapt length to the content: short answers stay short, complex topics get a clear explanation
+- For long/detailed responses, distill to the key 2-4 takeaways — don't read a wall of text
+- For short answers, keep them concise but friendly
+- If there are action items or results, highlight those naturally
+- Never use meta-language like "the text says" or "according to the response"
+- Start naturally — no "Okay so..." every time, vary your openings
+- Output ONLY the spoken text, no quotes, no prefixes.`,
+          },
+          {
+            role: "user",
+            content: `Convert this into natural spoken conversation:\n\n${text}`,
+          },
+        ],
+        max_tokens: 600,
+        temperature: 0.7,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("Spoken rewrite API error:", response.status);
+      return cleanupForSpeech(text);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const spoken = data.choices?.[0]?.message?.content?.trim();
+    if (!spoken) {
+      return cleanupForSpeech(text);
+    }
+
+    return spoken;
+  } catch (error) {
+    console.error("Spoken rewrite failed:", error);
+    return cleanupForSpeech(text);
+  }
+}
+
+/**
+ * Basic cleanup fallback: strip markdown, truncate for speech.
+ */
+function cleanupForSpeech(text: string): string {
+  let cleaned = text
+    .replace(/\*\*(.+?)\*\*/g, "$1")       // bold
+    .replace(/\*(.+?)\*/g, "$1")             // italic
+    .replace(/`{1,3}[^`]*`{1,3}/g, "")       // inline/block code
+    .replace(/^#{1,6}\s+/gm, "")             // headings
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // links
+    .replace(/^[-*+]\s+/gm, "")              // list markers
+    .replace(/^\d+\.\s+/gm, "")              // numbered lists
+    .replace(/\n{3,}/g, "\n\n")              // collapse whitespace
+    .trim();
+
+  // Truncate to reasonable voice length (~2-3 sentences)
+  const sentences = cleaned.match(/[^.!?]+[.!?]+/g);
+  if (sentences && sentences.length > 3) {
+    cleaned = sentences.slice(0, 3).join(" ");
+  } else if (cleaned.length > 500) {
+    cleaned = cleaned.substring(0, 500).replace(/\s+\S*$/, "");
+  }
+
+  return cleaned || "Done.";
+}
+
+/**
+ * Synthesize text to speech, returning an OGG/Opus buffer suitable for
+ * Telegram's sendVoice API.
+ */
+export async function synthesizeSpeech(text: string): Promise<Buffer> {
+  // Step 0: Convert to natural spoken conversation first
+  const spokenText = await conversationalizeText(text);
+
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "telepi-tts-"));
+  const mp3Path = path.join(tmpDir, "speech.mp3");
+  const oggPath = path.join(tmpDir, "speech.ogg");
+
+  try {
+    // Step 1: edge-tts → MP3
+    await synthesizeWithEdgeTts(spokenText, mp3Path);
+
+    // Step 2: ffmpeg MP3 → OGG/Opus (required for Telegram voice messages)
+    await convertToOggOpus(mp3Path, oggPath);
+
+    const oggBuffer = await readFile(oggPath);
+    return oggBuffer;
+  } finally {
+    // Cleanup temp dir
+    rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function synthesizeWithEdgeTts(text: string, outputPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const args = [
+      "-m", "edge_tts",
+      "--voice", TTS_VOICE,
+      "--text", text,
+      "--write-media", outputPath,
+    ];
+
+    const proc = spawn("python3", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    proc.once("error", (error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        reject(new Error("python3 not found. Install Python 3 and edge-tts: pip install edge-tts"));
+        return;
+      }
+      reject(error);
+    });
+
+    proc.once("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`edge-tts failed (exit ${code}): ${stderr.trim() || "unknown error"}`));
+        return;
+      }
+      if (!existsSync(outputPath)) {
+        reject(new Error("edge-tts did not produce output file"));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function convertToOggOpus(inputPath: string, outputPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const args = [
+      "-y",
+      "-i", inputPath,
+      "-filter:a", "atempo=1.2",
+      "-c:a", "libopus",
+      "-b:a", "32k",
+      "-ar", "24000",
+      "-ac", "1",
+      "-application", "audio",
+      "-f", "ogg",
+      outputPath,
+    ];
+
+    const proc = spawn("ffmpeg", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    proc.once("error", (error) => {
+      reject(error);
+    });
+
+    proc.once("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffmpeg ogg conversion failed (exit ${code}): ${stderr.trim() || "unknown error"}`));
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 function extractTranscribedText(result: unknown): string | undefined {


### PR DESCRIPTION
## Summary

This PR adds several new capabilities to TelePi:

### 🎤 Voice Replies (TTS)
- Text-to-speech via **edge-tts** (free Microsoft TTS, no API key needed)
- Configurable voice via `TELEPI_TTS_VOICE` env var (default: `en-US-JennyNeural`)
- Spoken-rewrite step: text response is converted to natural conversation via LLM before TTS (uses `DEEPSEEK_API_KEY` env var, falls back to basic cleanup if not set)
- Voice reply sent alongside text reply when input was a voice message

### 🎙️ Whisper.cpp Transcription Backend
- New `whisper-cpp` backend for local/free transcription
- Configurable via `WHISPER_CPP_URL` env var
- Auto-converts Telegram's OGG/Opus to WAV (whisper.cpp only accepts WAV)

### 🖼️ Image Analysis via Gemini
- Images sent via Telegram are described by **Gemini** (`gemini-2.5-flash`, free tier)
- Description is fed as text to pi's LLM — no model switching needed
- Configurable via `GEMINI_API_KEY` env var

### 📄 File Handling
- Non-image documents (PDF, DOCX, TXT, etc.) are downloaded to `/tmp/telepi-files/<filename>`
- File path included in prompt so pi's tools can read/process them

### ↩️ Reply Context
- When replying to a message, the original message is prepended as context
- Works for text, voice, photo, and file replies
- Marks bot messages as "Assistant" for conversational context

### 🛑 Shutdown Fix
- `bot.stop()` is now properly awaited during shutdown
- Prevents 409 polling conflicts on restart

### 🔧 Bug Fix
- Made `WHISPER_CPP_URL` and other env vars read lazily (at call time) instead of at module init, fixing a module-load ordering bug

---

**Files changed:** `src/voice.ts`, `src/bot.ts`, `src/bot/prompt-handler.ts`, `src/index.ts`

**New env vars (all optional):**
- `WHISPER_CPP_URL` — whisper.cpp server URL
- `TELEPI_TTS_VOICE` — edge-tts voice name  
- `DEEPSEEK_API_KEY` — for spoken-rewrite step
- `GEMINI_API_KEY` — for image description