### PR TITLE
fix: load extensions with current Pi SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          # npm Trusted Publishing currently requires Node 22.14.0+.
-          node-version: 22.14
+          # TelePi's Pi SDK requires Node 22.19.0+ (also satisfies Trusted Publishing).
+          node-version: 22.19
           cache: npm
 
       - name: Show Node and npm versions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Early open-source release: **80+ stars, 13 forks, and hundreds of npm downloads*
 
 You need:
 
-- **Node.js 20+**
+- **Node.js 22.19+**
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)
 - Your numeric Telegram user ID for the allowlist
 - Pi installed and authenticated locally (`~/.pi/agent/auth.json` exists after a working Pi login)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-coding-agent": "^0.82.1",
         "@grammyjs/auto-retry": "^2.0.2",
         "grammy": "^1.35.0",
         "minimatch": "^10.2.4"
@@ -27,7 +27,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.19.0"
       },
       "optionalDependencies": {
         "parakeet-coreml": "^2.2.0",
@@ -143,17 +143,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
-      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.0",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -162,15 +162,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
-      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
+      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -178,17 +178,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
-      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
+      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -196,13 +196,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -210,23 +210,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
-      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
+      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-login": "^3.972.59",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-login": "^3.972.68",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -234,16 +234,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
-      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
+      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -251,21 +251,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
-      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
+      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-ini": "^3.972.60",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-ini": "^3.973.6",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -273,15 +273,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
-      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
+      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -289,17 +289,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
-      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
+      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/token-providers": "3.1079.0",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -307,16 +307,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1079.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
-      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
+      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -324,16 +324,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
-      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
+      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -341,14 +341,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.25.tgz",
-      "integrity": "sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.30.tgz",
+      "integrity": "sha512-hJboPgIpq5+ADc++/B9TBqn65CXV21cZLGB8V5RBQbxkZ/rQ6qMfcxTnW/SvQlasX4jhaSG8B1wsVjhQyDrsnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -356,14 +356,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.21.tgz",
-      "integrity": "sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.25.tgz",
+      "integrity": "sha512-9SFbPzJDHHR5k6Q6KvXVas/veUm/TzNcNTFM2UhdXHZHpyIvI2lS+s4cxljw1BihGpVhsAkQDo/2nW7dHxpf4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -371,17 +371,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.35.tgz",
-      "integrity": "sha512-7/ZAlq5o5A9FnRsQEftZvcct9LVZf1YaYmWR3eOzyJAdKU66YpOKy5ahUVvyBvCTLyO4Ej4yWIk8dllWNXPBsw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.43.tgz",
+      "integrity": "sha512-n29++15Vma64Kd0enp9Bo8a6LTm8TvUoMbJEwqXtIksv0oEs+SUCRMm3gozDfPD1Ly0k/sSBughxarlLlRF6Xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -389,18 +389,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
-      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "version": "3.997.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
+      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -408,13 +408,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -422,14 +422,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -454,12 +454,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -479,12 +479,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -570,12 +570,13 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
-      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
+      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -585,9 +586,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
+      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -610,15 +611,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
+      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1081,11 +1082,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1095,8 +1097,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1112,15 +1114,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1228,9 +1230,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,9 +1245,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1266,9 +1262,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1278,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,9 +1293,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1644,9 +1631,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2214,9 +2201,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3082,9 +3069,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -3153,9 +3140,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3509,12 +3496,12 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3522,13 +3509,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
-      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3536,13 +3523,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
-      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3576,13 +3563,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3590,9 +3577,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4109,6 +4096,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4322,9 +4318,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -4363,9 +4359,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -5833,9 +5829,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.19.0"
   },
   "type": "module",
   "main": "./dist/index.js",
@@ -51,10 +51,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "^0.82.1",
     "@grammyjs/auto-retry": "^2.0.2",
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3",
     "grammy": "^1.35.0",
     "minimatch": "^10.2.4"
   },

