### PR TITLE
feat(voice): support compatible transcription endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,14 @@ TELEGRAM_ALLOWED_USER_IDS=123456789
 
 # Optional: enable cloud-based voice transcription via OpenAI Whisper (~$0.006/min)
 # OPENAI_API_KEY=sk-...
+#
+# Optional: use any OpenAI-compatible transcription provider instead.
+# Existing OPENAI_API_KEY users keep the OpenAI defaults when these are unset.
+# TELEPI_TRANSCRIPTION_API_KEY=...  # falls back to OPENAI_API_KEY
+# TELEPI_TRANSCRIPTION_URL=https://provider.example/v1/audio/transcriptions
+# TELEPI_TRANSCRIPTION_MODEL=provider-model-name
+# TELEPI_TRANSCRIPTION_AUTH_HEADER=api-key  # optional; defaults to Authorization: Bearer
+# TELEPI_TRANSCRIPTION_PROMPT=Context that improves recognition of project-specific terms.
 
 # Optional: enable local/offline transcription via Sherpa-ONNX Parakeet
 # (primarily for Intel-based Macs, where parakeet-coreml is not supported)

--- a/README.md
+++ b/README.md
@@ -228,19 +228,19 @@ Send any Telegram **voice message** or **audio file** and TelePi will transcribe
 [Pi responds normally]
 ```
 
-TelePi supports three transcription backends and picks the best one automatically:
+TelePi supports three transcription backends and picks the best available one automatically:
 
 | Backend | How to enable | Cost | Privacy |
 |---------|---------------|------|---------|
 | **Parakeet CoreML** (local) | `npm install parakeet-coreml` + `brew install ffmpeg` | Free | On-device |
 | **Sherpa-ONNX Parakeet** (local, Intel Mac path) | `npm install sherpa-onnx-node` + download model + set `SHERPA_ONNX_MODEL_DIR` | Free | On-device |
-| **OpenAI Whisper** (cloud) | `OPENAI_API_KEY=sk-...` in your TelePi config file | ~$0.006/min | Cloud |
+| **Cloud transcription** | `OPENAI_API_KEY=sk-...` for OpenAI Whisper, or `TELEPI_TRANSCRIPTION_URL`, `TELEPI_TRANSCRIPTION_MODEL`, and `TELEPI_TRANSCRIPTION_API_KEY` for a compatible provider | Provider-dependent | Cloud |
 
 TelePi tries backends in this order:
 
 1. **Parakeet CoreML** — best local path on Apple Silicon
 2. **Sherpa-ONNX Parakeet** — the local/offline path for Intel Macs, where `parakeet-coreml` does not run (and a CPU fallback on Apple Silicon)
-3. **OpenAI Whisper** — cloud fallback
+3. **OpenAI Whisper or a configured compatible provider** — cloud fallback
 
 The `/start` command shows which backends are currently active.
 
@@ -302,6 +302,30 @@ OPENAI_API_KEY=sk-...
 ```
 
 No additional packages are required. Supports the same audio formats Telegram delivers (Ogg Opus, MP3, M4A, WAV, etc.).
