### PR TITLE
fix: install undici globals so provider responses decompress on Node 26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@earendil-works/pi-coding-agent": "^0.82.1",
         "@grammyjs/auto-retry": "^2.0.2",
         "grammy": "^1.35.0",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "undici": "^8.9.0"
       },
       "bin": {
         "telepi": "dist/cli.js"
@@ -5521,6 +5522,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@earendil-works/pi-coding-agent": "^0.82.1",
     "@grammyjs/auto-retry": "^2.0.2",
     "grammy": "^1.35.0",
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.4",
+    "undici": "^8.9.0"
   },
   "optionalDependencies": {
     "parakeet-coreml": "^2.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 import { isEntrypoint } from "./entrypoint.js";
+import { configureHttpRuntime } from "./http-runtime.js";
 import { getTelePiStatus, resolveTelePiInstallContext, setupTelePi } from "./install.js";
 import { startBot } from "./index.js";
+
+// Must run before any provider request is issued. See http-runtime.ts.
+configureHttpRuntime();
 
 const HELP_TEXT = `TelePi CLI
 

--- a/src/http-runtime.ts
+++ b/src/http-runtime.ts
@@ -1,0 +1,31 @@
+import { install } from "undici";
+
+/**
+ * Align `globalThis.fetch` with undici's global dispatcher.
+ *
+ * Importing `@earendil-works/pi-coding-agent` installs an npm-undici global
+ * dispatcher as a module side effect. Node's *bundled* fetch honours that
+ * dispatcher but, on Node 26, does not decompress responses that came through
+ * it — so a gzipped `text/event-stream` reaches the provider parser as raw
+ * gzip bytes. The stream yields no events, every reply becomes an empty
+ * assistant message, and TelePi renders its "✅ Done" fallback.
+ *
+ * Pi's own CLI avoids this by calling `configureHttpDispatcher()` in its entry
+ * point, which ends with `undici.install()`. That helper is not part of the
+ * package's public exports, so embedders have to install the undici globals
+ * themselves.
+ *
+ * Call this once, as early as possible, before any provider request is issued.
+ */
+export function configureHttpRuntime(): void {
+	if (installed) {
+		return;
+	}
+	installed = true;
+
+	// `install` was added in undici v7.11; older copies simply keep the
+	// bundled fetch, which is the pre-existing behaviour.
+	install?.();
+}
+
+let installed = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { createBot, registerCommands } from "./bot.js";
 import { loadConfig } from "./config.js";
 import { isEntrypoint } from "./entrypoint.js";
+import { configureHttpRuntime } from "./http-runtime.js";
 import { PiSessionRegistry } from "./pi-session.js";
 
 const MAX_RESTART_ATTEMPTS = 5;
@@ -11,6 +12,10 @@ export async function startBot(): Promise<void> {
   let bot: ReturnType<typeof createBot> | undefined;
   let shuttingDown = false;
   let restartAttempts = 0;
+
+  // Idempotent: `telepi` sets this up in cli.ts, but startBot() is also the
+  // documented library entry point. See http-runtime.ts.
+  configureHttpRuntime();
 
   try {
     const config = loadConfig();

--- a/test/http-runtime.test.ts
+++ b/test/http-runtime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { configureHttpRuntime } from "../src/http-runtime.js";
+
+const UNDICI_GLOBAL_DISPATCHER = Symbol.for("undici.globalDispatcher.1");
+
+describe("configureHttpRuntime", () => {
+  it("replaces the bundled fetch so it shares undici's global dispatcher", async () => {
+    const bundledFetch = globalThis.fetch;
+
+    configureHttpRuntime();
+
+    const { install } = await import("undici");
+    if (typeof install !== "function") {
+      // Older undici copies have no install(); nothing to assert.
+      expect(globalThis.fetch).toBe(bundledFetch);
+      return;
+    }
+
+    expect(globalThis.fetch).not.toBe(bundledFetch);
+  });
+
+  it("is idempotent", () => {
+    configureHttpRuntime();
+    const installedFetch = globalThis.fetch;
+
+    configureHttpRuntime();
+
+    expect(globalThis.fetch).toBe(installedFetch);
+  });
+
+  it("leaves undici's global dispatcher in place", () => {
+    configureHttpRuntime();
+
+    expect(
+      (globalThis as Record<symbol, unknown>)[UNDICI_GLOBAL_DISPATCHER],
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

On Node 26, every TelePi reply renders as the `✅ Done` fallback.

The assistant messages are genuinely empty — session JSONL shows:

```json
{"role":"assistant","content":[],"usage":{"input":0,"output":0,"totalTokens":0},"stopReason":"stop"}
```

`prompt-handler.ts` is behaving correctly; `buildFinalResponseText()` gets an
empty string and falls back to `✅ Done`.

## Root cause

Importing `@earendil-works/pi-coding-agent` installs an npm-undici global
dispatcher as a module side effect (verified: `Symbol.for("undici.globalDispatcher.1")`
goes from `undefined` to a dispatcher purely on import).

Node 26's *bundled* fetch honours that dispatcher but does not decompress
responses that travelled through it. A gzipped `text/event-stream` therefore
reaches the provider parser as raw gzip bytes, the stream yields no events, and
the assistant message ends up empty with `stopReason: "stop"`.

Instrumenting `globalThis.fetch` in an embedder process confirmed it end to end:

```
[FETCH] https://api.anthropic.com/v1/messages -> 200, bodyLen=620
magic: 1f8b08          # gzip, still compressed
```

Decompressing that body by hand shows the response was fine all along:

```
event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"P"}}
event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ONG-LIB"}}
```

Pi's own CLI never hits this because `dist/cli.js` calls
`configureHttpDispatcher()` before anything issues a request, and that helper
ends with `undici.install()`. Its source comment names the exact failure mode:

> Keep fetch and the dispatcher on the same undici implementation. Node 26.0's
> bundled fetch can otherwise consume compressed responses through npm undici's
> dispatcher without decompressing them, causing `response.json()` failures.

`configureHttpDispatcher` is not part of the package's public exports (only `.`
and `./rpc-entry`), so embedders like TelePi have to install the undici globals
themselves.

## Fix

Add `configureHttpRuntime()` (`src/http-runtime.ts`), which calls
`undici.install()` once, and invoke it from both entry points:

- `src/cli.ts` — for the `telepi` binary
- `startBot()` in `src/index.ts` — for library use

It is idempotent, and `install?.()` is optional-called so older undici copies
without `install` keep today's behaviour.

## Verification

- Reproduced against the pi SDK outside the bot, then confirmed
  `undici.install()` fixes it: empty string → the model's actual reply.
- Re-verified through the built `dist/http-runtime.js` before restarting the
  real service.
- Ran the live bot after the fix.
- `npm test`: 426 tests / 32 files pass, including 3 new tests for
  `configureHttpRuntime`.

## Notes

Arguably pi should also export `configureHttpDispatcher` (or call
`undici.install()` wherever it sets the global dispatcher) so embedders can't
miss it. Worth raising upstream — but TelePi shouldn't have to wait for that.

Repro environment: Node 26.0.0, macOS 26.3.1 arm64, TelePi 0.4.2,
`@earendil-works/pi-coding-agent` 0.82.1, provider `anthropic`.
