### PR TITLE
fix: migrate to pi-coding-agent 0.81.1 ModelRuntime API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-coding-agent": "^0.81.1",
         "@grammyjs/auto-retry": "^2.0.2",
         "grammy": "^1.35.0",
         "minimatch": "^10.2.4"
@@ -143,17 +143,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
-      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "version": "3.976.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.976.0.tgz",
+      "integrity": "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.0",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -162,15 +162,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
-      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.60.tgz",
+      "integrity": "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -178,17 +178,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
-      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.62.tgz",
+      "integrity": "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -196,13 +196,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.9.tgz",
+      "integrity": "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -210,23 +210,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
-      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.5.tgz",
+      "integrity": "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-login": "^3.972.59",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-login": "^3.972.67",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -234,16 +234,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
-      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.67.tgz",
+      "integrity": "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -251,21 +251,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
-      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.71.tgz",
+      "integrity": "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-ini": "^3.972.60",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-ini": "^3.973.5",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -273,15 +273,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
-      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.60.tgz",
+      "integrity": "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -289,17 +289,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
-      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.4.tgz",
+      "integrity": "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/token-providers": "3.1079.0",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/token-providers": "3.1092.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -307,16 +307,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1079.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
-      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1092.0.tgz",
+      "integrity": "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -324,16 +324,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
-      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.66.tgz",
+      "integrity": "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -341,14 +341,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.25.tgz",
-      "integrity": "sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
+      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -356,14 +356,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.21.tgz",
-      "integrity": "sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -371,17 +371,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.35.tgz",
-      "integrity": "sha512-7/ZAlq5o5A9FnRsQEftZvcct9LVZf1YaYmWR3eOzyJAdKU66YpOKy5ahUVvyBvCTLyO4Ej4yWIk8dllWNXPBsw==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.42.tgz",
+      "integrity": "sha512-dw+GP8DC7QC2C8tUoK7DI8BnrNAjz8tb+uBHSrD2qJvxkCf58kTtFr98pljSrk+umU4n4HDW4eU2k7C2dWMzsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -389,18 +389,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
-      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "version": "3.997.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.34.tgz",
+      "integrity": "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -408,13 +408,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.9.tgz",
+      "integrity": "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -422,14 +422,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -454,12 +454,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -479,12 +479,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -570,12 +570,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
-      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.1.tgz",
+      "integrity": "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.81.1",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.1.tgz",
+      "integrity": "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -610,15 +610,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.81.1.tgz",
+      "integrity": "sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-tui": "^0.81.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1081,11 +1081,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.81.1",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1095,8 +1095,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.81.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1112,15 +1112,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.81.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1228,9 +1228,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,9 +1243,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1266,9 +1260,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1276,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,9 +1291,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1644,9 +1629,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3082,9 +3067,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -3153,9 +3138,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3509,12 +3494,12 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "version": "3.29.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.7.tgz",
+      "integrity": "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3522,13 +3507,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
-      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.12.tgz",
+      "integrity": "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3536,13 +3521,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
-      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.9.tgz",
+      "integrity": "sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3576,13 +3561,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.8.tgz",
+      "integrity": "sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3590,9 +3575,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4322,9 +4307,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -5833,9 +5818,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.81.1",
+    "@earendil-works/pi-ai": "^0.81.1",
+    "@earendil-works/pi-coding-agent": "^0.81.1",
     "@grammyjs/auto-retry": "^2.0.2",
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3",
     "grammy": "^1.35.0",
     "minimatch": "^10.2.4"
   },

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -5,7 +5,6 @@ import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import {
 	type AgentSession,
 	type AgentSessionRuntime,
-	AuthStorage,
 	type ContextUsage,
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionFromServices,
@@ -14,6 +13,7 @@ import {
 	createCodingTools,
 	getAgentDir,
 	ModelRegistry,
+	ModelRuntime,
 	type ResourceDiagnostic,
 	type ResourceLoader,
 	type SessionEntry,
@@ -527,7 +527,7 @@ async function createPiSessionHandle(
 	sessionManager: SessionManager,
 	initialSessionStartEvent?: { reason: "new" | "resume" | "fork" },
 ): Promise<PiSessionHandle> {
-	const authStorage = AuthStorage.create();
+	let sharedModelRuntime: ModelRuntime | undefined;
 	let getSlashCommands = (): SlashCommandInfo[] => [];
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 		cwd,
@@ -536,24 +536,26 @@ async function createPiSessionHandle(
 		sessionStartEvent,
 	}) => {
 		const settingsManager = SettingsManager.create(cwd);
-		const modelRegistry = ModelRegistry.create(authStorage);
+		if (!sharedModelRuntime) {
+			sharedModelRuntime = await ModelRuntime.create({
+				authPath: path.join(agentDir, "auth.json"),
+				modelsPath: path.join(agentDir, "models.json"),
+			});
+		}
 		const services = await createAgentSessionServices({
 			cwd,
 			agentDir,
-			authStorage,
-			modelRegistry,
+			modelRuntime: sharedModelRuntime,
 			settingsManager,
 			resourceLoaderOptions: {
 				extensionFactories: [createProviderResponseNoticeExtension()],
 			},
 		});
-		const configuredModel = resolveModelOverride(
-			services.modelRegistry,
-			config.piModel,
-		);
+		const modelRegistry = new ModelRegistry(services.modelRuntime);
+		const configuredModel = resolveModelOverride(modelRegistry, config.piModel);
 		const scopedModels = await resolveScopedModels(
 			services.settingsManager,
-			services.modelRegistry,
+			modelRegistry,
 		);
 		const hasExistingSession =
 			sessionStartEvent?.reason !== "new" &&
@@ -562,7 +564,7 @@ async function createPiSessionHandle(
 			configuredModel,
 			scopedModels,
 			settingsManager: services.settingsManager,
-			modelRegistry: services.modelRegistry,
+			modelRegistry,
 			hasExistingSession,
 		});
 
@@ -744,7 +746,7 @@ export class PiSessionService {
 	}
 
 	async prompt(text: string, images?: ImageContent[]): Promise<void> {
-		this.reloadAuthStorage();
+		await this.reloadAuthStorage();
 		await promptSession(this.getSession(), text, images);
 	}
 
@@ -865,7 +867,7 @@ export class PiSessionService {
 	}
 
 	async listModels(showAll = false): Promise<PiSessionModelOption[]> {
-		this.reloadAuthStorage();
+		await this.reloadAuthStorage();
 		const session = this.getSession();
 		const currentModel = session.model;
 		const availableModels = this.getModelRegistry().getAvailable();
@@ -904,7 +906,7 @@ export class PiSessionService {
 		modelId: string,
 		thinkingLevel?: ThinkingLevel,
 	): Promise<string> {
-		this.reloadAuthStorage();
+		await this.reloadAuthStorage();
 		const session = this.getSession();
 		const modelRegistry = this.getModelRegistry();
 		const model = modelRegistry.find(provider, modelId);
@@ -1283,12 +1285,12 @@ export class PiSessionService {
 		return this.handle;
 	}
 
-	private reloadAuthStorage(): void {
-		this.getHandle().runtime.services.authStorage.reload();
+	private async reloadAuthStorage(): Promise<void> {
+		await this.getModelRegistry().refresh();
 	}
 
 	private getModelRegistry(): ModelRegistry {
-		return this.getHandle().runtime.services.modelRegistry;
+		return new ModelRegistry(this.getHandle().runtime.services.modelRuntime);
 	}
 
 	private async replaceHandle(nextHandle: PiSessionHandle): Promise<void> {

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -18,7 +18,7 @@ const mockState = vi.hoisted(() => {
 	const createdSessions: Array<{ session: any; options: any }> = [];
 	const createdRuntimes: Array<{ runtime: any; options: any }> = [];
 	const modelRegistryInstances: any[] = [];
-	const authStorageInstances: any[] = [];
+	const modelRuntimeInstances: any[] = [];
 	const sessionSubscribers = new WeakMap<object, (event: any) => void>();
 	const sessionPathWorkspaces = new Map<string, string>();
 	const resolvedSessionPaths = new Map<string, string>();
@@ -247,9 +247,8 @@ const mockState = vi.hoisted(() => {
 		.mockImplementation(async (options: any) => ({
 			cwd: options.cwd,
 			agentDir: options.agentDir ?? "/mock-agent",
-			authStorage: options.authStorage ?? { kind: "auth-storage" },
+			modelRuntime: options.modelRuntime,
 			settingsManager: options.settingsManager,
-			modelRegistry: options.modelRegistry,
 			resourceLoader: { kind: "resource-loader", cwd: options.cwd },
 			diagnostics: [],
 		}));
@@ -385,34 +384,37 @@ const mockState = vi.hoisted(() => {
 		.fn()
 		.mockReturnValue([{ name: "mock-tool", description: "Mock tool" }]);
 
-	const AuthStorage = {
-		create: vi.fn().mockImplementation(() => {
+	const ModelRuntime = {
+		create: vi.fn().mockImplementation(async () => {
 			const instance = {
-				kind: "auth-storage",
-				reload: vi.fn(),
+				kind: "model-runtime",
+				reloadConfig: vi.fn(),
 			};
-			authStorageInstances.push(instance);
+			modelRuntimeInstances.push(instance);
 			return instance;
 		}),
 	};
 
-	const ModelRegistry = {
-		create: vi.fn().mockImplementation(() => {
-			const instance = {
-				getAvailable: vi.fn().mockReturnValue(models),
-				getAll: vi.fn().mockReturnValue(models),
-				find: vi
-					.fn()
-					.mockImplementation((provider: string, id: string) =>
-						models.find(
-							(model) => model.provider === provider && model.id === id,
-						),
+	const refreshSpy = vi.fn();
+	const ModelRegistry = vi.fn().mockImplementation((runtime: any) => {
+		const instance = {
+			getAvailable: vi.fn().mockReturnValue(models),
+			getAll: vi.fn().mockReturnValue(models),
+			find: vi
+				.fn()
+				.mockImplementation((provider: string, id: string) =>
+					models.find(
+						(model) => model.provider === provider && model.id === id,
 					),
-			};
-			modelRegistryInstances.push(instance);
-			return instance;
-		}),
-	};
+				),
+			refresh: vi.fn().mockImplementation(async (...args: unknown[]) => {
+				refreshSpy(...args);
+				await runtime?.reloadConfig?.();
+			}),
+		};
+		modelRegistryInstances.push(instance);
+		return instance;
+	});
 
 	const SessionManager = {
 		create: vi
@@ -452,12 +454,13 @@ const mockState = vi.hoisted(() => {
 		createdSessions,
 		createdRuntimes,
 		modelRegistryInstances,
-		authStorageInstances,
+		refreshSpy,
+		modelRuntimeInstances,
 		createAgentSession,
 		createAgentSessionRuntime,
 		createAgentSessionServices,
 		createCodingTools,
-		AuthStorage,
+		ModelRuntime,
 		ModelRegistry,
 		SessionManager,
 		SettingsManager,
@@ -479,15 +482,16 @@ const mockState = vi.hoisted(() => {
 			createdSessions.length = 0;
 			createdRuntimes.length = 0;
 			modelRegistryInstances.length = 0;
+			refreshSpy.mockClear();
 			sessionPathWorkspaces.clear();
 			resolvedSessionPaths.clear();
-			authStorageInstances.length = 0;
+			modelRuntimeInstances.length = 0;
 			createAgentSession.mockClear();
 			createAgentSessionRuntime.mockClear();
 			createAgentSessionServices.mockClear();
 			createCodingTools.mockClear();
-			AuthStorage.create.mockClear();
-			ModelRegistry.create.mockClear();
+			ModelRuntime.create.mockClear();
+			ModelRegistry.mockClear();
 			SessionManager.create.mockClear();
 			SessionManager.open.mockClear();
 			SessionManager.listAll.mockReset();
@@ -526,7 +530,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 	createAgentSessionRuntime: mockState.createAgentSessionRuntime,
 	createAgentSessionServices: mockState.createAgentSessionServices,
 	createCodingTools: mockState.createCodingTools,
-	AuthStorage: mockState.AuthStorage,
+	ModelRuntime: mockState.ModelRuntime,
 	ModelRegistry: mockState.ModelRegistry,
 	SessionManager: mockState.SessionManager,
 	SettingsManager: mockState.SettingsManager,
@@ -581,10 +585,10 @@ describe("PiSessionService", () => {
 	it("creates a session service and initializes the Pi session runtime", async () => {
 		const service = await PiSessionService.create(createConfig());
 
-		expect(mockState.AuthStorage.create).toHaveBeenCalledTimes(1);
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(1);
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledWith(
-			expect.objectContaining({ kind: "auth-storage" }),
+		expect(mockState.ModelRuntime.create).toHaveBeenCalledTimes(1);
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(1);
+		expect(mockState.ModelRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "model-runtime" }),
 		);
 		expect(mockState.createAgentSessionRuntime).toHaveBeenCalledWith(
 			expect.any(Function),
@@ -599,7 +603,7 @@ describe("PiSessionService", () => {
 		expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cwd: "/workspace/base",
-				authStorage: expect.objectContaining({ kind: "auth-storage" }),
+				modelRuntime: expect.objectContaining({ kind: "model-runtime" }),
 			}),
 		);
 		expect(mockState.createCodingTools).toHaveBeenCalledWith("/workspace/base");
@@ -1347,16 +1351,12 @@ describe("PiSessionService", () => {
 
 	it("recreates the model registry each time the runtime factory creates a same-runtime replacement session", async () => {
 		const service = await PiSessionService.create(createConfig());
-		const firstRegistry =
-			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
 
 		await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
 
-		const secondRegistry =
-			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-		expect(firstRegistry).toBe(mockState.modelRegistryInstances[0]);
-		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(2);
+		const firstRegistry = mockState.modelRegistryInstances[0];
+		const secondRegistry = mockState.modelRegistryInstances[1];
 		expect(secondRegistry).not.toBe(firstRegistry);
 	});
 
@@ -1369,16 +1369,13 @@ describe("PiSessionService", () => {
 			{ name: "find", description: "Find files" },
 		]);
 		const service = await PiSessionService.create(createConfig());
-		const firstRegistry =
-			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
+		const firstRegistry = mockState.modelRegistryInstances[0];
 
 		await service.newSession("/workspace/other");
 
-		const secondRegistry =
-			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
+		const secondRegistry = mockState.modelRegistryInstances[1];
 		const replacementSession = mockState.createdSessions[1]?.session;
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(2);
 		expect(secondRegistry).not.toBe(firstRegistry);
 		expect(replacementSession.setActiveToolsByName).toHaveBeenCalledWith(
 			expect.arrayContaining([
@@ -2364,7 +2361,7 @@ describe("PiSessionService", () => {
 
 		await service.prompt("hello");
 
-		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+		expect(mockState.refreshSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("passes image attachments through when prompting", async () => {
@@ -2384,7 +2381,7 @@ describe("PiSessionService", () => {
 
 		await service.listModels();
 
-		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+		expect(mockState.refreshSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("wraps prompt errors with a helpful message", async () => {


### PR DESCRIPTION
## Why

`@earendil-works/pi-coding-agent` is pinned to `^0.80.3` in `package.json`, which resolves to `0.80.3` in the lockfile. Newer pi-coding-agent releases (up to `0.81.1`) add newly released models (e.g. `claude-sonnet-5`) that aren't available to TelePi users on this older pin.

Bumping the dependency directly breaks the TypeScript build: `0.81.x` removed the standalone `AuthStorage` export and changed `ModelRegistry` from a static factory (`ModelRegistry.create(authStorage)`) into a plain class wrapping a `ModelRuntime` instance (`new ModelRegistry(modelRuntime)`). `AgentSessionServices` now exposes `modelRuntime` instead of `authStorage`/`modelRegistry`.

## What

- Bump `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-ai` from `^0.80.3` to `^0.81.1` (these three packages are released in lockstep).
- `src/pi-session.ts`: create a single shared `ModelRuntime` per session handle (via `ModelRuntime.create({ authPath, modelsPath })`, resolved from `agentDir`), replacing `AuthStorage.create()`. Build a `ModelRegistry` facade from `services.modelRuntime` wherever a `ModelRegistry` was previously threaded through. Replace the synchronous `authStorage.reload()` cache-busting calls with an async `modelRegistry.refresh()` (which now maps to `modelRuntime.reloadConfig()`), awaited at all three call sites (`prompt`, `listModels`, `setModel`).
- `test/pi-session.test.ts`: update mocks/assertions to match the new `ModelRuntime`/`ModelRegistry` shapes.

## Testing

- `npm run build` — passes
- `npm test` — all 418 tests pass (29 files)