+
+### Using an OpenAI-compatible transcription provider
+
+Set a custom full transcription endpoint when your provider accepts the OpenAI-compatible multipart `audio/transcriptions` request shape. Existing `OPENAI_API_KEY` setups remain unchanged when these values are unset.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TELEPI_TRANSCRIPTION_API_KEY` | `OPENAI_API_KEY` | Credential sent to the provider |
+| `TELEPI_TRANSCRIPTION_URL` | OpenAI's `/v1/audio/transcriptions` endpoint | Full HTTP(S) endpoint |
+| `TELEPI_TRANSCRIPTION_MODEL` | `whisper-1` | Value for the multipart `model` field |
+| `TELEPI_TRANSCRIPTION_AUTH_HEADER` | unset | Custom credential-header name; unset uses `Authorization: Bearer` |
+| `TELEPI_TRANSCRIPTION_PROMPT` | unset | Optional recognition context for project-specific names and terms |
+
+For example:
+
+```bash
+TELEPI_TRANSCRIPTION_API_KEY=...
+TELEPI_TRANSCRIPTION_URL=https://provider.example/v1/audio/transcriptions
+TELEPI_TRANSCRIPTION_MODEL=provider-whisper
+TELEPI_TRANSCRIPTION_AUTH_HEADER=api-key
+TELEPI_TRANSCRIPTION_PROMPT="Conversation about TelePi and Pi coding-agent sessions."
+```
+
+TelePi removes URL credentials, queries, and fragments from endpoint details shown in errors.
 
 ## Session Tree Navigation
 

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -60,6 +60,13 @@ const SHERPA_ONNX_MODEL_DIR_ENV = "SHERPA_ONNX_MODEL_DIR";
 const SHERPA_ONNX_NUM_THREADS_ENV = "SHERPA_ONNX_NUM_THREADS";
 const SHERPA_MODEL_DOCS_URL =
   "https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-transducer/nemo-transducer-models.html";
+const TRANSCRIPTION_URL_ENV = "TELEPI_TRANSCRIPTION_URL";
+const TRANSCRIPTION_MODEL_ENV = "TELEPI_TRANSCRIPTION_MODEL";
+const TRANSCRIPTION_API_KEY_ENV = "TELEPI_TRANSCRIPTION_API_KEY";
+const TRANSCRIPTION_AUTH_HEADER_ENV = "TELEPI_TRANSCRIPTION_AUTH_HEADER";
+const TRANSCRIPTION_PROMPT_ENV = "TELEPI_TRANSCRIPTION_PROMPT";
+const DEFAULT_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions";
+const DEFAULT_TRANSCRIPTION_MODEL = "whisper-1";
 const FFMPEG_INSTALL_MESSAGE = `ffmpeg not found. Install it with: ${getPlatformInstallHint("ffmpeg")}`;
 const NO_BACKEND_ERROR = `Voice messages require a transcription backend.
 
@@ -75,7 +82,12 @@ Option 2: Install Sherpa-ONNX for local/offline Parakeet transcription on Intel-
   Set ${SHERPA_ONNX_MODEL_DIR_ENV}=/path/to/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8
 
 Option 3: Set OPENAI_API_KEY for cloud transcription (~$0.006/min):
-  Add OPENAI_API_KEY=sk-... to your .env file`;
+  Add OPENAI_API_KEY=sk-... to your .env file
+
+  Or configure an OpenAI-compatible transcription endpoint:
+    ${TRANSCRIPTION_API_KEY_ENV}=... (falls back to OPENAI_API_KEY)
+    ${TRANSCRIPTION_URL_ENV}=https://provider.example/v1/audio/transcriptions
+    ${TRANSCRIPTION_MODEL_ENV}=provider-model-name`;
 
 const _require = createRequire(import.meta.url);
 let _importModule: (specifier: string) => Promise<unknown> = async (specifier) => _require(specifier);
