### PR TITLE
fix: support compressed provider streams on Node 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.19, 26]
 
     steps:
       - name: Check out repository
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@earendil-works/pi-coding-agent": "^0.82.1",
         "@grammyjs/auto-retry": "^2.0.2",
         "grammy": "^1.35.0",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "undici": "8.5.0"
       },
       "bin": {
         "telepi": "dist/cli.js"
@@ -5521,6 +5522,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@earendil-works/pi-coding-agent": "^0.82.1",
     "@grammyjs/auto-retry": "^2.0.2",
     "grammy": "^1.35.0",
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.4",
+    "undici": "8.5.0"
   },
   "optionalDependencies": {
     "parakeet-coreml": "^2.2.0",

--- a/src/http-runtime.ts
+++ b/src/http-runtime.ts
@@ -1,0 +1,26 @@
+import { install } from "undici";
+
+const originalGlobalFetch = globalThis.fetch;
+let installedGlobalFetch: typeof globalThis.fetch | undefined;
+
+/**
+ * Keep the process fetch implementation aligned with Pi's npm Undici dispatcher.
+ *
+ * Node 26's bundled fetch can leave compressed provider responses undecoded when
+ * Pi has initialized its npm Undici dispatcher. Installing Undici's globals
+ * makes fetch and that dispatcher use the same implementation. A replacement
+ * made by an embedding application after this module loads is left untouched.
+ */
+export function configureHttpRuntime(): void {
+  const shouldInstallGlobals =
+    installedGlobalFetch === undefined
+      ? globalThis.fetch === originalGlobalFetch
+      : globalThis.fetch === installedGlobalFetch;
+
+  if (!shouldInstallGlobals) {
+    return;
+  }
+
+  install();
+  installedGlobalFetch = globalThis.fetch;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import { createBot, registerCommands } from "./bot.js";
 import { loadConfig } from "./config.js";
 import { isEntrypoint } from "./entrypoint.js";
+import { configureHttpRuntime } from "./http-runtime.js";
 import { PiSessionRegistry } from "./pi-session.js";
 
 const MAX_RESTART_ATTEMPTS = 5;
 const RESTART_DELAY_MS = 3000;
 
 export async function startBot(): Promise<void> {
+  configureHttpRuntime();
+
   let sessionRegistry: PiSessionRegistry | undefined;
   let bot: ReturnType<typeof createBot> | undefined;
   let shuttingDown = false;

--- a/test/http-runtime.test.ts
+++ b/test/http-runtime.test.ts
@@ -1,0 +1,128 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+const nodeMajorVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+const webGlobalNames = [
+  "fetch",
+  "Headers",
+  "Response",
+  "Request",
+  "FormData",
+  "WebSocket",
+  "CloseEvent",
+  "ErrorEvent",
+  "MessageEvent",
+  "EventSource",
+] as const;
+const originalWebGlobalDescriptors = new Map(
+  webGlobalNames.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+);
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  for (const name of webGlobalNames) {
+    const descriptor = originalWebGlobalDescriptors.get(name);
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  }
+});
+
+describe("configureHttpRuntime", () => {
+  it("preserves a fetch implementation replaced after the runtime module loaded", async () => {
+    const { configureHttpRuntime } = await import("../src/http-runtime.js");
+    const customFetch = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", customFetch);
+
+    configureHttpRuntime();
+
+    expect(globalThis.fetch).toBe(customFetch);
+  });
+
+  it("installs fetch globals once when fetch has not been replaced", async () => {
+    const { configureHttpRuntime } = await import("../src/http-runtime.js");
+
+    configureHttpRuntime();
+    const installedFetch = globalThis.fetch;
+    configureHttpRuntime();
+
+    expect(installedFetch).not.toBe(originalFetch);
+    expect(globalThis.fetch).toBe(installedFetch);
+  });
+
+  it.skipIf(nodeMajorVersion !== 26)("decompresses gzipped SSE after the Pi SDK initializes npm Undici", async () => {
+    const ssePayload = 'data: {"type":"content_block_delta","text":"hello"}\n\n';
+    const server = createServer((_request, response) => {
+      const compressed = gzipSync(ssePayload);
+      response.writeHead(200, {
+        "content-encoding": "gzip",
+        "content-length": compressed.length,
+        "content-type": "text/event-stream",
+      });
+      response.end(compressed);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the local HTTP server to bind to a TCP port");
+    }
+
+    const runtimeUrl = pathToFileURL(`${process.cwd()}/src/http-runtime.ts`).href;
+    const script = `
+      await import("@earendil-works/pi-coding-agent");
+      if (!globalThis[Symbol.for("undici.globalDispatcher.1")]) {
+        throw new Error("Pi SDK did not initialize an npm Undici dispatcher");
+      }
+      const { configureHttpRuntime } = await import(${JSON.stringify(runtimeUrl)});
+      configureHttpRuntime();
+      const response = await fetch(${JSON.stringify(`http://127.0.0.1:${address.port}/sse`)});
+      const body = await response.text();
+      if (body !== ${JSON.stringify(ssePayload)}) {
+        throw new Error("Expected decompressed SSE payload, got: " + JSON.stringify(body));
+      }
+    `;
+
+    try {
+      const result = await runNode(script);
+      expect(result.code, result.stderr).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});
+
+function runNode(script: string): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+      cwd: process.cwd(),
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Node 26 gzip/SSE regression process timed out: ${stderr}`));
+    }, 10_000);
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stderr });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- install the matching npm Undici globals only when TelePi still owns `globalThis.fetch`
- configure HTTP only when `startBot()` runs, leaving setup/status/help side-effect free
- cover fetch-override preservation, idempotence, and an isolated Node 26 gzip/SSE subprocess regression; CI now runs Node 22.19 and 26

## Validation
- `npx vitest run test/http-runtime.test.ts` (2 passed, 1 Node-26-only test skipped on local Node 23.11)
- `npm test` (441 passed, 1 Node-26-only test skipped)
- `npm run test:coverage` (passed; statements/lines 86.63%, branches 80.98%, functions 90.09%)
- `npm run build`

The Node 26 gzip/SSE test cannot run locally because this workstation currently has Node 23.11 only; the CI matrix executes it under Node 26.