--- a/src/pi-session.ts
+++ b/src/pi-session.ts
@@ -5,7 +5,6 @@ import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import {
 	type AgentSession,
 	type AgentSessionRuntime,
-	AuthStorage,
 	type ContextUsage,
 	type CreateAgentSessionRuntimeFactory,
 	createAgentSessionFromServices,
@@ -14,6 +13,7 @@ import {
 	createCodingTools,
 	getAgentDir,
 	ModelRegistry,
+	ModelRuntime,
 	type ResourceDiagnostic,
 	type ResourceLoader,
 	type SessionEntry,
@@ -24,6 +24,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 import type { TelePiConfig } from "./config.js";
+import { createReloadingCredentialStore } from "./reloading-credential-store.js";
 import {
 	resolveInitialScopedModelSelection,
 	resolveScopedModels,
@@ -527,7 +528,6 @@ async function createPiSessionHandle(
 	sessionManager: SessionManager,
 	initialSessionStartEvent?: { reason: "new" | "resume" | "fork" },
 ): Promise<PiSessionHandle> {
-	const authStorage = AuthStorage.create();
 	let getSlashCommands = (): SlashCommandInfo[] => [];
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 		cwd,
@@ -536,24 +536,29 @@ async function createPiSessionHandle(
 		sessionStartEvent,
 	}) => {
 		const settingsManager = SettingsManager.create(cwd);
-		const modelRegistry = ModelRegistry.create(authStorage);
+		const modelRuntime = await ModelRuntime.create({
+			credentials: await createReloadingCredentialStore(
+				path.join(agentDir, "auth.json"),
+			),
+			modelsPath: path.join(agentDir, "models.json"),
+		});
 		const services = await createAgentSessionServices({
 			cwd,
 			agentDir,
-			authStorage,
-			modelRegistry,
 			settingsManager,
+			modelRuntime,
 			resourceLoaderOptions: {
 				extensionFactories: [createProviderResponseNoticeExtension()],
 			},
 		});
+		const modelRegistry = new ModelRegistry(services.modelRuntime);
 		const configuredModel = resolveModelOverride(
-			services.modelRegistry,
+			modelRegistry,
 			config.piModel,
 		);
 		const scopedModels = await resolveScopedModels(
 			services.settingsManager,
-			services.modelRegistry,
+			modelRegistry,
 		);
 		const hasExistingSession =
 			sessionStartEvent?.reason !== "new" &&
@@ -562,7 +567,7 @@ async function createPiSessionHandle(
 			configuredModel,
 			scopedModels,
 			settingsManager: services.settingsManager,
-			modelRegistry: services.modelRegistry,
+			modelRegistry,
 			hasExistingSession,
 		});
 
@@ -744,7 +749,6 @@ export class PiSessionService {
 	}
 
 	async prompt(text: string, images?: ImageContent[]): Promise<void> {
-		this.reloadAuthStorage();
 		await promptSession(this.getSession(), text, images);
 	}
 
@@ -865,7 +869,7 @@ export class PiSessionService {
 	}
 
 	async listModels(showAll = false): Promise<PiSessionModelOption[]> {
-		this.reloadAuthStorage();
+		await this.getHandle().runtime.services.modelRuntime.getAvailable();
 		const session = this.getSession();
 		const currentModel = session.model;
 		const availableModels = this.getModelRegistry().getAvailable();
@@ -904,7 +908,6 @@ export class PiSessionService {
 		modelId: string,
 		thinkingLevel?: ThinkingLevel,
 	): Promise<string> {
-		this.reloadAuthStorage();
 		const session = this.getSession();
 		const modelRegistry = this.getModelRegistry();
 		const model = modelRegistry.find(provider, modelId);
@@ -1283,12 +1286,8 @@ export class PiSessionService {
 		return this.handle;
 	}
 
-	private reloadAuthStorage(): void {
-		this.getHandle().runtime.services.authStorage.reload();
-	}
-
 	private getModelRegistry(): ModelRegistry {
-		return this.getHandle().runtime.services.modelRegistry;
+		return new ModelRegistry(this.getHandle().runtime.services.modelRuntime);
 	}
 
 	private async replaceHandle(nextHandle: PiSessionHandle): Promise<void> {

--- a/src/reloading-credential-store.ts
+++ b/src/reloading-credential-store.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import type {
+  Credential,
+  CredentialInfo,
+  CredentialStore,
+} from "@earendil-works/pi-ai";
+
+type AuthStorageConstructor = {
+  create(authPath?: string): CredentialStore;
+};
+
+class ReloadingCredentialStore implements CredentialStore {
+  constructor(private readonly createStore: () => CredentialStore) {}
+
+  async read(providerId: string): Promise<Credential | undefined> {
+    return this.createStore().read(providerId);
+  }
+
+  async list(): Promise<readonly CredentialInfo[]> {
+    return this.createStore().list();
+  }
+
+  async modify(
+    providerId: string,
+    fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+  ): Promise<Credential | undefined> {
+    return this.createStore().modify(providerId, fn);
+  }
+
+  async delete(providerId: string): Promise<void> {
+    await this.createStore().delete(providerId);
+  }
+}
+
+/**
+ * Create a credential store that observes external auth.json changes while
+ * retaining Pi's value resolution, locking, and atomic persistence behavior.
+ * AuthStorage remains part of Pi 0.82.1 but is no longer a public root export,
+ * so resolve it relative to the installed coding-agent entrypoint.
+ */
+export async function createReloadingCredentialStore(
+  authPath: string,
+): Promise<CredentialStore> {
+  let searchDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const filesystemRoot = parse(searchDir).root;
+  let authStoragePath: string | undefined;
+
+  while (true) {
+    const candidate = join(
+      searchDir,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "core",
+      "auth-storage.js",
+    );
+    if (existsSync(candidate)) {
+      authStoragePath = candidate;
+      break;
+    }
+    if (searchDir === filesystemRoot) {
+      break;
+    }
+    searchDir = dirname(searchDir);
+  }
+
+  if (!authStoragePath) {
+    throw new Error("Could not locate Pi's credential storage implementation");
+  }
+
+  const authStorageUrl = pathToFileURL(authStoragePath).href;
+  const authModule = (await import(authStorageUrl)) as {
+    AuthStorage: AuthStorageConstructor;
+  };
+
+  return new ReloadingCredentialStore(() =>
+    authModule.AuthStorage.create(authPath),
+  );
+}

--- a/test/pi-sdk-compatibility.test.ts
+++ b/test/pi-sdk-compatibility.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+
+import packageJson from "../package.json" with { type: "json" };
+
+describe("Pi SDK compatibility", () => {
+  it("tracks the current Earendil Pi SDK release", () => {
+    expect(packageJson.engines.node).toBe(">=22.19.0");
+    expect(packageJson.dependencies["@earendil-works/pi-agent-core"]).toBe("^0.82.1");
+    expect(packageJson.dependencies["@earendil-works/pi-ai"]).toBe("^0.82.1");
+    expect(packageJson.dependencies["@earendil-works/pi-coding-agent"]).toBe("^0.82.1");
+  });
+
+  it("loads external extensions that import Earendil Pi packages", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "telepi-pi-extension-"));
+    const extensionPath = path.join(root, "extension.ts");
+
+    writeFileSync(
+      extensionPath,
+      [
+        'import { DefaultResourceLoader, type ExtensionAPI } from "@earendil-works/pi-coding-agent";',
+        'import { Container } from "@earendil-works/pi-tui";',
+        'import { uuidv7 as aiUuidv7 } from "@earendil-works/pi-ai";',
+        'import { uuidv7 as agentUuidv7 } from "@earendil-works/pi-agent-core";',
+        "",
+        "export default function extension(pi: ExtensionAPI): void {",
+        "  const runtimeImports = [DefaultResourceLoader, Container, aiUuidv7, agentUuidv7];",
+        "  pi.registerCommand(\"telepi-sdk-check\", {",
+        "    description: `loaded:${runtimeImports.every(Boolean)}` ,",
+        "    handler: async () => {},",
+        "  });",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir: path.join(root, "agent"),
+        additionalExtensionPaths: [extensionPath],
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+      await loader.reload();
+      const result = loader.getExtensions();
+
+      expect(result.errors).toEqual([]);
+      expect(result.extensions).toHaveLength(1);
+      expect(result.extensions[0]?.commands.has("telepi-sdk-check")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/pi-sdk-compatibility.test.ts
+++ b/test/pi-sdk-compatibility.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -12,6 +12,17 @@ describe("Pi SDK compatibility", () => {
     expect(packageJson.dependencies["@earendil-works/pi-agent-core"]).toBe("^0.82.1");
     expect(packageJson.dependencies["@earendil-works/pi-ai"]).toBe("^0.82.1");
     expect(packageJson.dependencies["@earendil-works/pi-coding-agent"]).toBe("^0.82.1");
+  });
+
+  it("documents and releases on the supported Node version", () => {
+    const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+    const releaseWorkflow = readFileSync(
+      new URL("../.github/workflows/release.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(readme).toContain("- **Node.js 22.19+**");
+    expect(releaseWorkflow).toMatch(/node-version:\s*["']?22\.19["']?/);
   });
 
   it("loads external extensions that import Earendil Pi packages", async () => {

--- a/test/pi-session.test.ts
+++ b/test/pi-session.test.ts
@@ -247,9 +247,9 @@ const mockState = vi.hoisted(() => {
 		.mockImplementation(async (options: any) => ({
 			cwd: options.cwd,
 			agentDir: options.agentDir ?? "/mock-agent",
-			authStorage: options.authStorage ?? { kind: "auth-storage" },
+			modelRuntime:
+				options.modelRuntime ?? { kind: "model-runtime", cwd: options.cwd },
 			settingsManager: options.settingsManager,
-			modelRegistry: options.modelRegistry,
 			resourceLoader: { kind: "resource-loader", cwd: options.cwd },
 			diagnostics: [],
 		}));
@@ -396,23 +396,30 @@ const mockState = vi.hoisted(() => {
 		}),
 	};
 
-	const ModelRegistry = {
-		create: vi.fn().mockImplementation(() => {
-			const instance = {
-				getAvailable: vi.fn().mockReturnValue(models),
-				getAll: vi.fn().mockReturnValue(models),
-				find: vi
-					.fn()
-					.mockImplementation((provider: string, id: string) =>
-						models.find(
-							(model) => model.provider === provider && model.id === id,
-						),
-					),
-			};
-			modelRegistryInstances.push(instance);
-			return instance;
-		}),
+	const ModelRuntime = {
+		create: vi.fn().mockImplementation(async (options: any) => ({
+			kind: "model-runtime",
+			options,
+			getAvailable: vi.fn().mockResolvedValue(models),
+		})),
 	};
+
+	const ModelRegistry = vi.fn().mockImplementation(() => {
+		const instance = {
+			refresh: vi.fn().mockResolvedValue(undefined),
+			getAvailable: vi.fn().mockReturnValue(models),
+			getAll: vi.fn().mockReturnValue(models),
+			find: vi
+				.fn()
+				.mockImplementation((provider: string, id: string) =>
+					models.find(
+						(model) => model.provider === provider && model.id === id,
+					),
+				),
+		};
+		modelRegistryInstances.push(instance);
+		return instance;
+	});
 
 	const SessionManager = {
 		create: vi
@@ -459,6 +466,7 @@ const mockState = vi.hoisted(() => {
 		createCodingTools,
 		AuthStorage,
 		ModelRegistry,
+		ModelRuntime,
 		SessionManager,
 		SettingsManager,
 		getSubscriber: (session: object) => sessionSubscribers.get(session),
@@ -487,7 +495,8 @@ const mockState = vi.hoisted(() => {
 			createAgentSessionServices.mockClear();
 			createCodingTools.mockClear();
 			AuthStorage.create.mockClear();
-			ModelRegistry.create.mockClear();
+			ModelRegistry.mockClear();
+			ModelRuntime.create.mockClear();
 			SessionManager.create.mockClear();
 			SessionManager.open.mockClear();
 			SessionManager.listAll.mockReset();
@@ -528,6 +537,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 	createCodingTools: mockState.createCodingTools,
 	AuthStorage: mockState.AuthStorage,
 	ModelRegistry: mockState.ModelRegistry,
+	ModelRuntime: mockState.ModelRuntime,
 	SessionManager: mockState.SessionManager,
 	SettingsManager: mockState.SettingsManager,
 	getAgentDir: vi.fn().mockReturnValue("/mock-agent"),
@@ -581,10 +591,14 @@ describe("PiSessionService", () => {
 	it("creates a session service and initializes the Pi session runtime", async () => {
 		const service = await PiSessionService.create(createConfig());
 
-		expect(mockState.AuthStorage.create).toHaveBeenCalledTimes(1);
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(1);
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledWith(
-			expect.objectContaining({ kind: "auth-storage" }),
+		expect(mockState.AuthStorage.create).not.toHaveBeenCalled();
+		expect(mockState.ModelRuntime.create).toHaveBeenCalledWith({
+			credentials: expect.anything(),
+			modelsPath: "/mock-agent/models.json",
+		});
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(1);
+		expect(mockState.ModelRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "model-runtime" }),
 		);
 		expect(mockState.createAgentSessionRuntime).toHaveBeenCalledWith(
 			expect.any(Function),
@@ -599,8 +613,11 @@ describe("PiSessionService", () => {
 		expect(mockState.createAgentSessionServices).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cwd: "/workspace/base",
-				authStorage: expect.objectContaining({ kind: "auth-storage" }),
+				modelRuntime: expect.objectContaining({ kind: "model-runtime" }),
 			}),
+		);
+		expect(mockState.createAgentSessionServices.mock.calls[0]?.[0]).not.toHaveProperty(
+			"authStorage",
 		);
 		expect(mockState.createCodingTools).toHaveBeenCalledWith("/workspace/base");
 		expect(mockState.createAgentSession).toHaveBeenCalledWith(
@@ -1347,17 +1364,19 @@ describe("PiSessionService", () => {
 
 	it("recreates the model registry each time the runtime factory creates a same-runtime replacement session", async () => {
 		const service = await PiSessionService.create(createConfig());
-		const firstRegistry =
-			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
+		const firstRuntime = mockState.ModelRegistry.mock.calls[0]?.[0];
 
 		await service.switchSession("/sessions/saved.jsonl", "/workspace/projectA");
 
-		const secondRegistry =
-			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-		expect(firstRegistry).toBe(mockState.modelRegistryInstances[0]);
-		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
-		expect(secondRegistry).not.toBe(firstRegistry);
+		const secondRuntime = mockState.ModelRegistry.mock.calls[1]?.[0];
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(2);
+		expect(firstRuntime).toEqual(
+			expect.objectContaining({ kind: "model-runtime" }),
+		);
+		expect(secondRuntime).toEqual(
+			expect.objectContaining({ kind: "model-runtime" }),
+		);
+		expect(secondRuntime).not.toBe(firstRuntime);
 	});
 
 	it("recreates the model registry and reapplies coding-tool activation for cross-runtime replacements", async () => {
@@ -1369,17 +1388,17 @@ describe("PiSessionService", () => {
 			{ name: "find", description: "Find files" },
 		]);
 		const service = await PiSessionService.create(createConfig());
-		const firstRegistry =
-			mockState.createAgentSessionServices.mock.calls[0]?.[0]?.modelRegistry;
+		const firstRuntime = mockState.ModelRegistry.mock.calls[0]?.[0];
 
 		await service.newSession("/workspace/other");
 
-		const secondRegistry =
-			mockState.createAgentSessionServices.mock.calls[1]?.[0]?.modelRegistry;
+		const secondRuntime = mockState.ModelRegistry.mock.calls[1]?.[0];
 		const replacementSession = mockState.createdSessions[1]?.session;
-		expect(mockState.ModelRegistry.create).toHaveBeenCalledTimes(2);
-		expect(secondRegistry).toBe(mockState.modelRegistryInstances[1]);
-		expect(secondRegistry).not.toBe(firstRegistry);
+		expect(mockState.ModelRegistry).toHaveBeenCalledTimes(2);
+		expect(secondRuntime).toEqual(
+			expect.objectContaining({ kind: "model-runtime" }),
+		);
+		expect(secondRuntime).not.toBe(firstRuntime);
 		expect(replacementSession.setActiveToolsByName).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				"read",
@@ -2129,6 +2148,11 @@ describe("PiSessionService", () => {
 			name: "GPT-4o",
 		});
 		expect(currentSession.setThinkingLevel).not.toHaveBeenCalled();
+		expect(
+			mockState.modelRegistryInstances.every(
+				(registry) => registry.refresh.mock.calls.length === 0,
+			),
+		).toBe(true);
 	});
 
 	it("applies a scoped thinking-level override when switching models", async () => {
@@ -2359,12 +2383,16 @@ describe("PiSessionService", () => {
 		expect(onAgentEnd).toHaveBeenCalledTimes(1);
 	});
 
-	it("reloads auth storage before prompting", async () => {
+	it("does not refresh remote model catalogs before prompting", async () => {
 		const service = await PiSessionService.create(createConfig());
 
 		await service.prompt("hello");
 
-		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+		expect(
+			mockState.modelRegistryInstances.every(
+				(registry) => registry.refresh.mock.calls.length === 0,
+			),
+		).toBe(true);
 	});
 
 	it("passes image attachments through when prompting", async () => {
@@ -2379,12 +2407,22 @@ describe("PiSessionService", () => {
 		expect(currentSession.prompt).toHaveBeenCalledWith("hello", { images });
 	});
 
-	it("reloads auth storage before listing models", async () => {
+	it("refreshes model availability without refreshing remote catalogs before listing models", async () => {
 		const service = await PiSessionService.create(createConfig());
+		const modelRuntime = mockState.ModelRuntime.create.mock.results[0]?.value;
 
 		await service.listModels();
 
-		expect(mockState.authStorageInstances[0]?.reload).toHaveBeenCalledTimes(1);
+		await expect(modelRuntime).resolves.toEqual(
+			expect.objectContaining({ getAvailable: expect.any(Function) }),
+		);
+		const resolvedRuntime = await modelRuntime;
+		expect(resolvedRuntime.getAvailable).toHaveBeenCalledTimes(1);
+		expect(
+			mockState.modelRegistryInstances.every(
+				(registry) => registry.refresh.mock.calls.length === 0,
+			),
+		).toBe(true);
 	});
 
 	it("wraps prompt errors with a helpful message", async () => {

--- a/test/reloading-credential-store.test.ts
+++ b/test/reloading-credential-store.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createReloadingCredentialStore } from "../src/reloading-credential-store.js";
+
+describe("createReloadingCredentialStore", () => {
+  it("observes and resolves credentials changed by another process", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "telepi-auth-store-"));
+    const authPath = path.join(root, "auth.json");
+    const store = await createReloadingCredentialStore(authPath);
+
+    try {
+      writeFileSync(authPath, JSON.stringify({ openai: { type: "api_key", key: "first" } }));
+      await expect(store.read("openai")).resolves.toEqual({ type: "api_key", key: "first" });
+
+      vi.stubEnv("TELEPI_TEST_API_KEY", "second");
+      writeFileSync(
+        authPath,
+        JSON.stringify({ openai: { type: "api_key", key: "$TELEPI_TEST_API_KEY" } }),
+      );
+      await expect(store.read("openai")).resolves.toEqual({ type: "api_key", key: "second" });
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("persists credential modifications without losing other providers", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "telepi-auth-store-"));
+    const authPath = path.join(root, "auth.json");
+    const store = await createReloadingCredentialStore(authPath);
+
+    try {
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          anthropic: { type: "api_key", key: "anthropic-key" },
+          openai: { type: "api_key", key: "old-key" },
+        }),
+      );
+
+      await store.modify("openai", async () => ({ type: "api_key", key: "new-key" }));
+
+      expect(JSON.parse(readFileSync(authPath, "utf8"))).toEqual({
+        anthropic: { type: "api_key", key: "anthropic-key" },
+        openai: { type: "api_key", key: "new-key" },
+      });
+      await expect(store.list()).resolves.toEqual([
+        { providerId: "anthropic", type: "api_key" },
+        { providerId: "openai", type: "api_key" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- update the embedded Earendil Pi SDK packages to 0.82.1 and require Node 22.19+
- adapt TelePi sessions to the `ModelRuntime` API while preserving external `auth.json` updates without triggering remote catalog refreshes
- add an integration regression test that runtime-loads an external extension importing `pi-coding-agent`, `pi-tui`, `pi-ai`, and `pi-agent-core`

## Root cause
The installed TelePi service embedded an older Pi runtime while user extensions imported the current `@earendil-works/pi-*` packages. The embedded extension loader therefore could not resolve those package imports even though the standalone global Pi installation could.

## Test plan
- [x] observed the SDK-version regression test fail on the previous dependency version
- [x] `npm test` — 422 tests pass
- [x] `npm run test:coverage` — thresholds pass (86.54% statements, 81.02% branches)
- [x] `npm run build`
- [x] `npm run package:release`
- [x] exercised the credential store from built `dist/`
- [x] independent code review completed with no Critical or Important findings

Supersedes #20 with Pi 0.82.1, extension-loading coverage, preserved auth hot reload, and no per-request remote catalog refresh.