@@ -311,10 +323,13 @@ async function transcribeWithSherpaOnnx(
 }
 
 async function transcribeWithOpenAI(filePath: string): Promise<TranscriptionResult> {
-  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  const apiKey = resolveTranscriptionApiKey();
   if (!apiKey) {
     throw new Error(NO_BACKEND_ERROR);
   }
+  const endpoint = resolveTranscriptionEndpoint();
+  const model = process.env[TRANSCRIPTION_MODEL_ENV]?.trim() || DEFAULT_TRANSCRIPTION_MODEL;
+  const authHeader = process.env[TRANSCRIPTION_AUTH_HEADER_ENV]?.trim();
 
   const startedAt = Date.now();
   const audioBuffer = await readFile(filePath);
@@ -327,26 +342,36 @@ async function transcribeWithOpenAI(filePath: string): Promise<TranscriptionResu
   const mimeType = mimeTypes[ext] ?? "audio/ogg";
   const form = new FormData();
   form.append("file", new Blob([audioBuffer], { type: mimeType }), path.basename(filePath) || "audio.ogg");
-  form.append("model", "whisper-1");
+  form.append("model", model);
+  const transcriptionPrompt = process.env[TRANSCRIPTION_PROMPT_ENV]?.trim();
+  if (transcriptionPrompt) {
+    form.append("prompt", transcriptionPrompt);
+  }
 
-  const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: form,
-  });
+  let response: Response;
+  try {
+    response = await fetch(endpoint.url, {
+      method: "POST",
+      headers: authHeader ? { [authHeader]: apiKey } : { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Transcription request failed [endpoint: ${endpoint.display}]: ${redactEndpointFromMessage(message, endpoint)}`,
+    );
+  }
 
   if (!response.ok) {
     const errorText = (await response.text().catch(() => "")).trim();
     throw new Error(
-      `OpenAI transcription failed (${response.status}): ${errorText || response.statusText || "Unknown error"}`,
+      `OpenAI transcription failed (${response.status}): ${errorText || response.statusText || "Unknown error"} [endpoint: ${endpoint.display}]`,
     );
   }
 
   const payload = (await response.json()) as { text?: unknown };
   if (typeof payload.text !== "string") {
-    throw new Error("OpenAI transcription response did not include a text field");
+    throw new Error(`OpenAI transcription response did not include a text field [endpoint: ${endpoint.display}]`);
   }
 
   return {
@@ -504,8 +529,39 @@ function decodeAudioToSamples(filePath: string): Promise<Float32Array> {
   });
 }
 
+function resolveTranscriptionApiKey(): string | undefined {
+  return process.env[TRANSCRIPTION_API_KEY_ENV]?.trim() || process.env.OPENAI_API_KEY?.trim() || undefined;
+}
+
+function resolveTranscriptionEndpoint(): { url: string; display: string; configuredUrl: string } {
+  const configuredUrl = process.env[TRANSCRIPTION_URL_ENV]?.trim() || DEFAULT_TRANSCRIPTION_URL;
+  let endpoint: URL;
+  try {
+    endpoint = new URL(configuredUrl);
+  } catch {
+    throw new Error("Configured transcription endpoint is not a valid URL.");
+  }
+  if (endpoint.protocol !== "https:" && endpoint.protocol !== "http:") {
+    throw new Error("Configured transcription endpoint must use HTTP or HTTPS.");
+  }
+  return {
+    url: endpoint.toString(),
+    display: `${endpoint.protocol}//${endpoint.host}${endpoint.pathname}`,
+    configuredUrl,
+  };
+}
+
+function redactEndpointFromMessage(
+  message: string,
+  endpoint: { url: string; display: string; configuredUrl: string },
+): string {
+  return [endpoint.configuredUrl, endpoint.url]
+    .sort((left, right) => right.length - left.length)
+    .reduce((redacted, candidate) => redacted.replaceAll(candidate, endpoint.display), message);
+}
+
 function hasOpenAIApiKey(): boolean {
-  return Boolean(process.env.OPENAI_API_KEY?.trim());
+  return Boolean(resolveTranscriptionApiKey());
 }
 
 function extractTranscribedText(result: unknown): string | undefined {

--- a/test/voice.test.ts
+++ b/test/voice.test.ts
@@ -15,6 +15,16 @@ import {
 
 describe("voice transcription", () => {
   const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  const transcriptionEnvKeys = [
+    "TELEPI_TRANSCRIPTION_API_KEY",
+    "TELEPI_TRANSCRIPTION_URL",
+    "TELEPI_TRANSCRIPTION_MODEL",
+    "TELEPI_TRANSCRIPTION_AUTH_HEADER",
+    "TELEPI_TRANSCRIPTION_PROMPT",
+  ] as const;
+  const originalTranscriptionEnv = Object.fromEntries(
+    transcriptionEnvKeys.map((key) => [key, process.env[key]]),
+  );
   const originalSherpaModelDir = process.env.SHERPA_ONNX_MODEL_DIR;
   const originalSherpaNumThreads = process.env.SHERPA_ONNX_NUM_THREADS;
 
@@ -53,6 +63,9 @@ describe("voice transcription", () => {
     sherpaModelDir = path.join(tempDir, "sherpa-model");
     writeFileSync(audioPath, Buffer.from("audio"));
     delete process.env.OPENAI_API_KEY;
+    for (const key of transcriptionEnvKeys) {
+      delete process.env[key];
+    }
     delete process.env.SHERPA_ONNX_MODEL_DIR;
     delete process.env.SHERPA_ONNX_NUM_THREADS;
     _resetImportHook();
@@ -68,6 +81,14 @@ describe("voice transcription", () => {
       delete process.env.OPENAI_API_KEY;
     } else {
       process.env.OPENAI_API_KEY = originalOpenAIKey;
+    }
+    for (const key of transcriptionEnvKeys) {
+      const original = originalTranscriptionEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
     }
 
     if (originalSherpaModelDir === undefined) {
@@ -322,6 +343,75 @@ describe("voice transcription", () => {
         body: expect.any(FormData),
       }),
     );
+  });
+
+  it("supports a configured OpenAI-compatible endpoint without changing OpenAI defaults", async () => {
+    _setImportHook(async (specifier) => {
+      if (specifier === "parakeet-coreml") {
+        throw moduleNotFound("parakeet-coreml");
+      }
+      throw new Error(`unexpected import: ${specifier}`);
+    });
+    process.env.TELEPI_TRANSCRIPTION_API_KEY = "provider-key";
+    process.env.TELEPI_TRANSCRIPTION_URL = "https://transcribe.example.test/v1/audio/transcriptions";
+    process.env.TELEPI_TRANSCRIPTION_MODEL = "provider-whisper";
+    process.env.TELEPI_TRANSCRIPTION_AUTH_HEADER = "api-key";
+    process.env.TELEPI_TRANSCRIPTION_PROMPT = "TelePi software-development terms.";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ text: "custom transcript" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(transcribeAudio(audioPath)).resolves.toMatchObject({
+      text: "custom transcript",
+      backend: "openai",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://transcribe.example.test/v1/audio/transcriptions",
+      expect.objectContaining({ headers: { "api-key": "provider-key" } }),
+    );
+    const [, init] = fetchMock.mock.calls[0] as [string, { body: FormData }];
+    expect(init.body.get("model")).toBe("provider-whisper");
+    expect(init.body.get("prompt")).toBe("TelePi software-development terms.");
+  });
+
+  it("redacts configured endpoint secrets in HTTP, payload, and transport errors", async () => {
+    _setImportHook(async (specifier) => {
+      if (specifier === "parakeet-coreml") {
+        throw moduleNotFound("parakeet-coreml");
+      }
+      throw new Error(`unexpected import: ${specifier}`);
+    });
+    process.env.TELEPI_TRANSCRIPTION_API_KEY = "provider-key";
+    process.env.TELEPI_TRANSCRIPTION_URL = "https://user:password@transcribe.example.test/v1/audio/transcriptions?token=secret#fragment";
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: async () => "upstream failed",
+    }));
+    await expect(transcribeAudio(audioPath)).rejects.toThrow(
+      "[endpoint: https://transcribe.example.test/v1/audio/transcriptions]",
+    );
+    await expect(transcribeAudio(audioPath)).rejects.not.toThrow(/user|password|token=secret|fragment/);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    await expect(transcribeAudio(audioPath)).rejects.toThrow(
+      "OpenAI transcription response did not include a text field [endpoint: https://transcribe.example.test/v1/audio/transcriptions]",
+    );
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("connect ECONNREFUSED")));
+    await expect(transcribeAudio(audioPath)).rejects.toThrow(
+      "Transcription request failed [endpoint: https://transcribe.example.test/v1/audio/transcriptions]: connect ECONNREFUSED",
+    );
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError(
+      "request to https://user:password@transcribe.example.test/v1/audio/transcriptions?token=secret#fragment failed",
+    )));
+    await expect(transcribeAudio(audioPath)).rejects.not.toThrow(/user|password|token=secret|fragment/);
   });
 
   it("throws a helpful error when no backend is available", async () => {


### PR DESCRIPTION
Reimplements the useful configuration flexibility from #22 as a focused, current-main change.\n\n- preserves OpenAI defaults and OPENAI_API_KEY fallback\n- supports configurable endpoint, model, API key, auth-header, and optional transcription prompt\n- validates HTTP(S) endpoints and redacts URL credentials, query strings, and fragments—including in transport error messages\n- documents the configuration and adds focused regression coverage\n\nValidation: npm test (439 passing), npm run test:coverage (thresholds met), npm run build.